### PR TITLE
LRT: Create EZ Metrics Tables

### DIFF
--- a/macros/staking/calc_staked_eth.sql
+++ b/macros/staking/calc_staked_eth.sql
@@ -1,10 +1,10 @@
-{% macro calc_staked_eth(table_name) %}
+{% macro calc_staked_eth(table_name, is_restaking=false) %}
 with
     temp as (
         select
             f.date,
-            f.total_supply as num_staked_eth,
-            f.total_supply * p.shifted_token_price_usd as amount_staked_usd,
+            f.total_supply,
+            f.total_supply * p.shifted_token_price_usd as total_supply_usd,
             p.shifted_token_price_usd
         from {{ ref(table_name) }} f
         join pc_dbt_db.prod.fact_coingecko_token_date_adjusted_gold as p
@@ -14,25 +14,25 @@ with
     )
 select
     t.date,
-    t.num_staked_eth,
-    t.amount_staked_usd,
+    t.total_supply as {% if is_restaking %} num_restaked_eth {% else %} num_staked_eth {% endif %},
+    t.total_supply_usd {% if is_restaking %} amount_restaked_usd {% else %} amount_staked_usd {% endif %},
     case
         when t.date = (select min(date) from {{ ref(table_name) }})
         then 0
-        else t.num_staked_eth - lag(t.num_staked_eth, 1) over (order by t.date)
-    end as num_staked_eth_net_change,  
+        else t.total_supply - lag(t.total_supply, 1) over (order by t.date)
+    end as {% if is_restaking %} num_restaked_eth_net_change {% else %} num_staked_eth_net_change {% endif %},
     case
         when t.date = (select min(date) from {{ ref(table_name) }})
         then 0
         else
