### PR TITLE
Flipside Table Update: `ez_native_transfers`

### DIFF
--- a/macros/wallets/get_wallet_cex_amount_funded.sql
+++ b/macros/wallets/get_wallet_cex_amount_funded.sql
@@ -97,7 +97,7 @@
         coalesce(
             sum(case when project_name like 'bilaxy' then amount_usd end), 0
         ) as bilaxy_transfer_amt
-    from {{ chain }}_flipside.core.ez_eth_transfers et
+    from {{ chain }}_flipside.core.ez_native_transfers et
     inner join
         {{ chain }}_flipside.core.dim_labels dl on dl.address = et.origin_from_address
     where label_type like 'cex'

--- a/models/staging/arbitrum_one_bridge/fact_arbitrum_one_bridge_transfers.sql
+++ b/models/staging/arbitrum_one_bridge/fact_arbitrum_one_bridge_transfers.sql
@@ -18,7 +18,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'ethereum' as source_chain,
             'arbitrum' as destination_chain
-        from ethereum_flipside.core.ez_eth_transfers
+        from ethereum_flipside.core.ez_native_transfers
         where
             eth_to_address = lower('0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a')
             {% if is_incremental() %}

--- a/models/staging/base_bridge/fact_base_bridge_transfers.sql
+++ b/models/staging/base_bridge/fact_base_bridge_transfers.sql
@@ -49,7 +49,7 @@ with
                     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
                     'ethereum' as source_chain,
                     'base' as destination_chain
-                from ethereum_flipside.core.ez_eth_transfers
+                from ethereum_flipside.core.ez_native_transfers
                 where
                     eth_to_address = lower('0x49048044d57e1c92a77f79988d21fa8faf74e97e')
                     and origin_to_address
@@ -112,7 +112,7 @@ with
                     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
                     'ethereum' as source_chain,
                     'base' as destination_chain
-                from ethereum_flipside.core.ez_eth_transfers
+                from ethereum_flipside.core.ez_native_transfers
                 where
                     origin_from_address
                     = lower('0x49048044d57e1c92a77f79988d21fa8faf74e97e')

--- a/models/staging/zksync_era_bridge/fact_zksync_era_bridge_transfers.sql
+++ b/models/staging/zksync_era_bridge/fact_zksync_era_bridge_transfers.sql
@@ -19,7 +19,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'ethereum' as source_chain,
             'zksync' as destination_chain
-        from ethereum_flipside.core.ez_eth_transfers
+        from ethereum_flipside.core.ez_native_transfers
         where
             eth_to_address = lower('0x32400084C286CF3E17e7B677ea9583e60a000324')
             {% if is_incremental() %}


### PR DESCRIPTION
1. Flipside changed table name from `ez_eth_transfers` to `ez_native_transfers`
