### PR TITLE
Flipside Pricing: porting over to pricing

### DIFF
--- a/macros/decentralized_exchanges/fact_curve_trading_vol_trading_fees_trading_revenue.sql
+++ b/macros/decentralized_exchanges/fact_curve_trading_vol_trading_fees_trading_revenue.sql
@@ -98,7 +98,7 @@
                     then 1.0
                     else avg(price)
                 end as price
-            from {{ _chain }}_flipside.price.ez_hourly_token_prices
+            from {{ _chain }}_flipside.price.ez_prices_hourly
 
             group by date, token_address, decimals
         ),

--- a/macros/decentralized_exchanges/fact_curve_tvl.sql
+++ b/macros/decentralized_exchanges/fact_curve_tvl.sql
@@ -115,7 +115,7 @@
                     then 1.0
                     else avg(price)
                 end as price
-            from {{ _chain }}_flipside.price.ez_hourly_token_prices
+            from {{ _chain }}_flipside.price.ez_prices_hourly
             group by date, token_address, decimals
             {% if _chain == "ethereum" %}
                 union all

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_trading_vol_and_fees.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_trading_vol_and_fees.sql
@@ -100,10 +100,10 @@
                 token0_out_amount_usd + token1_out_amount_usd as total_out
             from swaps t1
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t2
+                {{ chain }}_flipside.price.ez_prices_hourly t2
                 on (lower(t1.token0) = lower(t2.token_address) and t2.hour = t1.hour)
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t3
+                {{ chain }}_flipside.price.ez_prices_hourly t3
                 on (lower(t1.token1) = lower(t3.token_address) and t3.hour = t1.hour)
             where token1_decimals > 0 and token0_decimals > 0
         ),

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_tvl.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_tvl.sql
@@ -137,7 +137,7 @@
         ),
         average_token_price_per_day as (
             select trunc(hour, 'day') as date, token_address, avg(price) as price
-            from {{ chain }}_flipside.price.ez_hourly_token_prices
+            from {{ chain }}_flipside.price.ez_prices_hourly
             group by date, token_address
         ),
         with_price as (

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_tvl_by_pool.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v2_fork_tvl_by_pool.sql
@@ -137,7 +137,7 @@
         ),
         average_token_price_per_day as (
             select trunc(hour, 'day') as date, token_address, symbol, avg(price) as price
-            from {{ chain }}_flipside.price.ez_hourly_token_prices
+            from {{ chain }}_flipside.price.ez_prices_hourly
             group by date, token_address, symbol
         ),
         with_price as (

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_trading_vol_and_fees.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_trading_vol_and_fees.sql
@@ -70,10 +70,10 @@
             from swaps t1
 
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t2
+                {{ chain }}_flipside.price.ez_prices_hourly t2
                 on (lower(t1.token0) = lower(t2.token_address) and t2.hour = t1.hour)
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t3
+                {{ chain }}_flipside.price.ez_prices_hourly t3
                 on (lower(t1.token1) = lower(t3.token_address) and t3.hour = t1.hour)
             where token1_decimals != 0 and token0_decimals != 0
         ),

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_tvl.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_tvl.sql
@@ -136,7 +136,7 @@
         ),
         average_token_price_per_day as (
             select trunc(hour, 'day') as date, token_address, avg(price) as price
-            from {{ chain }}_flipside.price.ez_hourly_token_prices
+            from {{ chain }}_flipside.price.ez_prices_hourly
             group by date, token_address
         ),
         with_price as (

--- a/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_tvl_by_pool.sql
+++ b/macros/decentralized_exchanges/fact_daily_uniswap_v3_fork_tvl_by_pool.sql
@@ -136,7 +136,7 @@
         ),
         average_token_price_per_day as (
             select trunc(hour, 'day') as date, token_address, symbol, avg(price) as price
-            from {{ chain }}_flipside.price.ez_hourly_token_prices
+            from {{ chain }}_flipside.price.ez_prices_hourly
             group by date, token_address, symbol
         ),
         with_price as (

--- a/macros/decentralized_exchanges/fact_uniswap_v2_fork_dex_swaps.sql
+++ b/macros/decentralized_exchanges/fact_uniswap_v2_fork_dex_swaps.sql
@@ -108,10 +108,10 @@
                 token0_out_amount_usd + token1_out_amount_usd as total_out
             from swaps t1
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t2
+                {{ chain }}_flipside.price.ez_prices_hourly t2
                 on (lower(t1.token0) = lower(t2.token_address) and t2.hour = t1.hour)
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t3
+                {{ chain }}_flipside.price.ez_prices_hourly t3
                 on (lower(t1.token1) = lower(t3.token_address) and t3.hour = t1.hour)
             where token1_decimals > 0 and token0_decimals > 0
         ),