-            (t.num_staked_eth - lag(t.num_staked_eth, 1) over (order by t.date)) * (
+            (t.total_supply - lag(t.total_supply, 1) over (order by t.date)) * (
                 (
                     t.shifted_token_price_usd
                     + lag(t.shifted_token_price_usd, 1) over (order by t.date)
                 )
                 / 2
             )
-    end as amount_staked_usd_net_change  
+    end as {% if is_restaking %} amount_restaked_usd_net_change {% else %} amount_staked_usd_net_change {% endif %}  
 from temp t
 order by date desc
 {% endmacro %}

--- a/models/projects/etherfi/ez_etherfi_metrics_by_chain.sql
+++ b/models/projects/etherfi/ez_etherfi_metrics_by_chain.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ETHERFI",
+        database="etherfi",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    restaked_eth_metrics as (
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_etherfi_restaked_eth_count_with_usd_and_change') }}
+    )
+select
+    restaked_eth_metrics.date,
+    'etherfi' as protocol,
+    'DeFi' as category,
+    restaked_eth_metrics.chain,
+    restaked_eth_metrics.num_restaked_eth,
+    restaked_eth_metrics.amount_restaked_usd,
+    restaked_eth_metrics.num_restaked_eth_net_change,
+    restaked_eth_metrics.amount_restaked_usd_net_change
+from restaked_eth_metrics
+where restaked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/puffer_finance/ez_puffer_finance_metrics_by_chain.sql
+++ b/models/projects/puffer_finance/ez_puffer_finance_metrics_by_chain.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="PUFFER_FINANCE",
+        database="puffer_finance",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    restaked_eth_metrics as (
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_puffer_finance_restaked_eth_count_with_usd_and_change') }}
+    )
+select
+    restaked_eth_metrics.date,
+    'puffer_finance' as protocol,
+    'DeFi' as category,
+    restaked_eth_metrics.chain,
+    restaked_eth_metrics.num_restaked_eth,
+    restaked_eth_metrics.amount_restaked_usd,
+    restaked_eth_metrics.num_restaked_eth_net_change,
+    restaked_eth_metrics.amount_restaked_usd_net_change
+from restaked_eth_metrics
+where restaked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/renzo_protocol/ez_renzo_protocol_metrics_by_chain.sql
+++ b/models/projects/renzo_protocol/ez_renzo_protocol_metrics_by_chain.sql
@@ -1,0 +1,86 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="RENZO_PROTOCOL",
+        database="renzo_protocol",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    restaked_eth_metrics_by_chain as (
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change') }}
+        union all
+        select
+            date,
+            chain,
+            num_restaked_eth,
+            amount_restaked_usd,
+            num_restaked_eth_net_change,
+            amount_restaked_usd_net_change
+        from {{ ref('fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change') }}
+    )
+select
+    restaked_eth_metrics_by_chain.date,
+    'renzo_protocol' as protocol,
+    'DeFi' as category,
+    restaked_eth_metrics_by_chain.chain,
+    restaked_eth_metrics_by_chain.num_restaked_eth,
+    restaked_eth_metrics_by_chain.amount_restaked_usd,
+    restaked_eth_metrics_by_chain.num_restaked_eth_net_change,
+    restaked_eth_metrics_by_chain.amount_restaked_usd_net_change 
+from restaked_eth_metrics_by_chain
+where restaked_eth_metrics_by_chain.date < to_date(sysdate())

--- a/models/staging/etherfi/_test_fact_etherfi_staked_eth_count_with_USD_and_change.yml
+++ b/models/staging/etherfi/_test_fact_etherfi_staked_eth_count_with_USD_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_etherfi_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/etherfi/fact_etherfi_restaked_eth_count.sql
+++ b/models/staging/etherfi/fact_etherfi_restaked_eth_count.sql
@@ -1,3 +1,19 @@
 {{ config(materialized="table") }}
-
-{{flatten_cloudmos_json("raw_etherfi_restaked_eth_count", "total_supply")}}
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_etherfi_restaked_eth_count",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("value", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'ethereum' as chain
+from extracted_raw_data

--- a/models/staging/etherfi/fact_etherfi_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/etherfi/fact_etherfi_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'ethereum' as chain, 'etherfi' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_etherfi_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_etherfi_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/puffer_finance/_test_fact_puffer_finance_staked_eth_count_with_USD_and_change.yml
+++ b/models/staging/puffer_finance/_test_fact_puffer_finance_staked_eth_count_with_USD_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_puffer_finance_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count.sql
+++ b/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count.sql
@@ -1,3 +1,19 @@
 {{ config(materialized="table") }}
-
-{{flatten_cloudmos_json("raw_puffer_finance_restaked_eth_count", "total_supply")}}
+with
+extracted_raw_data as (
+    {{
+        unpack_json_array(
+            "raw_puffer_finance_restaked_eth_count",
+            "source_json",
+            column_map=[
+                ("date", to_date, "date"),
+                ("value", to_float, "total_supply")
+            ],
+            is_landing_table=true
+    )}}
+)
+select
+    date,
+    total_supply,
+    'ethereum' as chain
+from extracted_raw_data

--- a/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/puffer_finance/fact_puffer_finance_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'ethereum' as chain, 'puffer_finance' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_puffer_finance_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_puffer_finance_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/_test_fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.yml
+++ b/models/staging/renzo_protocol/_test_fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.yml
@@ -1,0 +1,31 @@
+models:
+  - name: fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change
+    tests:
+      - "dbt_expectations.expect_table_row_count_to_be_between:":
+          min_value: 1
+          max_value: 1000000
+    columns:
+      - name: date
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: num_restaked_eth
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: num_restaked_eth_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: amount_restaked_usd_net_change
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_arbitrum_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'arbitrum' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_arbitrum_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_arbitrum_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_base_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'base' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_base_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_base_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_blast_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'blast' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_blast_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_blast_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_bsc_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'bsc' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_bsc_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_bsc_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_ethereum_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'ethereum' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_ethereum_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_ethereum_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_linea_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'linea' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_linea_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_linea_restaked_eth_count', is_restaking=true) }}
 )

--- a/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.sql
+++ b/models/staging/renzo_protocol/fact_renzo_protocol_mode_restaked_eth_count_with_usd_and_change.sql
@@ -2,5 +2,5 @@
 
 select *, 'mode' as chain, 'renzo_protocol' as app, 'DeFi' as category 
 from (
-    {{ calc_staked_eth('fact_renzo_protocol_mode_restaked_eth_count') }}
+    {{ calc_staked_eth('fact_renzo_protocol_mode_restaked_eth_count', is_restaking=true) }}
 )


### PR DESCRIPTION
1. Creating ez_metric_by_chain tables for Etherfi, Puffer Finance, Renzo Protocol. We are currently tracking the same metrics as liquid staking
