### PR TITLE
Updating Bridge Flows models 

### DIFF
--- a/models/dimensions/dim_chain_ids.sql
+++ b/models/dimensions/dim_chain_ids.sql
@@ -1,0 +1,28 @@
+{{ config(materialized="table") }}
+select id, chain
+from
+    (
+        values
+            (1, 'ethereum'),
+            (10, 'optimism'),
+            (137, 'polygon'),
+            (288, 'boba'),
+            (42161, 'arbitrum'),
+            (8453, 'base'),
+            (324, 'zksync'),
+            (59144, 'linea'),
+            (1313161554, 'aurora'),
+            (250, 'fantom'),
+            (1088, 'metis'),
+            (1284, 'moonbeam'),
+            (8217, 'klaytn'),
+            (43114, 'avalanche'),
+            (1285, 'moonriver'),
+            (7700, 'canto'),
+            (2000, 'dogechain'),
+            (53935, 'dfk'),
+            (1666600000, 'harmony'),
+            (56, 'bsc'),
+            (25, 'cronos'),
+            (81457, 'blast')
+    ) as t(id, chain)

--- a/models/metrics/bridges/fact_bridgehub_flows.sql
+++ b/models/metrics/bridges/fact_bridgehub_flows.sql
@@ -1,31 +1,34 @@
 {{ config(materialized="table") }}
 
-select *
-from {{ ref("fact_across_flows") }}
-union
-select *
-from {{ ref("fact_synapse_flows") }}
-union
-select *
-from {{ ref("fact_wormhole_flows") }}
-union
-select *
-from {{ ref("fact_arbitrum_one_bridge_flows") }}
-union
-select *
-from {{ ref("fact_avalanche_bridge_flows") }}
-union
-select *
-from {{ ref("fact_base_bridge_flows") }}
-union
-select *
-from {{ ref("fact_optimism_bridge_flows") }}
-union
-select *
-from {{ ref("fact_polygon_pos_bridge_flows") }}
-union
-select *
-from {{ ref("fact_starknet_bridge_flows") }}
-union
-select *
-from {{ ref("fact_zksync_era_bridge_flows") }}
+with
+    daily_data as (
+        {{
+            dbt_utils.union_relations(
+                relations=[
+                    ref("fact_across_flows"),
+                    ref("fact_synapse_flows"),
+                    ref("fact_wormhole_flows"),
+                    ref("fact_arbitrum_one_bridge_flows"),
+                    ref("fact_avalanche_bridge_flows"),
+                    ref("fact_base_bridge_flows"),
+                    ref("fact_optimism_bridge_flows"),
+                    ref("fact_polygon_pos_bridge_flows"),
+                    ref("fact_starknet_bridge_flows"),
+                    ref("fact_zksync_era_bridge_flows"),
+                ]
+            )
+        }}
+    )
+select
+    *,
+    date::string
+    || '-'
+    || app
+    || '-'
+    || source_chain
+    || '-'
+    || destination_chain
+    || '-'
+    || category as unique_id
+from daily_data
+where date < to_date(sysdate())

--- a/models/staging/avalanche_bridge/fact_avalanche_bridge_flows.sql
+++ b/models/staging/avalanche_bridge/fact_avalanche_bridge_flows.sql
@@ -10,26 +10,26 @@ with
         where token_address in (select * from distinct_tokens)
     ),
 
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
+
     hourly_volume as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
-            t.token_address,
-            sum(
-                (coalesce(amount, 0) / power(10, coalesce(p.decimals, 0)))
-                * coalesce(price, 0)
-            ) as amount_usd,
-            sum(
-                (coalesce(fee, 0) / power(10, coalesce(p.decimals, 0)))
-                * coalesce(price, 0)
-            ) as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd,
+            coalesce((fee / power(10, p.decimals)) * price, 0) as fee_usd
         from {{ ref("fact_avalanche_bridge_transfers") }} t
         left join
             prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
-        group by 1, 2, 3, 4
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'avalanche' --only using l1token
     )
 
 select
@@ -41,5 +41,4 @@ select
     sum(amount_usd) as amount_usd,
     sum(fee_usd) as fee_usd
 from hourly_volume
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5

--- a/models/staging/base_bridge/fact_base_bridge_flows.sql
+++ b/models/staging/base_bridge/fact_base_bridge_flows.sql
@@ -1,22 +1,23 @@
 with
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
+
     volume_and_fees_by_chain_and_symbol as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
-            p.symbol,
-            t.token_address,
-            sum(
-                (coalesce(amount, 0) / power(10, coalesce(p.decimals, 18)))
-                * coalesce(price, 0)
-            ) as amount_usd,
-            sum(null) as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_base_bridge_transfers") }} t
         left join
             ethereum_flipside.price.ez_hourly_token_prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
-        group by 1, 2, 3, 4, 5
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     )
 
 select
@@ -26,8 +27,7 @@ select
     destination_chain,
     category,
     sum(amount_usd) as amount_usd,
-    sum(fee_usd) as fee_usd
+    null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5
 order by date asc, source_chain asc

