### PR TITLE
Customer 911: Fixing Ethereum and Osmosis

### DIFF
--- a/macros/p2p/filter_p2p_token_transfers.sql
+++ b/macros/p2p/filter_p2p_token_transfers.sql
@@ -105,7 +105,7 @@
                         sum(amount_in_usd) as amount_in_usd
                     from {{ chain }}_flipside.defi.ez_dex_swaps 
                     where (amount_in_usd is not null and amount_out_usd is not null) and
-                        (amount_in_usd <> 0 and amount_out_usd <> 0) and
+                        (amount_in_usd > 0 and amount_out_usd > 0) and
                         abs(
                             ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
                             - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -1,6 +1,8 @@
 -- depends_on {{ ref("ez_ethereum_transactions") }}
 -- depends_on {{ ref('fact_ethereum_block_producers_silver') }}
 -- depends_on {{ ref('fact_ethereum_amount_staked_silver') }}
+-- depends_on {{ ref('fact_ethereum_p2p_transfer_volume') }}
+
 {{
     config(
         materialized="table",

--- a/models/staging/ethereum/fact_ethereum_p2p_transfer_volume.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_transfer_volume.sql
@@ -1,3 +1,8 @@
+-- depends_on {{ ref("fact_ethereum_p2p_native_transfers") }}
+-- depends_on {{ ref("fact_ethereum_p2p_token_transfers") }}
+-- depends_on {{ ref("fact_ethereum_p2p_stablecoin_transfers") }}
+
+
 {{
     config(
         materialized="table",

--- a/models/staging/osmosis/_test_fact_osmosis_gas_gas_usd_fees_revenue.yml
+++ b/models/staging/osmosis/_test_fact_osmosis_gas_gas_usd_fees_revenue.yml
@@ -25,10 +25,6 @@ models:
               datepart: day
               interval: 3
               severity: warn
-      - name: gas
-        tests:
-          - not_null
-          - dbt_expectations.expect_column_to_exist
       - name: gas_usd
         tests:
           - not_null


### PR DESCRIPTION
1. Fixing Osmosis Test to not include native gas
2. Fixing Ethereum_p2p_token_transfers to filter based on positive dex volumes
