### PR TITLE
Set Model Name as Query Tag

### DIFF
--- a/macros/set_query_tag.sql
+++ b/macros/set_query_tag.sql
@@ -1,0 +1,10 @@
+  {% macro set_query_tag() -%}
+  {% set new_query_tag = model.name %} 
+  {% if new_query_tag %}
+    {% set original_query_tag = get_current_query_tag() %}
+    {{ log("Setting query_tag to '" ~ new_query_tag ~ "'. Will reset to '" ~ original_query_tag ~ "' after materialization.") }}
+    {% do run_query("alter session set query_tag = '{}'".format(new_query_tag)) %}
+    {{ return(original_query_tag)}}
+  {% endif %}
+  {{ return(none)}}
+{% endmacro %}


### PR DESCRIPTION
## Summary 
Attribute query runs to the corresponding dbt model
https://docs.getdbt.com/reference/resource-configs/snowflake-configs#query-tags

## Test Plan

```
dbt parse
dbt run --select fact_compound_lending_v2_ethereum
```

```
SELECT
    query_tag,
    database_name
FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY
WHERE
    query_tag = 'fact_compound_v2_lending_ethereum'
```
Old query tags for tests + `CREATE TABLE` statements are all rolled up into `DEV`
<img width="361" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/6aedca74-96a8-4297-89cd-6e14d6bf2c9b">
<img width="362" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/95056f24-3c3c-487a-8cc1-8183ef16440f">

New tags allow us to attribute the query to the specific dbt model + test
<img width="351" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/c9507259-7241-4723-a3be-78a16db82c23">
<img width="344" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/b610bffd-608b-4fd2-bb69-6453f7712416">


