### PR TITLE
BCC: MAU and Deduped Stablecoin Volumes

### DIFF
--- a/macros/agg_chain_stablecoin_transfers.sql
+++ b/macros/agg_chain_stablecoin_transfers.sql
@@ -9,6 +9,7 @@
         select
             block_timestamp,
             trunc(block_timestamp, 'day') as date,
+            transaction_hash as tx_hash,
             from_address,
             to_address,
             -- NULL address on TRON is different
@@ -39,6 +40,7 @@
         select
             block_timestamp,
             trunc(block_timestamp, 'day') as date,
+            tx_id as tx_hash,
             tx_from as from_address,
             tx_to as to_address,
             tx_from in (
@@ -77,6 +79,11 @@
         select
             block_timestamp,
             trunc(block_timestamp, 'day') as date,
+            {% if chain in ("celo") %}
+                transaction_hash as tx_hash,
+            {% else %}
+                tx_hash,
+            {% endif %}
             -- Notably, we do NOT use the Mint / Burn events here because the
             -- basic IERC20 interface does not require them to be implemented
             coalesce(
@@ -120,10 +127,10 @@
             )
             -- DO NOT include mint / burn events here - they will be duped
             and event_name in ('Transfer', 'Issue', 'Redeem')
-            {% if chain in ("celo") %}
+        {% if chain in ("celo") %}
             and tx_status = 1
-            {% else %}
+        {% else %}
             and tx_status = 'SUCCESS'
-            {% endif %}
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/macros/metrics/get_mau_metrics.sql
+++ b/macros/metrics/get_mau_metrics.sql
@@ -1,0 +1,17 @@
+{% macro get_mau_metrics(chain) %}
+    {% if chain == "tron" %}
+        select 
+            date_trunc('month', block_timestamp) as date,
+            count(distinct from_address) as mau
+        from tron_allium.raw.transactions 
+        where receipt_status = 1
+        group by date
+    {% else %} 
+        select
+            date_trunc('month', block_timestamp) as date,
+            count(distinct from_address) as mau
+        from {{ chain }}_flipside.core.fact_transactions
+        where status = 'SUCCESS'
+        group by date
+    {% endif %}
+{% endmacro %}

--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -5,7 +5,8 @@
         sum(total_supply) as stablecoin_total_supply,
         sum(txns) as stablecoin_txns,
         sum(dau) as stablecoin_dau,
-        sum(transfer_volume) as stablecoin_transfer_volume
+        sum(transfer_volume) as stablecoin_transfer_volume,
+        sum(deduped_transfer_volume) as deduped_stablecoin_transfer_volume
     from {{ ref("agg_daily_stablecoin_metrics") }}
     where chain = '{{ chain }}'
     group by chain, date

--- a/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics.sql
@@ -5,6 +5,7 @@ select
     txns,
     dau,
     transfer_volume,
+    deduped_transfer_volume,
     chain,
     symbol,
     contract_address,

--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -21,12 +21,14 @@ with
     github_data as ({{ get_github_metrics("arbitrum") }}),
     contract_data as ({{ get_contract_metrics("arbitrum") }}),
     nft_metrics as ({{ get_nft_metrics("arbitrum") }}),
-    p2p_metrics as ({{ get_p2p_metrics("arbitrum") }})
+    p2p_metrics as ({{ get_p2p_metrics("arbitrum") }}),
+    mau_metrics as ({{ get_mau_metrics("arbitrum") }})
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees_native,  -- total gas fees paid on l2 by users(L2 Fees)
     fees,
     l1_data_cost_native,  -- fees paid to l1 by sequencer (L1 Fees)
@@ -54,6 +56,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
@@ -68,4 +71,5 @@ left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -23,13 +23,15 @@ with
         from {{ ref("fact_avalanche_validator_rewards_silver") }}
     ),
     nft_metrics as ({{ get_nft_metrics("avalanche") }}),
-    p2p_metrics as ({{ get_p2p_metrics("avalanche") }})
+    p2p_metrics as ({{ get_p2p_metrics("avalanche") }}),
+    mau_metrics as ({{ get_mau_metrics("avalanche") }}),
 
 select
     coalesce(fundamental_data.date, staking_data.date) as date,
     coalesce(fundamental_data.chain, 'avalanche') as chain,
     txns,
     dau,