--- a/models/staging/optimism_bridge/fact_optimism_bridge_flows.sql
+++ b/models/staging/optimism_bridge/fact_optimism_bridge_flows.sql
@@ -1,22 +1,23 @@
 with
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
+
     volume_and_fees_by_chain_and_symbol as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
-            p.symbol,
-            t.token_address,
-            sum(
-                (coalesce(amount, 0) / power(10, coalesce(p.decimals, 0)))
-                * coalesce(price, 0)
-            ) as amount_usd,
-            sum(null) as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_optimism_bridge_transfers") }} t
         left join
             ethereum_flipside.price.ez_hourly_token_prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
-        group by 1, 2, 3, 4, 5
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     )
 
 select
@@ -26,8 +27,7 @@ select
     destination_chain,
     category,
     sum(amount_usd) as amount_usd,
-    sum(fee_usd) as fee_usd
+    null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5
 order by date asc, source_chain asc

--- a/models/staging/polygon_pos_bridge/fact_polygon_pos_bridge_flows.sql
+++ b/models/staging/polygon_pos_bridge/fact_polygon_pos_bridge_flows.sql
@@ -1,19 +1,25 @@
 with
+
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
+
     volume_and_fees_by_chain_and_symbol as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
             p.symbol,
-            t.token_address,
-            (coalesce(amount, 0) / power(10, coalesce(p.decimals, 0)))
-            * coalesce(price, 0) as amount_usd,
-            null as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_polygon_pos_bridge_transfers") }} t
         left join
             ethereum_flipside.price.ez_hourly_token_prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     ),
 
     filtered_volume_and_fees_by_chain_and_symbol as (
@@ -22,17 +28,13 @@ with
             source_chain,
             destination_chain,
             symbol,
-            token_address,
-            sum(
-                case
-                    when (symbol in ('DG', 'BORING', 'TORG')) and amount_usd > 10000000
-                    then 0
-                    else amount_usd
-                end
-            ) as amount_usd,
-            sum(fee_usd) as fee_usd
+            category,
+            case
+                when (symbol in ('DG', 'BORING', 'TORG')) and amount_usd > 10000000
+                then 0
+                else amount_usd
+            end as amount_usd
         from volume_and_fees_by_chain_and_symbol
-        group by 1, 2, 3, 4, 5
     )
 
 select
@@ -42,8 +44,7 @@ select
     destination_chain,
     category,
     sum(amount_usd) as amount_usd,
-    sum(fee_usd) as fee_usd
+    null as fee_usd
 from filtered_volume_and_fees_by_chain_and_symbol
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5
 order by date asc, source_chain asc

--- a/models/staging/starknet_bridge/fact_starknet_bridge_flows.sql
+++ b/models/staging/starknet_bridge/fact_starknet_bridge_flows.sql
@@ -1,22 +1,23 @@
 with
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
+
     volume_and_fees_by_chain_and_symbol as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
-            p.symbol,
-            t.token_address,
-            sum(
-                (coalesce(amount, 0) / power(10, coalesce(p.decimals, 0)))
-                * coalesce(price, 0)
-            ) as amount_usd,
-            sum(null) as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_starknet_bridge_transfers") }} t
         left join
             ethereum_flipside.price.ez_hourly_token_prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
-        group by 1, 2, 3, 4, 5
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     )
 
 select
@@ -26,8 +27,7 @@ select
     destination_chain,
     category,
     sum(amount_usd) as amount_usd,
-    sum(fee_usd) as fee_usd
+    null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5
 order by date asc, source_chain asc

--- a/models/staging/zksync_era_bridge/fact_zksync_era_bridge_flows.sql
+++ b/models/staging/zksync_era_bridge/fact_zksync_era_bridge_flows.sql
@@ -1,22 +1,22 @@
 with
+    dim_contracts as (
+        select distinct address, chain, category
+        from {{ ref("dim_contracts_gold") }} 
+        where category is not null and chain is not null
+    ),
     volume_and_fees_by_chain_and_symbol as (
         select
             date_trunc('hour', block_timestamp) as hour,
             source_chain,
             destination_chain,
-            p.symbol,
-            t.token_address,
-            sum(
-                (coalesce(amount, 0) / power(10, coalesce(p.decimals, 18)))
-                * coalesce(price, 0)
-            ) as amount_usd,
-            sum(null) as fee_usd
+            coalesce(c.category, 'Not Categorized') as category,
+            coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_zksync_era_bridge_transfers") }} t
         left join
             ethereum_flipside.price.ez_hourly_token_prices p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
-        group by 1, 2, 3, 4, 5
+        left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     )
 
 select
@@ -26,8 +26,7 @@ select
     destination_chain,
     category,
     sum(amount_usd) as amount_usd,
-    sum(fee_usd) as fee_usd
+    null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-left join {{ ref("dim_contracts_gold") }} t2 on lower(token_address) = lower(t2.address)
 group by 1, 2, 3, 4, 5
 order by date asc, source_chain asc


### PR DESCRIPTION
## :pushpin: Updating Bridge Flows Models to fix duplication issue
1. Previously, when categorizing the flows between chains the model only joined `dim_contracts_gold` on the contract `address`, this caused duplicate rows to be created if there were two addresses that existed. 
2. The model now joins on both `address` and (`destination_chain` or `source_chain`. This will remove those duplicate rows
