### PR TITLE
adding p2p transfer volume through ez metrics

### DIFF
--- a/macros/metrics/get_p2p_metrics.sql
+++ b/macros/metrics/get_p2p_metrics.sql
@@ -1,0 +1,4 @@
+{% macro get_p2p_metrics(chain) %}
+    select date, p2p_native_transfer_volume, p2p_token_transfer_volume, p2p_stablecoin_transfer_volume, p2p_transfer_volume
+    from {{ ref("fact_" ~ chain ~ "_p2p_transfer_volume") }}
+{% endmacro %}

--- a/macros/p2p/filter_p2p_token_transfers.sql
+++ b/macros/p2p/filter_p2p_token_transfers.sql
@@ -1,0 +1,44 @@
+{% macro filter_p2p_token_transfers(chain, limit_number, blacklist=('')) %}
+with
+    dex_swap_liquidity as (
+        select 
+            sum(amount_in_usd) as daily_volume,
+            token_in, 
+            token_out
+        from {{ chain }}_flipside.defi.ez_dex_swaps 
+        where amount_in_usd is not null and amount_out_usd is not null and
+            abs(
+                ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
+                - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)
+            )
+            < 1
+        group by token_in, token_out
+        order by daily_volume desc
+        limit {{ limit_number }}-- choose top pairs depending on the chain   
+    ),
+    tokens as (
+        select distinct token_in as token
+        from dex_swap_liquidity
+        union
+        select distinct token_out as token
+        from dex_swap_liquidity
+    )
+    select 
+        block_timestamp,
+        block_number,
+        tx_hash,
+        index,
+        token_address,
+        from_address,
+        to_address,
+        raw_amount_precise,
+        amount_precise,
+        amount_usd
+    from {{ ref("fact_"~ chain ~"_p2p_token_transfers_silver")}} 
+    where amount_usd is not null 
+        and token_address in (select token from tokens)
+        and 
+        {% if blacklist is string %} lower(token_address) != '{{ blacklist }}'
+        {% elif blacklist | length > 1 %} token_address not in {{ blacklist }}
+        {% endif %}
+{% endmacro %}

--- a/macros/p2p/p2p_native_transfers.sql
+++ b/macros/p2p/p2p_native_transfers.sql
@@ -1,0 +1,51 @@
+{% macro p2p_native_transfers(chain) %}
+    with 
+        {% if chain == "avalanche" %}
+            prices as ({{ get_coingecko_price_with_latest("avalanche-2") }}),
+        {% elif chain == "polygon" %}
+            prices as ({{ get_coingecko_price_with_latest("matic-network") }}),
+        {% else %}
+            prices as ({{ get_coingecko_price_with_latest(chain) }}),
+        {% endif %}
+        distinct_peer_address as (
+            select address
+            from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
+        ), 
+        transfers as (
+            select 
+                block_timestamp,
+                block_number,
+                tx_hash,
+                trace_index as index,
+                from_address,
+                to_address,
+                amount_precise_raw as raw_amount_precise,
+                amount_precise,
+            from {{ chain }}_flipside.core.ez_native_transfers
+            {% if is_incremental() %} 
+                where block_timestamp >= (
+                    select dateadd('day', -3, max(block_timestamp))
+                    from {{ this }}
+                )
+            {% endif %}
+
+        )
+
+    select 
+        t1.block_timestamp,
+        t1.block_number,
+        t1.tx_hash,
+        t1.index,
+        t1.from_address,
+        t1.to_address,
+        t1.raw_amount_precise,
+        t1.amount_precise,
+        coalesce(t1.amount_precise * price, 0) as amount_usd
+    from transfers t1
+    inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
+    inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
+    left join prices on prices.date = t1.block_timestamp::date
+    where to_address != from_address 
+        and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+        and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
+{% endmacro %}

