### PR TITLE
Updating Github Action permissions

### DIFF
--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -34,6 +34,7 @@ jobs:
             console.log(`User apart of Artemis Org: ${skipWorkflow}. Skip Action if TRUE`);
             core.setOutput("skip_workflow", skipWorkflow);
   build:
+    needs: check-user
     runs-on: ubuntu-latest
     if: needs.check-user.outputs.skip_workflow == 'true'
     steps:

--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -8,8 +8,8 @@ env:
   SYSTEM_SNOWFLAKE_USER: ${{ secrets.SYSTEM_SNOWFLAKE_USER }}
   SYSTEM_SNOWFLAKE_PASSWORD: ${{ secrets.SYSTEM_SNOWFLAKE_PASSWORD }}
   SYSTEM_SNOWFLAKE_ROLE: ${{ secrets.SYSTEM_SNOWFLAKE_ROLE }}
-permissions: {}
-concurrency:
+permissions:
+  members: read
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:

--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -10,6 +10,7 @@ env:
   SYSTEM_SNOWFLAKE_ROLE: ${{ secrets.SYSTEM_SNOWFLAKE_ROLE }}
 permissions:
   members: read
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 jobs:


### PR DESCRIPTION
1. Updating Github actions permission to allow a read to [members](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions) -- `/orgs/{org}/teams`