### PR TITLE
Fix Sei all null metrics

### DIFF
--- a/models/projects/sei/core/ez_sei_metrics.sql
+++ b/models/projects/sei/core/ez_sei_metrics.sql
@@ -19,10 +19,10 @@ select
     , avg_block_time
     , avg_tps
     , 'sei' as chain
-    , txns + evm_txns as txns
-    , daa + evm_daa as dau
-    , gas + evm_gas as fees_native
-    , gas_usd + evm_gas_usd as fees
+    , txns + coalesce(evm_txns, 0) as txns
+    , daa + coalesce(evm_daa, 0) as dau
+    , gas + coalesce(evm_gas, 0) as fees_native
+    , gas_usd + coalesce(evm_gas_usd, 0) as fees
     , 0 as revenue
     , txns as wasm_txns
     , daa as wasm_dau


### PR DESCRIPTION
## :pushpin: References

Sei update with EVM chain borked ez sei metrics dau, txns, and fees which is no a summation of both v1 and v2. 

## 🎄 Asset Checklist

- [x] Added to `assets.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [x] `Show Changed Models` in Github matches expectations for what metric value should be