--- a/macros/p2p/p2p_token_transfers.sql
+++ b/macros/p2p/p2p_token_transfers.sql
@@ -1,0 +1,45 @@
+{% macro p2p_token_transfers(chain) %}
+    with 
+        distinct_peer_address as (
+            select address
+            from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
+        ), 
+        transfers as (
+            select 
+                block_timestamp,
+                block_number,
+                tx_hash,
+                event_index as index,
+                from_address,
+                to_address,
+                raw_amount_precise,
+                amount_precise,
+                contract_address as token_address,
+                amount_usd
+            from {{ chain }}_flipside.core.ez_token_transfers
+            {% if is_incremental() %} 
+                where block_timestamp >= (
+                    select dateadd('day', -3, max(block_timestamp))
+                    from {{ this }}
+                )
+            {% endif %}
+        )
+
+    select 
+        t1.block_timestamp,
+        t1.block_number,
+        t1.tx_hash,
+        t1.index,
+        t1.token_address,
+        t1.from_address,
+        t1.to_address,
+        t1.raw_amount_precise,
+        t1.amount_precise,
+        t1.amount_usd
+    from transfers t1
+    inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
+    inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
+    where to_address != from_address 
+        and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+        and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
+{% endmacro %}

--- a/macros/p2p/p2p_transfer_volume.sql
+++ b/macros/p2p/p2p_transfer_volume.sql
@@ -1,0 +1,38 @@
+{% macro p2p_transfer_volume(chain) %}
+with 
+    native_transfers as (
+        select 
+            block_timestamp::date as date,
+            sum(amount_usd) as amount
+        from {{ ref("fact_"~ chain ~"_p2p_native_transfers")}}
+        group by date
+    ),
+    token_transfers as (
+        select
+            block_timestamp::date as date,
+            sum(amount_usd) as amount
+        from {{ ref("fact_"~ chain ~"_p2p_token_transfers")}}
+        where token_address not in (select lower(contract_address) from {{ ref("fact_" ~chain~"_stablecoin_contracts")}})
+        group by date
+    ),
+    stablecoin_transfers as (
+        select
+            block_timestamp::date as date,
+            sum(amount_usd) as amount
+        from {{ ref("fact_"~ chain ~"_p2p_token_transfers")}}
+        where token_address in (select lower(contract_address) from {{ ref("fact_" ~chain~ "_stablecoin_contracts")}})
+        group by date
+    )
+
+select 
+    date,
+    '{{chain}}' as chain,
+    t1.amount as p2p_native_transfer_volume,
+    t2.amount as p2p_token_transfer_volume,
+    t3.amount as p2p_stablecoin_transfer_volume,
+    coalesce(t1.amount, 0) + coalesce(t2.amount, 0) + coalesce(t3.amount, 0)  as p2p_transfer_volume
+from native_transfers t1
+left join token_transfers t2 using(date)
+left join stablecoin_transfers t3 using(date)
+order by date
+{% endmacro %}

--- a/macros/wallets/distinct_evm_eoa_addresses.sql
+++ b/macros/wallets/distinct_evm_eoa_addresses.sql
@@ -1,0 +1,5 @@
+{% macro distinct_evm_eoa_addresses(chain) %}
+select 
+    distinct from_address as address, 'eoa' as address_type
+from {{ chain }}_flipside.core.fact_transactions
+{% endmacro %}

--- a/models/dimensions/wallet/dim_arbitrum_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_arbitrum_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("arbitrum") }}

--- a/models/dimensions/wallet/dim_avalanche_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_avalanche_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("avalanche") }}

--- a/models/dimensions/wallet/dim_base_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_base_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("base") }}

--- a/models/dimensions/wallet/dim_ethereum_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_ethereum_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("ethereum") }}

--- a/models/dimensions/wallet/dim_optimism_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_optimism_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("optimism") }}

--- a/models/dimensions/wallet/dim_polygon_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_polygon_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_evm_eoa_addresses("polygon") }}

--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -20,7 +20,8 @@ with
     ),
     github_data as ({{ get_github_metrics("arbitrum") }}),
     contract_data as ({{ get_contract_metrics("arbitrum") }}),
-    nft_metrics as ({{ get_nft_metrics("arbitrum") }})
+    nft_metrics as ({{ get_nft_metrics("arbitrum") }}),
+    p2p_metrics as ({{ get_p2p_metrics("arbitrum") }})
 select
     fundamental_data.date,
     fundamental_data.chain,
@@ -52,7 +53,11 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
-    nft_trading_volume
+    nft_trading_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -61,4 +66,5 @@ left join expenses_data on fundamental_data.date = expenses_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
+left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -22,7 +22,8 @@ with
         select date, validator_rewards as issuance
         from {{ ref("fact_avalanche_validator_rewards_silver") }}
     ),
