### PR TITLE
Only Run Modified Model Children

### DIFF
--- a/dbt_scripts/show_changed.sh
+++ b/dbt_scripts/show_changed.sh
@@ -1,4 +1,4 @@
-changed_models=$(dbt ls --select state:modified+ --state . --quiet)
+changed_models=$(dbt ls --select state:modified+1 --resource-type model --state . --quiet)
 
 echo "\nCHANGED MODELS:"
 echo $changed_models


### PR DESCRIPTION
## Summary
- Only run first-order children of modified models instead of all downstreams
- Only run models via (`--resource-type model`)