### PR TITLE
Short Term Stablecoin fix

### DIFF
--- a/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics_silver.sql
+++ b/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics_silver.sql
@@ -7,7 +7,6 @@ with
                     ref("agg_arbitrum_stablecoin_metrics"),
                     ref("agg_avalanche_stablecoin_metrics"),
                     ref("agg_base_stablecoin_metrics"),
-                    ref("agg_blast_stablecoin_metrics"),
                     ref("agg_bsc_stablecoin_metrics"),
                     ref("agg_ethereum_stablecoin_metrics"),
                     ref("agg_optimism_stablecoin_metrics"),


### PR DESCRIPTION
1. Removing blast from agg_stablecoin_metrics_silver

To do:
1. Update the api in gokustats and front end