+    mau,
     fees_native,
     case when fees is null then fees_native * price else fees end as fees,
     avg_txn_fee,
@@ -55,6 +57,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     total_staked_native,
     total_staked_usd,
     issuance,
@@ -73,4 +76,5 @@ left join contract_data on staking_data.date = contract_data.date
 left join issuance_data on staking_data.date = issuance_data.date
 left join nft_metrics on staking_data.date = nft_metrics.date
 left join p2p_metrics on staking_data.date = p2p_metrics.date
+left join mau_metrics on staking_data.date = mau_metrics.date
 where coalesce(fundamental_data.date, staking_data.date) < to_date(sysdate())

--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -19,13 +19,15 @@ with
         from {{ ref("agg_daily_base_revenue") }}
     ),  -- supply side revenue and fees
     nft_metrics as ({{ get_nft_metrics("base") }}),
-    p2p_metrics as ({{ get_p2p_metrics("base") }})
+    p2p_metrics as ({{ get_p2p_metrics("base") }}),
+    mau_metrics as ({{ get_mau_metrics("base") }})
 
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees_native,  -- total gas fees paid on l2 by users(L2 Fees)
     fees,
     l1_data_cost_native,  -- fees paid to l1 by sequencer (L1 Fees)
@@ -45,6 +47,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
@@ -57,4 +60,5 @@ left join expenses_data on fundamental_data.date = expenses_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/blast/core/ez_blast_metrics.sql
+++ b/models/projects/blast/core/ez_blast_metrics.sql
@@ -20,7 +20,8 @@ with
     expenses_data as (
         select date, chain, l1_data_cost_native, l1_data_cost, revenue_native, revenue
         from {{ ref("agg_daily_blast_revenue") }}
-    )
+    ),
+    mau_metrics as ({{ get_mau_metrics("blast") }})
 select
     coalesce(
         fundamental_data.date,
@@ -32,6 +33,7 @@ select
     'blast' as chain,
     txns,
     dau,
+    mau,
     fees_native, 
     fees,
     l1_data_cost_native,  
@@ -50,10 +52,12 @@ select
     stablecoin_total_supply,
     stablecoin_txns,
     stablecoin_dau,
-    stablecoin_transfer_volume
+    stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume
 from fundamental_data
 left join defillama_data on fundamental_data.date = defillama_data.date
 left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join expenses_data on fundamental_data.date = expenses_data.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/bsc/core/ez_bsc_metrics.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics.sql
@@ -16,12 +16,14 @@ with
     stablecoin_data as ({{ get_stablecoin_metrics("bsc") }}),
     github_data as ({{ get_github_metrics("Binance Smart Chain") }}),
     contract_data as ({{ get_contract_metrics("bsc") }}),
-    nft_metrics as ({{ get_nft_metrics("bsc") }})
+    nft_metrics as ({{ get_nft_metrics("bsc") }}),
+    mau_metrics as ({{ get_mau_metrics("bsc") }})
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees_native,
     fees,
     avg_txn_fee,
@@ -47,6 +49,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     nft_trading_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
@@ -55,4 +58,5 @@ left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/celo/core/ez_celo_metrics.sql
+++ b/models/projects/celo/core/ez_celo_metrics.sql
@@ -16,12 +16,15 @@ with
     ),
     price_data as ({{ get_coingecko_metrics("celo") }}),
     defillama_data as ({{ get_defillama_metrics("celo") }}),
-    github_data as ({{ get_github_metrics("celo") }})
+    github_data as ({{ get_github_metrics("celo") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("celo") }}),
+    mau_metrics as ({{ get_mau_metrics("celo") }})
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees,
     revenue,
     avg_txn_fee,
@@ -33,8 +36,16 @@ select
     weekly_commits_core_ecosystem,
     weekly_commits_sub_ecosystem,
     weekly_developers_core_ecosystem,
