### PR TITLE
C911: Fixing LST Staleness

### DIFF
--- a/models/staging/frax/fact_frax_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/frax/fact_frax_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="FRAX", materialized="table") }}
 with
-    prices as ({{get_coingecko_price_with_latest("ethereum")}})
+    prices as ({{get_coingecko_price_with_latest("ethereum")}}),
     temp as (
         select
             f.date,

--- a/models/staging/frax/fact_frax_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/frax/fact_frax_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="FRAX", materialized="table") }}
 with
-    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
+    prices as ({{get_coingecko_price_with_latest("ethereum")}})
     temp as (
         select
             f.date,

--- a/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="LIDO", materialized="table") }}
 with
-    prices as ({{get_coingecko_price_with_latest("ethereum")}})
+    prices as ({{get_coingecko_price_with_latest("ethereum")}}),
     temp as (
         select
             f.date,

--- a/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
@@ -1,14 +1,14 @@
 {{ config(snowflake_warehouse="LIDO", materialized="table") }}
 with
+    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
     temp as (
         select
             f.date,
             f.value as num_staked_eth,
-            f.value * p.shifted_token_price_usd as amount_staked_usd,
-            p.shifted_token_price_usd
+            f.value * price as amount_staked_usd,
+            price
         from {{ ref("fact_lido_staked_eth_count") }} f
-        join pc_dbt_db.prod.fact_coingecko_token_date_adjusted_gold p on f.date = p.date
-        where p.coingecko_id = 'ethereum'
+        left join prices on f.date = prices.date
         order by date desc
     )
 select
@@ -28,8 +28,8 @@ select
         else
             (t.num_staked_eth - lag(t.num_staked_eth, 1) over (order by t.date)) * (
                 (
-                    t.shifted_token_price_usd
-                    + lag(t.shifted_token_price_usd, 1) over (order by t.date)
+                    t.price
+                    + lag(t.price, 1) over (order by t.date)
                 )
                 / 2
             )

--- a/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/lido/fact_lido_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="LIDO", materialized="table") }}
 with
-    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
+    prices as ({{get_coingecko_price_with_latest("ethereum")}})
     temp as (
         select
             f.date,

--- a/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="MANTLE", materialized="table") }}
 with
-    prices as ({{get_coingecko_price_with_latest("ethereum")}})
+    prices as ({{get_coingecko_price_with_latest("ethereum")}}),
     temp as (
         select
             f.date,

--- a/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="MANTLE", materialized="table") }}
 with
-    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
+    prices as ({{get_coingecko_price_with_latest("ethereum")}})
     temp as (
         select
             f.date,

--- a/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/mantle/fact_meth_staked_eth_count_with_USD_and_change.sql
@@ -1,14 +1,14 @@
 {{ config(snowflake_warehouse="MANTLE", materialized="table") }}
 with
+    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
     temp as (
         select
             f.date,
             f.value as num_staked_eth,
-            f.value * p.shifted_token_price_usd as amount_staked_usd,
-            p.shifted_token_price_usd
+            f.value * price as amount_staked_usd,
+            price
         from {{ ref("fact_meth_staked_eth_count") }} f
-        join pc_dbt_db.prod.fact_coingecko_token_date_adjusted_gold p on f.date = p.date
-        where p.coingecko_id = 'ethereum'
+        left join prices on f.date = prices.date
         order by date desc
     )
 select
@@ -26,8 +26,8 @@ select
         else
             (t.num_staked_eth - lag(t.num_staked_eth, 1) over (order by t.date)) * (
                 (
-                    t.shifted_token_price_usd
-                    + lag(t.shifted_token_price_usd, 1) over (order by t.date)
+                    t.price
+                    + lag(t.price, 1) over (order by t.date)
                 )
                 / 2
             )

--- a/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
@@ -1,14 +1,14 @@
 {{ config(snowflake_warehouse="ROCKETPOOL", materialized="table") }}
 with
+    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
     temp as (
         select
             f.date,
             f.value * 32 as num_staked_eth,
-            f.value * 32 * p.shifted_token_price_usd as amount_staked_usd,
-            p.shifted_token_price_usd
+            f.value * 32 * price as amount_staked_usd,
+            price
         from {{ ref("fact_rocketpool_staked_eth_count") }} f
-        join pc_dbt_db.prod.fact_coingecko_token_date_adjusted_gold p on f.date = p.date
-        where p.coingecko_id = 'ethereum'
+        left join prices on f.date = prices.date
         order by date desc
     )
 select
@@ -28,8 +28,8 @@ select
         else
             (t.num_staked_eth - lag(t.num_staked_eth, 1) over (order by t.date)) * (
                 (
-                    t.shifted_token_price_usd
-                    + lag(t.shifted_token_price_usd, 1) over (order by t.date)
+                    t.price
+                    + lag(t.price, 1) over (order by t.date)
                 )
                 / 2
             )

--- a/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="ROCKETPOOL", materialized="table") }}
 with
