### PR TITLE
Show Changed Models GH Action: Update to only run on open source contributors

### DIFF
--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -25,22 +25,17 @@ jobs:
         id: check_user
         with:
           script: |
-            const { data: collaborators } = await github.rest.repos.listCollaborators({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              affiliation: 'all'
+            const { data: artemisMembers } = await github.rest.teams.listMembersInOrg({
+              "Artemis-xyz",
+              "All",
             });
 
-            const usersWithPushAccess = collaborators
-              .filter(collaborator => collaborator.permissions.push)
-              .map(user => user.login);
-
-            const hasPushAccess = usersWithPushAccess.includes(context.actor);
-
-            core.setOutput("has_push_access", hasPushAccess);
+            const skipWorkflow = members.some(member => member.login === context.actor);
+            console.log(`User apart of Artemis Org: ${skipWorkflow}. Skip Action if TRUE`);
+            core.setOutput("skip_workflow", skipWorkflow);
   build:
     runs-on: ubuntu-latest
-    if: needs.check-user.outputs.should_run == 'true'
+    if: needs.check-user.outputs.skip_workflow == 'true'
     steps:
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -13,12 +13,38 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:
+  check-user:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out PR
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/github-script@v7
+        retries: 3
+        id: check_user
+        with:
+          script: |
+            const { data: collaborators } = await github.rest.repos.listCollaborators({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              affiliation: 'all'
+            });
+
+            const usersWithPushAccess = collaborators
+              .filter(collaborator => collaborator.permissions.push)
+              .map(user => user.login);
+
+            const hasPushAccess = usersWithPushAccess.includes(context.actor);
+
+            core.setOutput("has_push_access", hasPushAccess);
   build:
     runs-on: ubuntu-latest
+    if: needs.check-user.outputs.should_run == 'true'
     steps:
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Check out PR
         uses: actions/checkout@v3


### PR DESCRIPTION
1. Our Current Setup for when Show Changed Models runs every time a user submits a PR or merges to main. This ends up using an unnecessary about of snowflake credits as members apart of the Artemis Team can test the models in dagster. See [here](https://artemisxyz.slack.com/archives/C064A3GBYJ2/p1717390935288159) for amount of credits used last week.
2. For users who are in the Artemis [All](https://github.com/orgs/Artemis-xyz/teams/all) team do not run the show changed models GH action.