-    nft_metrics as ({{ get_nft_metrics("avalanche") }})
+    nft_metrics as ({{ get_nft_metrics("avalanche") }}),
+    p2p_metrics as ({{ get_p2p_metrics("avalanche") }})
 
 select
     coalesce(fundamental_data.date, staking_data.date) as date,
@@ -57,7 +58,11 @@ select
     total_staked_native,
     total_staked_usd,
     issuance,
-    nft_trading_volume
+    nft_trading_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from staking_data
 left join fundamental_data on staking_data.date = fundamental_data.date
 left join price_data on staking_data.date = price_data.date
@@ -67,4 +72,5 @@ left join github_data on staking_data.date = github_data.date
 left join contract_data on staking_data.date = contract_data.date
 left join issuance_data on staking_data.date = issuance_data.date
 left join nft_metrics on staking_data.date = nft_metrics.date
+left join p2p_metrics on staking_data.date = p2p_metrics.date
 where coalesce(fundamental_data.date, staking_data.date) < to_date(sysdate())

--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -17,7 +17,8 @@ with
     expenses_data as (
         select date, chain, l1_data_cost_native, l1_data_cost, revenue_native, revenue
         from {{ ref("agg_daily_base_revenue") }}
-    )  -- supply side revenue and fees
+    ),  -- supply side revenue and fees
+    p2p_metrics as ({{ get_p2p_metrics("base") }})
 
 select
     fundamental_data.date,
@@ -41,10 +42,15 @@ select
     stablecoin_total_supply,
     stablecoin_txns,
     stablecoin_dau,
-    stablecoin_transfer_volume
+    stablecoin_transfer_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_data
 left join defillama_data on fundamental_data.date = defillama_data.date
 left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join expenses_data on fundamental_data.date = expenses_data.date
 left join contract_data on fundamental_data.date = contract_data.date
+left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -28,7 +28,8 @@ with
         select date, queue_entry_amount, queue_exit_amount, queue_active_amount
         from {{ ref("fact_ethereum_beacon_chain_queue_entry_active_exit_silver") }}
     ),
-    nft_metrics as ({{ get_nft_metrics("ethereum") }})
+    nft_metrics as ({{ get_nft_metrics("ethereum") }}),
+    p2p_metrics as ({{ get_p2p_metrics("ethereum") }})
 
 select
     fundamental_data.date,
@@ -76,7 +77,11 @@ select
     queue_entry_amount,
     queue_exit_amount,
     queue_active_amount,
-    nft_trading_volume
+    nft_trading_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -88,4 +93,5 @@ left join validator_queue_data on fundamental_data.date = validator_queue_data.d
 left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
+left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -19,7 +19,8 @@ with
     expenses_data as (
         select date, chain, l1_data_cost_native, l1_data_cost, revenue_native, revenue
         from {{ ref("agg_daily_optimism_revenue") }}
-    )  -- supply side revenue and fees
+    ),  -- supply side revenue and fees
+    p2p_metrics as ({{ get_p2p_metrics("optimism") }})
 
 select
     coalesce(
@@ -59,7 +60,11 @@ select
     stablecoin_total_supply,
     stablecoin_txns,
     stablecoin_dau,
-    stablecoin_transfer_volume
+    stablecoin_transfer_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -67,4 +72,5 @@ left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join expenses_data on fundamental_data.date = expenses_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
+left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -20,7 +20,8 @@ with
         select date, native_token_burn as revenue_native, revenue
         from {{ ref("agg_daily_polygon_revenue") }}
     ),
-    nft_metrics as ({{ get_nft_metrics("polygon") }})
+    nft_metrics as ({{ get_nft_metrics("polygon") }}),
+    p2p_metrics as ({{ get_p2p_metrics("polygon") }})
 
 select
     fundamental_data.date,
