### PR TITLE
Solana - Adding solana p2p metrics

### DIFF
--- a/macros/p2p/filter_p2p_token_transfers.sql
+++ b/macros/p2p/filter_p2p_token_transfers.sql
@@ -16,24 +16,67 @@
             {% if blacklist is string %} and token_address != '{{ blacklist }}'
             {% elif blacklist | length > 1 %} and token_address not in {{ blacklist }}
             {% endif %}
+        {% if is_incremental() %} 
+            and block_timestamp >= (
+                select dateadd('day', -3, max(block_timestamp))
+                from {{ this }}
+            )
+        {% endif %}
     {% else %}
         with
-        dex_swap_liquidity as (
-            select 
-                sum(amount_in_usd) as daily_volume,
-                token_in, 
-                token_out
-            from {{ chain }}_flipside.defi.ez_dex_swaps 
-            where amount_in_usd is not null and amount_out_usd is not null and
-                abs(
-                    ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
-                    - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)
-                )
-                < 1
-            group by token_in, token_out
-            order by daily_volume desc
-            limit {{ limit_number }}-- choose top pairs depending on the chain   
-        ),
+            {% if chain == "solana" %}
+                token_prices as (
+                    select
+                        recorded_hour::date as date,
+                        token_address,
+                        avg(close) as price
+                    from solana_flipside.price.ez_token_prices_hourly
+                    group by date, token_address
+                ),
+                dex_swap_liquidity as (
+                    select 
+                        sum(swap_from_amount * t2.price) as daily_volume,
+                        t1.swap_from_mint as token_in, 
+                        t1.swap_to_mint as token_out
+                    from solana_flipside.defi.fact_swaps t1
+                    left join token_prices t2 on t2.token_address = t1.swap_from_mint and t1.block_timestamp::date = t2.date
+                    left join token_prices t3 on t3.token_address = t1.swap_to_mint and t1.block_timestamp::date = t3.date
+                    where swap_to_amount <> 0 and swap_from_amount <> 0
+                        and swap_from_amount * t2.price is not null and swap_to_amount * t3.price is not null 
+                        and coalesce(swap_from_amount * t2.price, 0) > 0 and coalesce(swap_to_amount * t3.price, 0) > 0 and
+                        abs(
+                            ln(coalesce(nullif(swap_from_amount * t2.price, 0), 1)) / ln(10)
+                            - ln(coalesce(nullif(swap_to_amount * t3.price, 0), 1)) / ln(10)
+                        )
+                        < 1
+                        {% if is_incremental() %} -- largest volume over the last 10 days
+                            and block_timestamp >= (
+                                select dateadd('day', -10, max(block_timestamp))
+                                from {{ this }}
+                            )
+                        {% endif %}
+                    group by token_in, token_out
+                    order by daily_volume desc
+                    limit {{ limit_number }}-- choose top pairs depending on the chain   
+                ),
+            {% else %}
+                dex_swap_liquidity as (
+                    select 
+                        sum(amount_in_usd) as daily_volume,
+                        token_in, 
+                        token_out
+                    from {{ chain }}_flipside.defi.ez_dex_swaps 
+                    where amount_in_usd is not null and amount_out_usd is not null and
+                        abs(
+                            ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
+                            - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)
+                        )
+                        < 1
+                    group by token_in, token_out
+                    order by daily_volume desc
+                    limit {{ limit_number }}-- choose top pairs depending on the chain   
+                ),
+            {% endif %}
         tokens as (
             select distinct token_in as token
             from dex_swap_liquidity
@@ -55,8 +98,14 @@
         from {{ ref("fact_"~ chain ~"_p2p_token_transfers_silver")}} 
         where amount_usd is not null 
             and token_address in (select token from tokens) 
-            {% if blacklist is string %} and lower(token_address) != '{{ blacklist }}'
-            {% elif blacklist | length > 1 %} and token_address not in {{ blacklist }}
+            {% if blacklist is string %} and lower(token_address) != lower('{{ blacklist }}')
+            {% elif blacklist | length > 1 %} and token_address not in {{ blacklist }} --make sure you pass in lower
+            {% endif %}
+            {% if is_incremental() %} 
+                and block_timestamp >= (
+                    select dateadd('day', -3, max(block_timestamp))
+                    from {{ this }}
+                )
             {% endif %}
     {% endif %}
 {% endmacro %}

--- a/macros/p2p/p2p_native_transfers.sql
+++ b/macros/p2p/p2p_native_transfers.sql
@@ -6,6 +6,8 @@
             prices as ({{ get_coingecko_price_with_latest("matic-network") }}),
         {% elif chain == "tron" %}
             prices as ({{ get_coingecko_price_with_latest("tron") }}),
+        {% elif chain == "solana" %}
+            prices as ({{ get_coingecko_price_with_latest("solana") }}),
         {% else %}
             prices as ({{ get_coingecko_price_with_latest("ethereum") }}),
         {% endif %}
@@ -25,6 +27,25 @@
                     raw_amount as raw_amount_precise,
                     amount as amount_precise
                 from tron_allium.assets.trx_token_transfers
+                where to_address != from_address 
+                    and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq') -- Burn address of tron
+                    and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+            {% elif chain == "solana" %}
+                select 
+                    t2.block_timestamp,
+                    t1.block_id as block_number,
+                    t1.tx_id as tx_hash,
+                    t1.index,
+                    t1.tx_from as from_address,
+                    t1.tx_to as to_address,
+                    null as raw_amount_precise,
+                    t1.amount as amount_precise
+                from solana_flipside.core.fact_transfers t1
+                inner join solana_flipside.core.fact_blocks t2 using(block_id)
+                where mint = 'So11111111111111111111111111111111111111112'
+                    and t1.tx_from != t1.tx_to
+                    and lower(t1.tx_from) != lower('1nc1nerator11111111111111111111111111111111') -- Burn address of solana
+                    and lower(t1.tx_to) != lower('1nc1nerator11111111111111111111111111111111')
             {% else %}
                 select 
                     block_timestamp,
@@ -34,17 +55,20 @@
                     from_address,
                     to_address,
                     amount_precise_raw as raw_amount_precise,
-                    amount_precise,
+                    amount_precise
                 from {{ chain }}_flipside.core.ez_native_transfers
+                where to_address != from_address
+                    and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+                    and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
+
             {% endif %}
             {% if is_incremental() %} 
-                where block_timestamp >= (
+                and block_timestamp >= (
                     select dateadd('day', -3, max(block_timestamp))
                     from {{ this }}
                 )
             {% endif %}
         )
-
     select 
         t1.block_timestamp,
         t1.block_number,
@@ -59,16 +83,8 @@
     inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
     inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
     left join prices on prices.date = t1.block_timestamp::date
-    where to_address != from_address 
-        {% if chain == "tron" %}
-            and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq') -- Burn address of tron
-            and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
-        {% else %}
-            and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
-            and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
-        {% endif %}
     {% if is_incremental() %} 
-        and block_timestamp >= (
+        where block_timestamp >= (
             select dateadd('day', -3, max(block_timestamp))
             from {{ this }}
         )

--- a/macros/p2p/p2p_token_transfers.sql
+++ b/macros/p2p/p2p_token_transfers.sql
@@ -4,6 +4,16 @@
             select address
             from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
         ),
+        {% if chain == "solana" %}
+            token_prices as (
+                select
+                    recorded_hour::date as date,
+                    token_address,
+                    avg(close) as price
+                from solana_flipside.price.ez_token_prices_hourly
+                group by date, token_address
+            ),
+        {% endif %}
         transfers as (
             {% if chain == "tron" %}
                 select 
@@ -18,6 +28,28 @@
                     token_address,
                     usd_amount as amount_usd
                 from tron_allium.assets.trc20_token_transfers
+                where to_address != from_address 
+                    and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+                    and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+            {% elif chain == "solana" %}
+                select 
+                    t2.block_timestamp,
+                    t1.block_id as block_number,
+                    t1.tx_id as tx_hash,
+                    t1.index,
+                    t1.tx_from as from_address,
+                    t1.tx_to as to_address,
+                    null as raw_amount_precise,
+                    t1.amount as amount_precise,
+                    mint as token_address,
+                    coalesce(amount * price, 0) as amount_usd
+                from solana_flipside.core.fact_transfers t1
+                inner join solana_flipside.core.fact_blocks t2 using(block_id)
+                left join token_prices t3 on t1.mint = t3.token_address and t2.block_timestamp::date = t3.date
+                where mint <> 'So11111111111111111111111111111111111111112'
+                    and t1.tx_from != t1.tx_to
+                    and lower(t1.tx_from) != lower('1nc1nerator11111111111111111111111111111111') -- Burn address of solana
+                    and lower(t1.tx_to) != lower('1nc1nerator11111111111111111111111111111111')
             {% else %}
                 select 
                     block_timestamp,
@@ -31,9 +63,12 @@
                     contract_address as token_address,
                     amount_usd
                 from {{ chain }}_flipside.core.ez_token_transfers
+                where to_address != from_address 
+                    and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+                    and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
             {% endif %}
             {% if is_incremental() %} 
-                where block_timestamp >= (
+                and block_timestamp >= (
                     select dateadd('day', -3, max(block_timestamp))
                     from {{ this }}
                 )
@@ -54,16 +89,8 @@
     from transfers t1
     inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
     inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
-    where to_address != from_address 
-        {% if chain == "tron" %}
-            and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
-            and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
-        {% else %}
-            and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
-            and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
-        {% endif %}
     {% if is_incremental() %} 
-        and block_timestamp >= (
+        where block_timestamp >= (
             select dateadd('day', -3, max(block_timestamp))
             from {{ this }}
         )

--- a/macros/wallets/distinct_eoa_addresses.sql
+++ b/macros/wallets/distinct_eoa_addresses.sql
@@ -1,8 +1,11 @@
-{% macro distinct_evm_eoa_addresses(chain) %}
+{% macro distinct_eoa_addresses(chain) %}
     {% if chain == "tron" %}
         select 
             distinct from_address as address, 'eoa' as address_type
         from tron_allium.raw.transactions
+    {% elif chain == "solana" %}
+        select distinct signer as address,  'signer' as address_type
+        from solana_flipside.core.ez_signers 
     {% else %}
         select 
             distinct from_address as address, 'eoa' as address_type

--- a/models/dimensions/wallet/dim_arbitrum_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_arbitrum_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("arbitrum") }}
+{{ distinct_eoa_addresses("arbitrum") }}

--- a/models/dimensions/wallet/dim_avalanche_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_avalanche_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("avalanche") }}
+{{ distinct_eoa_addresses("avalanche") }}

