### PR TITLE
Added Support for Sui Contract labels

### DIFF
--- a/models/dimensions/apps/dim_apps_silver.sql
+++ b/models/dimensions/apps/dim_apps_silver.sql
@@ -56,15 +56,16 @@ with
 
 select
     coalesce(
-        sigma_app_tagged.namespace, dune_namespace.namespace, flipside.namespace
+        sigma_app_tagged.namespace, sui.namespace, dune_namespace.namespace, flipside.namespace
     ) as namespace,
     coalesce(
         sigma_app_tagged.friendly_name,
+        sui.friendly_name,
         initcap(replace(dune_namespace.namespace, '_', ' ')),
         flipside.friendly_name
     ) as friendly_name,
-    coalesce(sigma_app_tagged.sub_category, flipside.sub_category) as sub_category,
-    coalesce(sigma_app_tagged.category, flipside.category) as category,
+    coalesce(sigma_app_tagged.sub_category, sui.sub_category, flipside.sub_category) as sub_category,
+    coalesce(sigma_app_tagged.category, sui.category, flipside.category) as category,
     artemis_id,
     coingecko_id,
     ecosystem_id,
@@ -72,7 +73,7 @@ select
     parent_app,
     coalesce(visibility, 1) as visibility,
     symbol,
-    icon
+    coalesce(sigma_app_tagged.icon, sui.icon) as icon
 from sigma_app_tagged
 full join
     {{ ref("dim_dune_namespaces") }} as dune_namespace
@@ -80,7 +81,11 @@ full join
 full join
     {{ ref("dim_flipside_namespaces") }} as flipside
     on sigma_app_tagged.namespace = flipside.namespace
+full join 
+    {{ ref("dim_sui_namespaces") }} as sui
+    on sigma_app_tagged.namespace = sui.namespace
 where
     sigma_app_tagged.namespace is not null
     or dune_namespace.namespace is not null
     or flipside.namespace is not null
+    or sui.namespace is not null

--- a/models/dimensions/contracts/dim_contracts_silver.sql
+++ b/models/dimensions/contracts/dim_contracts_silver.sql
@@ -24,6 +24,9 @@ with
         union
         select lower(address) address, chain
         from {{ ref("dim_scanner_contracts") }}
+        union 
+        select lower(address) address, chain
+        from {{ ref("dim_sui_contracts") }}
     ),
     distinct_contract as (select address, chain from contracts group by address, chain),
     contract_waterfall as (
@@ -34,6 +37,7 @@ with
                 user_sub.namespace,
                 scanner.namespace,
                 dune.namespace,
+                sui.namespace,
                 flipside_near.namespace,
                 flipside_sol.namespace,
                 null
@@ -42,6 +46,7 @@ with
                 user_sub.name,
                 scanner.name,
                 dune.name,
+                sui.name,
                 flipside_near.name,
                 flipside_sol.name,
                 null
@@ -73,6 +78,9 @@ with
             {{ ref("dim_scanner_contracts") }} as scanner
             on lower(dc.address) = lower(scanner.address)
             and dc.chain = scanner.chain
+        left join {{ ref("dim_sui_contracts") }} sui
+            on lower(dc.address) = lower(sui.address)
+            and dc.chain = sui.chain
     ),
     contracts_to_parent_app as (
         select

--- a/models/staging/sui/__sui__sources.yml
+++ b/models/staging/sui/__sui__sources.yml
@@ -1,6 +1,12 @@
 sources:
+  - name: SIGMA
+    schema: PROD
+    database: SIGMA
+    tables:
+      - name: sui_overwrite_namespace
   - name: PROD_LANDING
     schema: PROD_LANDING
     database: LANDING_DATABASE
     tables:
       - name: raw_sui_data
+      - name: raw_sui_contracts

--- a/models/staging/sui/dim_sui_contracts.sql
+++ b/models/staging/sui/dim_sui_contracts.sql
@@ -1,0 +1,26 @@
+{{config(materialized="incremental", unique_key=["package_id", "version"])}}
+with 
+sui_contracts_sigma_over as (
+    select 
+        package_id as address,
+        package_name as name, 
+        coalesce(overwrite.overwrite_namespace, overwrite_w_exisiting_namespace, namespace) as namespace,
+        friendly_name,
+        project_img as icon,
+        category,
+        sub_category,
+        'sui' as chain
+    from {{ ref("fact_sui_contracts_silver") }} as sui_contracts full join {{ source("SIGMA", "sui_overwrite_namespace") }} overwrite
+    on sui_contracts.namespace = overwrite.sui_namespace
+) 
+select 
+    address,
+    name, 
+    namespace,
+    friendly_name,
+    icon,
+    category,
+    sub_category,
+    chain
+from sui_contracts_sigma_over
+where address is not null

--- a/models/staging/sui/dim_sui_namespaces.sql
+++ b/models/staging/sui/dim_sui_namespaces.sql
@@ -1,0 +1,10 @@
+{{config(materialized="incremental", unique_key=["namespace"])}}
+
+select 
+    namespace,
+    max(friendly_name) as friendly_name,
+    max(sub_category) as sub_category,
+    max(category) as category,
+    max(icon) as icon
+from {{ ref("dim_sui_contracts") }} as sui_contracts
+group by namespace

--- a/models/staging/sui/fact_sui_contracts_silver.sql
+++ b/models/staging/sui/fact_sui_contracts_silver.sql
@@ -1,0 +1,24 @@
+{{ config(materialized="incremental", unique_key=["package_id", "timestamp", "version"]) }}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_sui_contracts") }}
+    ),
+    sui_data as (
+        select parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_sui_contracts") }}
+        where extraction_date = (select max_date from max_extraction)
+    )
+    select
+        value:"packageId"::string as package_id,
+        value:"creator"::string as creator_address,
+        value:"packageName"::string as package_name,
+        lower(replace(value:"projectName"::string, ' ', '_')) as namespace,
+        value:"projectName"::string as friendly_name,
+        value:"projectImg"::string as project_img,
+        date(to_timestamp(value:"timestamp"::number / 1000)) as timestamp,
+        value:"transactions" as transactions,
+        value:"version"::number as version
+    from sui_data, lateral flatten(input => data)
+    order by transactions desc


### PR DESCRIPTION
## :pushpin: Added Support for Sui Contract Labels

Built support for sui contract labels.

## 🎄  Asset Checklist
- [X] Added to `assets.csv` or already exists

## 🧮  Metric Checklist
- [X] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