-    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
+    prices as ({{get_coingecko_price_with_latest("ethereum")}})
     temp as (
         select
             f.date,

--- a/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/rocketpool/fact_rocketpool_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="ROCKETPOOL", materialized="table") }}
 with
-    prices as ({{get_coingecko_price_with_latest("ethereum")}})
+    prices as ({{get_coingecko_price_with_latest("ethereum")}}),
     temp as (
         select
             f.date,

--- a/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
@@ -1,16 +1,16 @@
 {{ config(snowflake_warehouse="STAKEWISE", materialized="table") }}
 with
+    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
     temp as (
         select
             f.date,
             f.seth2_value as seth2_num_staked_eth,
             f.reth2_value as reth2_num_staked_eth,
-            f.seth2_value * p.shifted_token_price_usd as seth2_amount_staked_usd,
-            f.reth2_value * p.shifted_token_price_usd as reth2_amount_staked_usd,
-            p.shifted_token_price_usd
+            f.seth2_value * price as seth2_amount_staked_usd,
+            f.reth2_value * price as reth2_amount_staked_usd,
+            price
         from {{ ref("fact_stakewise_staked_eth_count") }} f
-        join pc_dbt_db.prod.fact_coingecko_token_date_adjusted_gold p on f.date = p.date
-        where p.coingecko_id = 'ethereum'
+        left join prices on f.date = prices.date
         order by date desc
     ),
     combined as (
@@ -22,7 +22,7 @@ with
             t.reth2_amount_staked_usd,
             t.seth2_num_staked_eth + t.reth2_num_staked_eth as num_staked_eth,
             t.seth2_amount_staked_usd + t.reth2_amount_staked_usd as amount_staked_usd,
-            t.shifted_token_price_usd
+            t.price
         from temp t
         order by date desc
     )
@@ -44,8 +44,8 @@ select
         else
             (c.num_staked_eth - lag(c.num_staked_eth, 1) over (order by c.date)) * (
                 (
-                    c.shifted_token_price_usd
-                    + lag(c.shifted_token_price_usd, 1) over (order by c.date)
+                    c.price
+                    + lag(c.price, 1) over (order by c.date)
                 )
                 / 2
             )

--- a/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="STAKEWISE", materialized="table") }}
 with
-    prices as ({{get_coingecko_price_with_latest("ethereum")}})
+    prices as ({{get_coingecko_price_with_latest("ethereum")}}),
     temp as (
         select
             f.date,

--- a/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
+++ b/models/staging/stakewise/fact_stakewise_staked_eth_count_with_USD_and_change.sql
@@ -1,6 +1,6 @@
 {{ config(snowflake_warehouse="STAKEWISE", materialized="table") }}
 with
-    prices as ({{ get_coingecko_price_for_trending("ethereum") }}),
+    prices as ({{get_coingecko_price_with_latest("ethereum")}})
     temp as (
         select
             f.date,


### PR DESCRIPTION
1. LST Data is usually stale. The issue was coming from an inner joining on the pricing table that does not have complete data for the next day. It is important to use the following macro to have the most up to date pricing data `get_coingecko_price_with_latest`