### PR TITLE
Update Github Action: Show Changed Models

### DIFF
--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/github-script@v7
-        retries: 3
+        max_attempts: 3
+				retry_on: error
+				timeout_seconds: 15
         id: check_user
         with:
           script: |


### PR DESCRIPTION
1. Borked github action: `show changed model` by adding `retries flags`. 
2. Remove this flag and use `max_attempts`