--- a/macros/decentralized_exchanges/fact_uniswap_v3_fork_dex_swaps.sql
+++ b/macros/decentralized_exchanges/fact_uniswap_v3_fork_dex_swaps.sql
@@ -78,10 +78,10 @@
             from swaps t1
 
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t2
+                {{ chain }}_flipside.price.ez_prices_hourly t2
                 on (lower(t1.token0) = lower(t2.token_address) and t2.hour = t1.hour)
             left join
-                {{ chain }}_flipside.price.ez_hourly_token_prices t3
+                {{ chain }}_flipside.price.ez_prices_hourly t3
                 on (lower(t1.token1) = lower(t3.token_address) and t3.hour = t1.hour)
             where token1_decimals != 0 and token0_decimals != 0
         ),

--- a/models/staging/across/fact_across_flows.sql
+++ b/models/staging/across/fact_across_flows.sql
@@ -43,23 +43,23 @@ with
 
     prices as (
         select *
-        from ethereum_flipside.price.ez_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where token_address in (select token_address from distinct_tokens where chain = 'ethereum')
         union
         select *
-        from optimism_flipside.price.ez_hourly_token_prices
+        from optimism_flipside.price.ez_prices_hourly
         where token_address in (select token_address from distinct_tokens where chain = 'optimism')
         union
         select *
-        from arbitrum_flipside.price.ez_hourly_token_prices
+        from arbitrum_flipside.price.ez_prices_hourly
         where token_address in (select token_address from distinct_tokens where chain = 'arbitrum')
         union
         select *
-        from polygon_flipside.price.ez_hourly_token_prices
+        from polygon_flipside.price.ez_prices_hourly
         where token_address in (select token_address from distinct_tokens where chain = 'polygon')
         union
         select *
-        from base_flipside.price.ez_hourly_token_prices
+        from base_flipside.price.ez_prices_hourly
         where token_address in (select token_address from distinct_tokens where chain = 'base')
     ),
     dim_tokens as (
@@ -132,7 +132,7 @@ with
 
     zksync_linea_prices as (
         select hour, token_address, decimals, avg(price) as price
-        from ethereum_flipside.price.ez_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         inner join dim_tokens on lower(token_address) = lower(address)
         group by 1, 2, 3
     ),

--- a/models/staging/arbitrum_one_bridge/fact_arbitrum_one_bridge_flows.sql
+++ b/models/staging/arbitrum_one_bridge/fact_arbitrum_one_bridge_flows.sql
@@ -8,11 +8,11 @@ with
 
     prices as (
         select *
-        from ethereum_flipside.price.ez_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where token_address in (select * from distinct_tokens)
         union
         select *
-        from arbitrum_flipside.price.ez_hourly_token_prices
+        from arbitrum_flipside.price.ez_prices_hourly
         where token_address in (select * from distinct_tokens)
     ),
 

--- a/models/staging/avalanche_bridge/fact_avalanche_bridge_flows.sql
+++ b/models/staging/avalanche_bridge/fact_avalanche_bridge_flows.sql
@@ -6,7 +6,7 @@ with
 
     prices as (
         select *
-        from avalanche_flipside.price.ez_hourly_token_prices
+        from avalanche_flipside.price.ez_prices_hourly
         where token_address in (select * from distinct_tokens)
     ),
 

--- a/models/staging/base_bridge/fact_base_bridge_flows.sql
+++ b/models/staging/base_bridge/fact_base_bridge_flows.sql
@@ -14,7 +14,7 @@ with
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_base_bridge_transfers") }} t
         left join
-            ethereum_flipside.price.ez_hourly_token_prices p
+            ethereum_flipside.price.ez_prices_hourly p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token

--- a/models/staging/optimism_bridge/fact_optimism_bridge_flows.sql
+++ b/models/staging/optimism_bridge/fact_optimism_bridge_flows.sql
@@ -14,7 +14,7 @@ with
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_optimism_bridge_transfers") }} t
         left join
-            ethereum_flipside.price.ez_hourly_token_prices p
+            ethereum_flipside.price.ez_prices_hourly p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token

--- a/models/staging/polygon_pos_bridge/fact_polygon_pos_bridge_flows.sql
+++ b/models/staging/polygon_pos_bridge/fact_polygon_pos_bridge_flows.sql
@@ -16,7 +16,7 @@ with
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_polygon_pos_bridge_transfers") }} t
         left join
-            ethereum_flipside.price.ez_hourly_token_prices p
+            ethereum_flipside.price.ez_prices_hourly p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token

--- a/models/staging/rainbow_bridge/fact_rainbow_bridge_transfers.sql
+++ b/models/staging/rainbow_bridge/fact_rainbow_bridge_transfers.sql
@@ -229,7 +229,7 @@ near_ethereum_token_transfers as (
         coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
     from ethereum_near_raw_transfers t
     left join ethereum_to_near_recipient r  on t.tx_hash = r.tx_hash
-    left join ethereum_flipside.price.ez_hourly_token_prices p
+    left join ethereum_flipside.price.ez_prices_hourly p
         on date_trunc('hour', t.block_timestamp) = p.hour
         and lower(t.token_address) = lower(p.token_address)
 )

--- a/models/staging/starknet_bridge/fact_starknet_bridge_flows.sql
+++ b/models/staging/starknet_bridge/fact_starknet_bridge_flows.sql
@@ -14,7 +14,7 @@ with
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_starknet_bridge_transfers") }} t
         left join
-            ethereum_flipside.price.ez_hourly_token_prices p
+            ethereum_flipside.price.ez_prices_hourly p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token

--- a/models/staging/synapse/fact_synapse_flows.sql
+++ b/models/staging/synapse/fact_synapse_flows.sql
@@ -6,25 +6,25 @@ with
         from
             (
                 select *
-                from ethereum_flipside.price.ez_hourly_token_prices
+                from ethereum_flipside.price.ez_prices_hourly
                 union
                 select *
-                from arbitrum_flipside.price.ez_hourly_token_prices
+                from arbitrum_flipside.price.ez_prices_hourly
                 union
                 select *
-                from optimism_flipside.price.ez_hourly_token_prices
+                from optimism_flipside.price.ez_prices_hourly
                 union
                 select *
-                from avalanche_flipside.price.ez_hourly_token_prices
+                from avalanche_flipside.price.ez_prices_hourly
                 union
                 select *
-                from base_flipside.price.ez_hourly_token_prices
+                from base_flipside.price.ez_prices_hourly
                 union
                 select *
-                from polygon_flipside.price.ez_hourly_token_prices
+                from polygon_flipside.price.ez_prices_hourly
                 union
                 select *
-                from bsc_flipside.price.ez_hourly_token_prices
+                from bsc_flipside.price.ez_prices_hourly
             )
         group by 1, 2, 3
     ),

--- a/models/staging/wormhole/fact_wormhole_transfers.sql
+++ b/models/staging/wormhole/fact_wormhole_transfers.sql
@@ -33,7 +33,7 @@ with
 
     prices as (
         select hour, token_address, decimals, price
-        from ethereum_flipside.price.ez_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
     ),
     decoded_transfers as (
         select

--- a/models/staging/zksync_era_bridge/fact_zksync_era_bridge_flows.sql
+++ b/models/staging/zksync_era_bridge/fact_zksync_era_bridge_flows.sql
@@ -13,7 +13,7 @@ with
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_zksync_era_bridge_transfers") }} t
         left join
-            ethereum_flipside.price.ez_hourly_token_prices p
+            ethereum_flipside.price.ez_prices_hourly p
             on date_trunc('hour', t.block_timestamp) = p.hour
             and t.token_address = p.token_address
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token


### PR DESCRIPTION
1. Flipside pricing changed their table name. We are porting over to the new pricing table. The schema is the same.
