### PR TITLE
Restaking/Customer 911

### DIFF
--- a/macros/flatten_cloudmos_json.sql
+++ b/macros/flatten_cloudmos_json.sql
@@ -2,11 +2,12 @@
     with
         max_extraction as (
             select max(extraction_date) as max_date
-            from landing_database.prod_landing.{{ raw_table_name }}
+            from {{ source("PROD_LANDING", raw_table_name ) }}
+            
         ),
         latest_data as (
             select parse_json(source_json) as data
-            from landing_database.prod_landing.{{ raw_table_name }}
+            from {{ source("PROD_LANDING", raw_table_name ) }}
             where extraction_date = (select max_date from max_extraction)
         ),
         flattened_snapshots as (

--- a/macros/upack/utils.sql
+++ b/macros/upack/utils.sql
@@ -17,3 +17,5 @@
 {% macro to_string(v) %} {{ v }}::string {% endmacro %}
 
 {% macro to_timestamp(v) %} {{ v }}::timestamp {% endmacro %}
+
+{% macro to_date(v) %} {{ v }}::date {% endmacro %}

--- a/models/staging/etherfi/__etherfi__source.yml
+++ b/models/staging/etherfi/__etherfi__source.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_etherfi_restaked_eth_count

--- a/models/staging/etherfi/fact_etherfi_restaked_eth_count.sql
+++ b/models/staging/etherfi/fact_etherfi_restaked_eth_count.sql
@@ -1,0 +1,3 @@
+{{ config(materialized="table") }}
+
+{{flatten_cloudmos_json("raw_etherfi_restaked_eth_count", "total_supply")}}

--- a/models/staging/etherfi/fact_etherfi_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/etherfi/fact_etherfi_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'ethereum' as chain, 'etherfi' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_etherfi_restaked_eth_count') }}
+)

--- a/models/staging/mantle/fact_mantle_daa_txns_gas_gas_usd_revenue.sql
+++ b/models/staging/mantle/fact_mantle_daa_txns_gas_gas_usd_revenue.sql
@@ -23,7 +23,13 @@ with
         group by 1
     ),
     -- USING BITDAO instead of MANTLE because it has larger history
-    mantle_prices as ({{ get_coingecko_price_with_latest("bitdao") }}),
+    bitdao_prices as ({{ get_coingecko_price_with_latest("bitdao") }}),
+    mnt_prices as ({{ get_coingecko_price_with_latest("mantle") }}),
+    mantle_prices as (
+        select coalesce(bitdao_prices.date, mnt_prices.date) as date, coalesce(bitdao_prices.price, mnt_prices.price) as price
+        from bitdao_prices
+        full outer join mnt_prices on bitdao_prices.date = mnt_prices.date
+    ),
     eth_prices as ({{ get_coingecko_price_with_latest("ethereum") }}),
     gas_usd_table as (
         select grouped_data.date, gas * price as gas_usd

--- a/models/staging/puffer_finance/__puffer_finance__source.yml
+++ b/models/staging/puffer_finance/__puffer_finance__source.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_puffer_finance_restaked_eth_count

--- a/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count.sql
+++ b/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count.sql
@@ -1,0 +1,3 @@
+{{ config(materialized="table") }}
+
+{{flatten_cloudmos_json("raw_puffer_finance_restaked_eth_count", "total_supply")}}

--- a/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'ethereum' as chain, 'puffer_finance' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_puffer_finance_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/__renzo_protocol__source.yml
+++ b/models/staging/renzo_protocol/__renzo_protocol__source.yml
@@ -1,0 +1,12 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_renzo_protocol_ethereum_restaked_eth
+      - name: raw_renzo_protocol_arbitrum_restaked_eth
+      - name: raw_renzo_protocol_base_restaked_eth
+      - name: raw_renzo_protocol_bsc_restaked_eth
+      - name: raw_renzo_protocol_blast_restaked_eth
+      - name: raw_renzo_protocol_mode_restaked_eth
+      - name: raw_renzo_protocol_linea_restaked_eth

--- a/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count.sql
@@ -1,0 +1,18 @@
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_arbitrum_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'arbitrum' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'arbitrum' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_arbitrum_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count.sql
@@ -1,0 +1,18 @@
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_base_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'base' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'base' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_base_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count.sql
@@ -1,0 +1,18 @@
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_blast_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'blast' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'blast' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_blast_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count.sql
@@ -1,0 +1,18 @@
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_bsc_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'bsc' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'bsc' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_bsc_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count.sql
@@ -1,0 +1,22 @@
+
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_ethereum_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("l1_restaked_eth", to_float, "l1_restaked_eth"),
+                ("bridged_restaked_eth", to_float, "bridged_restaked_eth")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    l1_restaked_eth,
+    bridged_restaked_eth,
+    l1_restaked_eth - bridged_restaked_eth as total_supply,
+    'ethereum' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'ethereum' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_ethereum_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count.sql
@@ -1,0 +1,18 @@
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_linea_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'linea' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'linea' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_linea_restaked_eth_count') }}
+)

--- a/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count.sql
@@ -1,0 +1,19 @@
+
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_renzo_protocol_mode_restaked_eth",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("restaked_eth", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'mode' as chain
+from extracted_raw_data

--- a/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.sql
@@ -1,0 +1,6 @@
+{{ config(materialized="table") }}
+
+select *, 'mode' as chain, 'renzo_protocol' as app, 'DeFi' as category 
+from (
+    {{ calc_staked_eth('fact_renzo_protocol_mode_restaked_eth_count') }}
+)


### PR DESCRIPTION
Restaking:
1. Adding models restaked eth models for `renzo_protocol`, `puffer_finance` and `etherfi`

Customer 911:
1. Fixing mantle model: mnt prices are now a combination of bitdao and mnt 
