### PR TITLE
Fix Ethereum Datahub

### DIFF
--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -8,6 +8,5 @@
         sum(transfer_volume) as stablecoin_transfer_volume,
         sum(deduped_transfer_volume) as deduped_stablecoin_transfer_volume
     from {{ ref("agg_" ~ chain ~ "_stablecoin_metrics") }}
-    where chain = '{{ chain }}'
     group by chain, date
 {% endmacro %}

--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -7,7 +7,7 @@
         sum(dau) as stablecoin_dau,
         sum(transfer_volume) as stablecoin_transfer_volume,
         sum(deduped_transfer_volume) as deduped_stablecoin_transfer_volume
-    from {{ ref("agg_daily_stablecoin_metrics") }}
+    from {{ ref("agg_" ~ chain ~ "_stablecoin_metrics") }}
     where chain = '{{ chain }}'
     group by chain, date
 {% endmacro %}

--- a/models/data_hubs/fact_daily_chain_datahub.sql
+++ b/models/data_hubs/fact_daily_chain_datahub.sql
@@ -74,6 +74,7 @@ with
                     ref("fact_flow_fees_revs_gold"),
                     ref("fact_mantle_daa_txns_gas_gas_usd_revenue_gold"),
                     ref("ez_sei_metrics"),
+                    ref("ez_ethereum_metrics"),
                     ref("fact_stride_daa_gas_usd_txns_gold"),
                     ref("fact_zcash_gas_gas_usd_txns_gold"),
                     ref("fact_parallel_finance_daa_gas_gas_usd_txns_gold"),

--- a/models/metrics/revenue/agg_daily_ethereum_revenue.sql
+++ b/models/metrics/revenue/agg_daily_ethereum_revenue.sql
@@ -3,7 +3,7 @@
 with
     prices as (
         select date_trunc('day', hour) as price_date, avg(price) as price
-        from ethereum_flipside.price.fact_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
         group by 1
     ),

--- a/models/metrics/revenue/agg_daily_gnosis_revenue.sql
+++ b/models/metrics/revenue/agg_daily_gnosis_revenue.sql
@@ -2,7 +2,7 @@
 with
     prices as (
         select date_trunc('day', hour) as price_date, avg(price) as price
-        from ethereum_flipside.price.fact_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where token_address = '0x6b175474e89094c44da98b954eedeac495271d0f'
         group by 1
     ),

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -54,6 +54,8 @@ select
     new_users,
     low_sleep_users,
     high_sleep_users,
+    sybil_users,
+    non_sybil_users,
     dau_over_100,
     price,
     market_cap,

--- a/models/staging/gnosis/fact_gnosis_daa_txns_gas_gas_usd.sql
+++ b/models/staging/gnosis/fact_gnosis_daa_txns_gas_gas_usd.sql
@@ -6,7 +6,7 @@ with
     ),
     prices as (
         select date_trunc('day', hour) as price_date, avg(price) as price
-        from ethereum_flipside.price.fact_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where
             token_address = '0x6b175474e89094c44da98b954eedeac495271d0f'
             and hour >= (select min(date) from min_date)

--- a/models/staging/zksync/fact_zksync_revenue.sql
+++ b/models/staging/zksync/fact_zksync_revenue.sql
@@ -7,7 +7,7 @@ with
     ),
     prices as (
         select date_trunc('day', hour) as price_date, avg(price) as price
-        from ethereum_flipside.price.fact_hourly_token_prices
+        from ethereum_flipside.price.ez_prices_hourly
         where
             token_address = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
             and hour >= dateadd(day, -5, (select min(date) from gas))


### PR DESCRIPTION
## :pushpin: References

Needed to add ez_ethereum_metrics to the datahub to prevent datahub data chain level from being borked. 

Also migrated to new flipside easy pricing data. 

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [x] `Show Changed Models` in Github matches expectations for what metric value should be