@@ -52,7 +53,11 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
-    nft_trading_volume
+    nft_trading_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -61,4 +66,5 @@ left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join revenue_data on fundamental_data.date = revenue_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
+left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/arbitrum/_test_fact_arbitrum_p2p_transfer_volume.yml
+++ b/models/staging/arbitrum/_test_fact_arbitrum_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_arbitrum_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/arbitrum/fact_arbitrum_p2p_native_transfers.sql
+++ b/models/staging/arbitrum/fact_arbitrum_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="ARBITRUM",
+    )
+}}
+
+{{ p2p_native_transfers("arbitrum") }}

--- a/models/staging/arbitrum/fact_arbitrum_p2p_token_transfers.sql
+++ b/models/staging/arbitrum/fact_arbitrum_p2p_token_transfers.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ARBITRUM",
+    )
+}}
+
+{{ filter_p2p_token_transfers("arbitrum", 500) }}

--- a/models/staging/arbitrum/fact_arbitrum_p2p_token_transfers_silver.sql
+++ b/models/staging/arbitrum/fact_arbitrum_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="ARBITRUM",
+    )
+}}
+
+{{ p2p_token_transfers("arbitrum") }}

--- a/models/staging/arbitrum/fact_arbitrum_p2p_transfer_volume.sql
+++ b/models/staging/arbitrum/fact_arbitrum_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ARBITRUM",
+    )
+}}
+
+{{ p2p_transfer_volume("arbitrum") }}

--- a/models/staging/avalanche/_test_fact_avalanche_p2p_transfer_volume.yml
+++ b/models/staging/avalanche/_test_fact_avalanche_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_avalanche_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/avalanche/fact_avalanche_amount_staked_silver.sql
+++ b/models/staging/avalanche/fact_avalanche_amount_staked_silver.sql
@@ -39,4 +39,4 @@ select
     total_staked_native * coalesce(price, 0) as total_staked_usd
 from map
 left join prices on map.date = prices.date
-where map.date < to_date(sysdate())
+where map.date < to_date(sysdate()) and map.date >= '2015-01-01' --sometimes the dashboard is borked

--- a/models/staging/avalanche/fact_avalanche_p2p_native_transfers.sql
+++ b/models/staging/avalanche/fact_avalanche_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="AVALANCHE",
+    )
+}}
+
+{{ p2p_native_transfers("avalanche") }}

--- a/models/staging/avalanche/fact_avalanche_p2p_token_transfers.sql
+++ b/models/staging/avalanche/fact_avalanche_p2p_token_transfers.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AVALANCHE",
+    )
+}}
+
+{{ filter_p2p_token_transfers("avalanche", 1000) }}

--- a/models/staging/avalanche/fact_avalanche_p2p_token_transfers_silver.sql
+++ b/models/staging/avalanche/fact_avalanche_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="AVALANCHE",
+    )
+}}
+
+{{ p2p_token_transfers("avalanche") }}

--- a/models/staging/avalanche/fact_avalanche_p2p_transfer_volume.sql
+++ b/models/staging/avalanche/fact_avalanche_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AVALANCHE",
+    )
+}}
+
+{{ p2p_transfer_volume("avalanche") }}

--- a/models/staging/base/_test_fact_base_p2p_transfer_volume.yml
+++ b/models/staging/base/_test_fact_base_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_base_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/base/fact_base_p2p_native_transfers.sql
+++ b/models/staging/base/fact_base_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="BASE",
+    )
+}}
+
+{{ p2p_native_transfers("base") }}

--- a/models/staging/base/fact_base_p2p_token_transfers.sql
+++ b/models/staging/base/fact_base_p2p_token_transfers.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="BASE",
+    )
+}}
+
+{{ filter_p2p_token_transfers("base", 1000) }}

--- a/models/staging/base/fact_base_p2p_token_transfers_silver.sql
+++ b/models/staging/base/fact_base_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="BASE",
+    )
+}}
+
+{{ p2p_token_transfers("base") }}

--- a/models/staging/base/fact_base_p2p_transfer_volume.sql
+++ b/models/staging/base/fact_base_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="BASE",
+    )
+}}
+
+{{ p2p_transfer_volume("base") }}

--- a/models/staging/ethereum/_test_fact_ethereum_p2p_transfer_volume.yml
+++ b/models/staging/ethereum/_test_fact_ethereum_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_ethereum_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/ethereum/fact_ethereum_p2p_native_transfers.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="table",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="ETHEREUM",
+    )
+}}
+
+{{ p2p_native_transfers("ethereum") }}