--- a/models/dimensions/wallet/dim_base_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_base_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("base") }}
+{{ distinct_eoa_addresses("base") }}

--- a/models/dimensions/wallet/dim_ethereum_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_ethereum_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("ethereum") }}
+{{ distinct_eoa_addresses("ethereum") }}

--- a/models/dimensions/wallet/dim_optimism_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_optimism_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("optimism") }}
+{{ distinct_eoa_addresses("optimism") }}

--- a/models/dimensions/wallet/dim_polygon_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_polygon_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("polygon") }}
+{{ distinct_eoa_addresses("polygon") }}

--- a/models/dimensions/wallet/dim_solana_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_solana_eoa_addresses.sql
@@ -1,0 +1,1 @@
+{{ distinct_eoa_addresses("solana") }}

--- a/models/dimensions/wallet/dim_tron_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_tron_eoa_addresses.sql
@@ -1,1 +1,1 @@
-{{ distinct_evm_eoa_addresses("tron") }}
+{{ distinct_eoa_addresses("tron") }}

--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -20,6 +20,7 @@ with
         select date, chain, issuance from {{ ref("fact_solana_issuance_silver") }}
     ),
     nft_metrics as ({{ get_nft_metrics("solana") }}),
+    p2p_metrics as ({{ get_p2p_metrics("solana") }}),
     {% if not is_incremental() %}
         unrefreshed_data as (
             select
@@ -166,7 +167,11 @@ select
     total_staked_native,
     total_staked_usd,
     issuance,
-    nft_trading_volume
+    nft_trading_volume,
+    p2p_native_transfer_volume,
+    p2p_token_transfer_volume,
+    p2p_stablecoin_transfer_volume,
+    p2p_transfer_volume
 from fundamental_usage
 left join defillama_data on fundamental_usage.date = defillama_data.date
 left join stablecoin_data on fundamental_usage.date = stablecoin_data.date
@@ -177,4 +182,5 @@ left join contract_data on fundamental_usage.date = contract_data.date
 left join staking_data on fundamental_usage.date = staking_data.date
 left join issuance_data on fundamental_usage.date = issuance_data.date
 left join nft_metrics on fundamental_usage.date = nft_metrics.date
+left join p2p_metrics on fundamental_usage.date = p2p_metrics.date
 where fundamental_usage.date < to_date(sysdate())

--- a/models/staging/solana/fact_solana_p2p_native_transfers.sql
+++ b/models/staging/solana/fact_solana_p2p_native_transfers.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="SOLANA",
+    )
+}}
+
+{{ p2p_native_transfers("solana") }}

--- a/models/staging/solana/fact_solana_p2p_token_transfers.sql
+++ b/models/staging/solana/fact_solana_p2p_token_transfers.sql
@@ -1,0 +1,16 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="SOLANA",
+    )
+}}
+
+{{ filter_p2p_token_transfers(
+    "solana", 
+    2000, 
+    blacklist=(
+        "o1Mw5Y3n68o8TakZFuGKLZMGjm72qv4JeoZvGiCLEvK", 
+        "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt",
+        "GiBrdw1tF8nuJxWuhTp83ULEMY9uJkYUHQUBzwfEnw5R"
+    )
+)}}

--- a/models/staging/solana/fact_solana_p2p_token_transfers_silver.sql
+++ b/models/staging/solana/fact_solana_p2p_token_transfers_silver.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="SOLANA",
+    )
+}}
+
+{{ p2p_token_transfers("solana") }}

--- a/models/staging/solana/fact_solana_p2p_transfer_volume.sql
+++ b/models/staging/solana/fact_solana_p2p_transfer_volume.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="SOLANA",
+    )
+}}
+
+{{ p2p_transfer_volume("solana") }}


### PR DESCRIPTION
1. Adding Solana p2p metric tables

Methodology:
1. All signers of transactions are consider a wallet
