### PR TITLE
Fixed current day nulls in Zora + Scroll

### DIFF
--- a/models/staging/scroll/fact_scroll_gas_gas_usd_revenue.sql
+++ b/models/staging/scroll/fact_scroll_gas_gas_usd_revenue.sql
@@ -33,3 +33,4 @@ select
 from gas
 left join prices on gas.date = prices.price_date
 left join expenses on gas.date = expenses.date
+where gas.date < date(sysdate())

--- a/models/staging/zora/fact_zora_gas_gas_usd_revenue.sql
+++ b/models/staging/zora/fact_zora_gas_gas_usd_revenue.sql
@@ -35,3 +35,4 @@ select
 from gas
 left join prices on gas.date = prices.price_date
 left join expenses on gas.date = expenses.date
+where gas.date < date(sysdate())


### PR DESCRIPTION
Prevents nulls from the current day from getting into zora + scroll gold tables.

## :pushpin: References

## 🎄 Asset Checklist

- [x] Added to `assets.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [x] `Show Changed Models` in Github matches expectations for what metric value should be