--- a/models/staging/ethereum/fact_ethereum_p2p_token_transfers.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_token_transfers.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ETHEREUM_XS",
+    )
+}}
+
+{{ filter_p2p_token_transfers("ethereum", 750, blacklist=('0x2b591e99afe9f32eaa6214f7b7629768c40eeb39')) }}

--- a/models/staging/ethereum/fact_ethereum_p2p_token_transfers_silver.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="ETHEREUM_XS",
+    )
+}}
+
+{{ p2p_token_transfers("ethereum") }}

--- a/models/staging/ethereum/fact_ethereum_p2p_transfer_volume.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ETHEREUM_XS",
+    )
+}}
+
+{{ p2p_transfer_volume("ethereum") }}

--- a/models/staging/optimism/_test_fact_optimism_p2p_transfer_volume.yml
+++ b/models/staging/optimism/_test_fact_optimism_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_optimism_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/optimism/fact_optimism_p2p_native_transfers.sql
+++ b/models/staging/optimism/fact_optimism_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="OPTIMISM",
+    )
+}}
+
+{{ p2p_native_transfers("optimism") }}

--- a/models/staging/optimism/fact_optimism_p2p_token_transfers.sql
+++ b/models/staging/optimism/fact_optimism_p2p_token_transfers.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM",
+    )
+}}
+
+{{ filter_p2p_token_transfers("optimism", 1000) }}

--- a/models/staging/optimism/fact_optimism_p2p_token_transfers_silver.sql
+++ b/models/staging/optimism/fact_optimism_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="OPTIMISM",
+    )
+}}
+
+{{ p2p_token_transfers("optimism") }}

--- a/models/staging/optimism/fact_optimism_p2p_transfer_volume.sql
+++ b/models/staging/optimism/fact_optimism_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM",
+    )
+}}
+
+{{ p2p_transfer_volume("optimism") }}

--- a/models/staging/polygon/_test_fact_polygon_p2p_transfer_volume.yml
+++ b/models/staging/polygon/_test_fact_polygon_p2p_transfer_volume.yml
@@ -1,0 +1,45 @@
+models:
+  - name: fact_polygon_p2p_transfer_volume
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: CHAIN
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: p2p_native_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: p2p_transfer_volume
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_column_values_to_be_within_n_moving_stdevs:
+              date_column_name: DATE
+              period: day
+              lookback_periods: 1
+              trend_periods: 14
+              test_periods: 28
+              sigma_threshold: 3
+              take_logs: true
+              severity: warn
+      - name: DATE
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: warn

--- a/models/staging/polygon/fact_polygon_p2p_native_transfers.sql
+++ b/models/staging/polygon/fact_polygon_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="table",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="POLYGON_SM",
+    )
+}}
+
+{{ p2p_native_transfers("polygon") }}

--- a/models/staging/polygon/fact_polygon_p2p_token_transfers.sql
+++ b/models/staging/polygon/fact_polygon_p2p_token_transfers.sql
@@ -1,0 +1,15 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="POLYGON_SM",
+    )
+}}
+
+{{ filter_p2p_token_transfers("polygon", 200, 
+    blacklist=(
+        "0xaaa5b9e6c589642f98a1cda99b9d024b8407285a",
+        "0x229b1b6c23ff8953d663c4cbb519717e323a0a84",
+        "0xef938b6da8576a896f6e0321ef80996f4890f9c4",
+        "0x228b5c21ac00155cf62c57bcc704c0da8187950b"
+    )
+)}}

--- a/models/staging/polygon/fact_polygon_p2p_token_transfers_silver.sql
+++ b/models/staging/polygon/fact_polygon_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="POLYGON_SM",
+    )
+}}
+
+{{ p2p_token_transfers("polygon") }}

--- a/models/staging/polygon/fact_polygon_p2p_transfer_volume.sql
+++ b/models/staging/polygon/fact_polygon_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="POLYGON_SM",
+    )
+}}
+
+{{ p2p_transfer_volume("polygon") }}


### PR DESCRIPTION
1. Created marcos for p2p transfer volume
2. Created p2p models for following chains:
`arbitrum`
`avalanche`
`base`
`ethereum`
`optimism`
`polygon`
