### PR TITLE
Move Stablecoin Transfers to Incremental Materialization

### DIFF
--- a/macros/agg_chain_stablecoin_breakdown.sql
+++ b/macros/agg_chain_stablecoin_breakdown.sql
@@ -1,8 +1,8 @@
 {% macro agg_chain_stablecoin_breakdown(chain, granularity) %}
     with
         transfer_transactions as (
-            {{ agg_chain_stablecoin_transfers(chain) }}
-            and block_timestamp >= (
+            select * from fact_{{ chain }}_stablecoin_transfers
+            where block_timestamp >= (
                 select dateadd({{ granularity }}, -1, max(block_timestamp))
                 {% if chain in ("tron") %} from tron_allium.assets.trc20_token_transfers
                 {% elif chain in ("solana") %} from solana_flipside.core.fact_transfers

--- a/macros/agg_chain_stablecoin_metrics.sql
+++ b/macros/agg_chain_stablecoin_metrics.sql
@@ -5,7 +5,7 @@
 -- 3. The table `{{ chain }}_flipside.core.fact_transactions` exists
 {% macro agg_chain_stablecoin_metrics(chain) %}
     with
-        transfer_transactions as ({{ agg_chain_stablecoin_transfers(chain) }}),
+        transfer_transactions as (select * from fact_{{ chain }}_stablecoin_transfers),
         deduped_flows as (
             select 
                 date,

--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -1,6 +1,8 @@
 {% macro p2p_stablecoin_transfers(chain) %}
 with 
-    stablecoin_transfers as ({{agg_chain_stablecoin_transfers(chain)}}),
+    stablecoin_transfers as (
+         select * from fact_{{ chain }}_stablecoin_transfers
+    ),
     distinct_peer_address as (
         select address
         from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}

--- a/macros/wallets/get_wallet_stablecoin_data.sql
+++ b/macros/wallets/get_wallet_stablecoin_data.sql
@@ -1,6 +1,8 @@
 {% macro get_wallet_stablecoin_metrics(chain) %}
     with
-        stablecoin_transfers as ({{ agg_chain_stablecoin_transfers(chain) }}),
+        stablecoin_transfers as (
+             select * from fact_{{ chain }}_stablecoin_transfers
+        ),
         -- stablecoin data
         generic_stablecoin_data as (
             select

--- a/models/metrics/stablecoins/breakdowns/daily/agg_arbitrum_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_arbitrum_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_arbitrum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_arbitrum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_arbitrum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("arbitrum", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_avalanche_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_avalanche_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_avalanche_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_avalanche_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_avalanche_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("avalanche", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_base_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_base_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_base_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_base_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_base_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("base", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_blast_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_blast_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("blast", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_bsc_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_bsc_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_bsc_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_bsc_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_bsc_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("bsc", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_celo_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_celo_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_celo_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_celo_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_celo_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("celo", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_ethereum_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_ethereum_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_ethereum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_ethereum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("ethereum", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_optimism_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_optimism_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_optimism_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_optimism_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_optimism_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("optimism", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_polygon_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_polygon_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_polygon_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_polygon_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_polygon_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("polygon", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_solana_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_solana_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_solana_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_solana_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("solana", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_tron_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_tron_stablecoin_breakdown_daily.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_tron_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_tron_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("tron", "day") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_arbitrum_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_arbitrum_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_arbitrum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_arbitrum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_arbitrum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("arbitrum", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_avalanche_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_avalanche_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_avalanche_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_avalanche_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_avalanche_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("avalanche", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_base_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_base_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_base_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_base_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_base_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("base", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_blast_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_blast_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("blast", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_bsc_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_bsc_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_bsc_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_bsc_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_bsc_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("bsc", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_celo_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_celo_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_celo_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_celo_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_celo_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("celo", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_ethereum_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_ethereum_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_ethereum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_ethereum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("ethereum", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_optimism_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_optimism_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_optimism_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_optimism_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_optimism_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("optimism", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_polygon_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_polygon_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_polygon_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_polygon_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_polygon_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("polygon", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_solana_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_solana_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_solana_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_solana_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("solana", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_tron_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_tron_stablecoin_breakdown_monthly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_tron_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_tron_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("tron", "month") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_arbitrum_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_arbitrum_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_arbitrum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_arbitrum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_arbitrum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("arbitrum", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_avalanche_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_avalanche_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_avalanche_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_avalanche_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_avalanche_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("avalanche", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_base_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_base_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_base_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_base_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_base_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("base", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_blast_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_blast_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("blast", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_bsc_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_bsc_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_bsc_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_bsc_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_bsc_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("bsc", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_celo_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_celo_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_celo_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_celo_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_celo_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("celo", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_ethereum_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_ethereum_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_ethereum_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_ethereum_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("ethereum", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_optimism_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_optimism_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_optimism_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_optimism_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_optimism_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("optimism", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_polygon_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_polygon_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_polygon_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_polygon_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_polygon_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("polygon", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_solana_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_solana_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_solana_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_solana_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("solana", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_tron_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_tron_stablecoin_breakdown_weekly.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_tron_address_balances_by_token') }}
+-- depends_on: {{ ref('fact_tron_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
 {{ agg_chain_stablecoin_breakdown("tron", "week") }}

--- a/models/metrics/stablecoins/metrics/agg_arbitrum_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_arbitrum_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_arbitrum_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_arbitrum_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("arbitrum") }}

--- a/models/metrics/stablecoins/metrics/agg_avalanche_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_avalanche_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_avalanche_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_avalanche_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("avalanche") }}

--- a/models/metrics/stablecoins/metrics/agg_base_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_base_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_base_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_base_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("base") }}

--- a/models/metrics/stablecoins/metrics/agg_blast_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_blast_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("blast") }}

--- a/models/metrics/stablecoins/metrics/agg_bsc_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_bsc_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_bsc_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_bsc_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("bsc") }}

--- a/models/metrics/stablecoins/metrics/agg_celo_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_celo_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_celo_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_celo_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("celo") }}

--- a/models/metrics/stablecoins/metrics/agg_ethereum_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_ethereum_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_ethereum_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("ethereum") }}

--- a/models/metrics/stablecoins/metrics/agg_optimism_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_optimism_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_optimism_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_optimism_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("optimism") }}

--- a/models/metrics/stablecoins/metrics/agg_polygon_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_polygon_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_polygon_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_polygon_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("polygon") }}

--- a/models/metrics/stablecoins/metrics/agg_solana_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_solana_stablecoin_metrics.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_solana_stablecoin_premint_addresses') }}
+-- depends_on: {{ ref('fact_solana_stablecoin_transfers') }}
 {{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG") }}
 {{ agg_chain_stablecoin_metrics("solana") }}

--- a/models/metrics/stablecoins/metrics/agg_tron_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_tron_stablecoin_metrics.sql
@@ -1,2 +1,3 @@
 -- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_tron_stablecoin_transfers') }}
 {{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("tron") }}

--- a/models/metrics/stablecoins/transfers/fact_arbitrum_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_arbitrum_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_arbitrum_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("arbitrum") }}

--- a/models/metrics/stablecoins/transfers/fact_avalanche_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_avalanche_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_avalanche_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("avalanche") }}

--- a/models/metrics/stablecoins/transfers/fact_base_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_base_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_base_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("base") }}

--- a/models/metrics/stablecoins/transfers/fact_blast_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_blast_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("blast") }}

--- a/models/metrics/stablecoins/transfers/fact_bsc_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_bsc_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_bsc_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("bsc") }}

--- a/models/metrics/stablecoins/transfers/fact_celo_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_celo_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_celo_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("celo") }}

--- a/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("ethereum") }}

--- a/models/metrics/stablecoins/transfers/fact_optimism_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_optimism_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_optimism_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("optimism") }}

--- a/models/metrics/stablecoins/transfers/fact_polygon_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_polygon_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_polygon_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("polygon") }}

--- a/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("solana") }}

--- a/models/metrics/stablecoins/transfers/fact_tron_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_tron_stablecoin_transfers.sql
@@ -1,0 +1,8 @@
+-- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
+{{ config(
+    materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("tron") }}


### PR DESCRIPTION
- Moved `agg_chain_stablecoin_transfers` to incremental tables for each chain. Should make it easier for @SebMelendez01 to pull EOA / contract transfers. 
- Notably, did not move these to flat databases in Snowflake. This was a 59 file change and I fear it would be a 100 file change to manage that migration - Nirmal will come back to this when necessary :) 