### PR TITLE
Update Injective Source Name

### DIFF
--- a/models/staging/injective/__injective__sources.yml
+++ b/models/staging/injective/__injective__sources.yml
@@ -9,7 +9,7 @@ sources:
       - name: raw_injective_fees_native_all
       - name: raw_injective_revenue
       - name: raw_injective_mints
-  - name: PC_DBT_DB.PROD
+  - name: PROD
     schema: PROD
     database: PC_DBT_DB
     tables:

--- a/models/staging/injective/fact_injective_fees_native_silver.sql
+++ b/models/staging/injective/fact_injective_fees_native_silver.sql
@@ -1,3 +1,3 @@
 select date, fees_native_all as fees_native, chain
-from {{ source("PC_DBT_DB.PROD", "fact_injective_fees_native_all_silver") }}
+from {{ source("PROD", "fact_injective_fees_native_all_silver") }}
 where coingecko_id = 'injective-protocol'

--- a/models/staging/injective/fact_injective_fees_usd_silver.sql
+++ b/models/staging/injective/fact_injective_fees_usd_silver.sql
@@ -1,18 +1,18 @@
 with
     unique_tokens as (
         select distinct (coingecko_id)
-        from {{ source("PC_DBT_DB.PROD", "fact_injective_fees_native_all_silver") }}
+        from {{ source("PROD", "fact_injective_fees_native_all_silver") }}
     ),
     prices as (
         select date as price_date, shifted_token_price_usd as price, coingecko_id
-        from {{ source("PC_DBT_DB.PROD", "fact_coingecko_token_date_adjusted_gold") }}
+        from {{ source("PROD", "fact_coingecko_token_date_adjusted_gold") }}
         where coingecko_id in (select * from unique_tokens)
         union
         select
             dateadd('day', -1, date) as price_date,
             token_current_price as price,
             token_id as coingecko_id
-        from {{ source("PC_DBT_DB.PROD", "fact_coingecko_token_realtime_data") }}
+        from {{ source("PROD", "fact_coingecko_token_realtime_data") }}
         where token_id in (select * from unique_tokens)
     ),
     collapsed_prices as (
@@ -21,7 +21,7 @@ with
         group by coingecko_id, date
     )
 select f.date as date, sum(p.price * f.fees_native_all) as fees, 'injective' as chain
-from {{ source("PC_DBT_DB.PROD", "fact_injective_fees_native_all_silver") }} f
+from {{ source("PROD", "fact_injective_fees_native_all_silver") }} f
 left join collapsed_prices p on f.date = p.date and f.coingecko_id = p.coingecko_id
 group by f.date
 order by f.date desc


### PR DESCRIPTION
## Summary 
- Aligning this definition with our convention for other `source`s
  - Renaming sources used by injective to not have a `.` so we don't have to add more custom logic via `CustomDagsterDbtTranslator`
- Updated `.yml` file as well as `source` macro callsites

## Test Plan
`dbt compile`
<img width="752" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/4388e952-9c9f-48fa-8ba0-7c7d0434d0bd">

