### PR TITLE
Fixing celo ez_metric table

### DIFF
--- a/models/projects/celo/core/ez_celo_metrics.sql
+++ b/models/projects/celo/core/ez_celo_metrics.sql
@@ -23,7 +23,6 @@ select
     fundamental_data.chain,
     txns,
     dau,
-    mau,
     fees,
     revenue,
     avg_txn_fee,


### PR DESCRIPTION
1. Removing `MAU` from CELO ez_metric table
