### PR TITLE
Add cbETH

### DIFF
--- a/models/data_hubs/fact_daily_app_datahub.sql
+++ b/models/data_hubs/fact_daily_app_datahub.sql
@@ -43,6 +43,7 @@ with
                     ref("fact_meth_staked_eth_count_with_USD_and_change_gold"),
                     ref("fact_binance_staked_eth_count_with_usd_and_change"),
                     ref("fact_sweth_staked_eth_count_with_usd_and_change"),
+                    ref("fact_coinbase_staked_eth_count_with_usd_and_change"),
                     ref("fact_rocketpool_staked_eth_count_with_USD_and_change_gold"),
                     ref("fact_frax_staked_eth_count_with_USD_and_change_gold"),
                     ref("fact_stakewise_staked_eth_count_with_USD_and_change_gold"),

--- a/models/staging/coinbase_staked_eth/fact_coinbase_staked_eth_count.sql
+++ b/models/staging/coinbase_staked_eth/fact_coinbase_staked_eth_count.sql
@@ -1,0 +1,22 @@
+{{ config(materialized="table") }}
+with cb_eth_market_cap as (
+    select date, shifted_token_market_cap from PC_DBT_DB.PROD.fact_coingecko_token_date_adjusted
+    where coingecko_id = 'coinbase-wrapped-staked-eth' and shifted_token_market_cap <> 0
+),
+eth_price as (
+    select date, shifted_token_price_usd from PC_DBT_DB.PROD.fact_coingecko_token_date_adjusted
+    where coingecko_id = 'ethereum'
+),
+eth_supply as (
+    select cb_eth_market_cap.date, shifted_token_market_cap / shifted_token_price_usd as total_supply from 
+    cb_eth_market_cap 
+    JOIN eth_price
+    on cb_eth_market_cap.date = eth_price.date
+),
+eth_supply_forward_filled as (
+    {{ forward_fill('date', 'total_supply', 'eth_supply') }}
+)
+select
+    eth_supply_forward_filled.date as date,
+    coalesce(eth_supply_forward_filled.value, 0) as total_supply
+from eth_supply_forward_filled

--- a/models/staging/coinbase_staked_eth/fact_coinbase_staked_eth_count_with_usd_and_change.sql
+++ b/models/staging/coinbase_staked_eth/fact_coinbase_staked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'ethereum' as chain, 'cbeth' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_coinbase_staked_eth_count') }}
+)


### PR DESCRIPTION
Materialized directly from CoinGecko MC 
Token supply is pre-minted on-chain, so have to hit an endpoint with no historical data - better to just use CoinGecko, which has full historical on same endpoint