### PR TITLE
Flow Payers -> Authorizers for DAA

### DIFF
--- a/models/staging/flow/fact_flow_daa_txns.sql
+++ b/models/staging/flow/fact_flow_daa_txns.sql
@@ -1,7 +1,7 @@
 {{ config(materialized="view") }}
 select
     date_trunc('day', block_timestamp) as date,
-    count(distinct payer) as daa,
+    count(distinct authorizers) as daa,
     count(distinct tx_id) as txns,
     'flow' as chain
 from flow_flipside.core.fact_transactions


### PR DESCRIPTION
Flow uses a model similar to Solana where the user need not be the fee payer.

Current methodology undercounts dApps by Dapper labs - NBA Topshot, NFL ALL DAY, LiveNation, Joyride - b/c they all use 1 fee payer.

New numbers are in line with most Flow block explorers.