-    weekly_developers_sub_ecosystem
+    weekly_developers_sub_ecosystem,
+    stablecoin_total_supply,
+    stablecoin_txns,
+    stablecoin_dau,
+    stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
 left join github_data on fundamental_data.date = github_data.date
+left join stablecoin_data on fundamental_data.date = stablecoin_data.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
+where fundamental_data.date < to_date(sysdate())

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -29,13 +29,15 @@ with
         from {{ ref("fact_ethereum_beacon_chain_queue_entry_active_exit_silver") }}
     ),
     nft_metrics as ({{ get_nft_metrics("ethereum") }}),
-    p2p_metrics as ({{ get_p2p_metrics("ethereum") }})
+    p2p_metrics as ({{ get_p2p_metrics("ethereum") }}),
+    mau_metrics as ({{ get_mau_metrics("ethereum") }})
 
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees_native,
     case when fees is null then fees_native * price else fees end as fees,
     avg_txn_fee,
@@ -65,6 +67,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     censored_blocks,
     semi_censored_blocks,
     non_censored_blocks,
@@ -94,4 +97,5 @@ left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -21,7 +21,8 @@ with
         from {{ ref("agg_daily_optimism_revenue") }}
     ),  -- supply side revenue and fees
     nft_metrics as ({{ get_nft_metrics("optimism") }}),
-    p2p_metrics as ({{ get_p2p_metrics("optimism") }})
+    p2p_metrics as ({{ get_p2p_metrics("optimism") }}),
+    mau_metrics as ({{ get_mau_metrics("optimism") }})
 
 select
     coalesce(
@@ -36,6 +37,7 @@ select
     'optimism' as chain,
     txns,
     dau,
+    mau,
     fees_native,  -- total gas fees paid on l2 by users(L2 Fees)
     fees,
     l1_data_cost_native,  -- fees paid to l1 by sequencer (L1 Fees)
@@ -63,6 +65,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
@@ -77,4 +80,5 @@ left join github_data on fundamental_data.date = github_data.date
 left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -21,13 +21,15 @@ with
         from {{ ref("agg_daily_polygon_revenue") }}
     ),
     nft_metrics as ({{ get_nft_metrics("polygon") }}),
-    p2p_metrics as ({{ get_p2p_metrics("polygon") }})
+    p2p_metrics as ({{ get_p2p_metrics("polygon") }}),
+    mau_metrics as ({{ get_mau_metrics("polygon") }})
 
 select
     fundamental_data.date,
     fundamental_data.chain,
     txns,
     dau,
+    mau,
     fees_native,
     fees,
     avg_txn_fee,
@@ -53,6 +55,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
@@ -67,4 +70,5 @@ left join contract_data on fundamental_data.date = contract_data.date
 left join revenue_data on fundamental_data.date = revenue_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -164,6 +164,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     total_staked_native,
     total_staked_usd,
     issuance,

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -14,7 +14,8 @@ with
     defillama_data as ({{ get_defillama_metrics("tron") }}),
     stablecoin_data as ({{ get_stablecoin_metrics("tron") }}),
     github_data as ({{ get_github_metrics("tron") }}),
-    p2p_metrics as ({{ get_p2p_metrics("tron") }})
+    p2p_metrics as ({{ get_p2p_metrics("tron") }}),
+    mau_metrics as ({{ get_mau_metrics("tron") }})
 select
     coalesce(
         fundamental_data.date,
@@ -26,6 +27,7 @@ select
     'tron' as chain,
     txns,
     dau,
+    mau,
     fees_native,
     fees_native as revenue_native,
     fees,
@@ -46,6 +48,7 @@ select
     stablecoin_txns,
     stablecoin_dau,
     stablecoin_transfer_volume,
+    deduped_stablecoin_transfer_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_stablecoin_transfer_volume,
@@ -56,4 +59,5 @@ left join defillama_data on fundamental_data.date = defillama_data.date
 left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
+left join mau_metrics on fundamental_data.date = mau_metrics.date
 where fundamental_data.date < to_date(sysdate())


### PR DESCRIPTION
MAU
1. `ethereum`, `base`, `polygon`, `tron`, `optimism`, `arbitrum`


Deduped_Stablecoin_transfer_volume
1. All chains that support stablecoins