### PR TITLE
Customer 911: Updating cosmos models

### DIFF
--- a/models/staging/cosmoshub/fact_cosmoshub_daa.sql
+++ b/models/staging/cosmoshub/fact_cosmoshub_daa.sql
@@ -6,10 +6,9 @@ with
     )
 select
     date(value:date) as date,
-    value:"DAU"::int as daa,
-    value as source,
+    value:"daa"::int as daa,
     'cosmoshub' as chain
 from
     {{ source("PROD_LANDING", "raw_cosmoshub_daa") }},
     lateral flatten(input => parse_json(source_json))
-where extraction_date = (select max_date from max_extraction)
+where extraction_date = (select max_date from max_extraction) and date(value:date) is not null

--- a/models/staging/cosmoshub/fact_cosmoshub_daa_gold.sql
+++ b/models/staging/cosmoshub/fact_cosmoshub_daa_gold.sql
@@ -1,3 +1,3 @@
 {{ config(materialized="table") }}
-select date, daa, chain, source
+select date, daa, chain
 from {{ ref("fact_cosmoshub_daa") }}

--- a/models/staging/cosmoshub/fact_cosmoshub_fees_and_revenue.sql
+++ b/models/staging/cosmoshub/fact_cosmoshub_fees_and_revenue.sql
@@ -6,7 +6,7 @@ with
     ),
     cosmoshub_prices as ({{ get_coingecko_price_with_latest("cosmos") }}),
     raw as (
-        select date(value:date) as date, value:"fees"::int as fees, value as source
+        select date(value:date) as date, value:"fee"::float as fees, value:"fee_currency"::string as fee_currency
         from
             {{ source("PROD_LANDING", "raw_cosmoshub_fees") }},
             lateral flatten(input => parse_json(source_json))
@@ -15,8 +15,9 @@ with
 select
     raw.date,
     'cosmoshub' as chain,
-    fees as gas,
-    fees * coalesce(price, 0) as gas_usd,
+    sum(fees) as gas,
+    sum(fees * coalesce(price, 0)) as gas_usd,
     gas_usd * .02 as revenue
 from raw
-left join cosmoshub_prices on raw.date = cosmoshub_prices.date
+left join cosmoshub_prices on raw.date = cosmoshub_prices.date and fee_currency = 'uatom'
+group by 1

--- a/models/staging/cosmoshub/fact_cosmoshub_txns.sql
+++ b/models/staging/cosmoshub/fact_cosmoshub_txns.sql
@@ -7,9 +7,8 @@ with
 select
     date(value:date) as date,
     value:txns::int as txns,
-    value as source,
     'cosmoshub' as chain
 from
     {{ source("PROD_LANDING", "raw_cosmoshub_txns") }},
     lateral flatten(input => parse_json(source_json))
-where extraction_date = (select max_date from max_extraction)
+where extraction_date = (select max_date from max_extraction) and date(value:date) is not null

--- a/models/staging/cosmoshub/fact_cosmoshub_txns_gold.sql
+++ b/models/staging/cosmoshub/fact_cosmoshub_txns_gold.sql
@@ -1,3 +1,3 @@
 {{ config(materialized="table") }}
-select date, txns, chain, source
+select date, txns, chain
 from {{ ref("fact_cosmoshub_txns") }}


### PR DESCRIPTION
1. Cosmos data was stale, switching to numia data instead of bitquery
