### PR TITLE
Add References into macros for rolling wau + mau

### DIFF
--- a/macros/rolling_active_addresses.sql
+++ b/macros/rolling_active_addresses.sql
@@ -4,7 +4,7 @@
             distinct_dates as (
                 select distinct 
                     raw_date
-                from {{ chain }}.prod_raw.ez_transactions
+                from {{ ref("ez_" ~ chain ~ "_transactions") }}
                 where succeeded = 'TRUE'
                 {% if is_incremental() %}
                     and raw_date > (select dateadd('day', -1, max(date)) from {{ this }})
@@ -14,14 +14,14 @@
                 select distinct 
                     raw_date,
                     value as from_address 
-                from {{ chain }}.prod_raw.ez_transactions, lateral flatten(input => signers)
+                from {{ ref("ez_" ~ chain ~ "_transactions") }}, lateral flatten(input => signers)
                 where succeeded = 'TRUE'
             ),
     {% elif chain == 'sui' %}
         distinct_dates as (
             select distinct
                 raw_date
-            from {{ chain }}.prod_raw.ez_transactions
+            from {{ ref("ez_" ~ chain ~ "_transactions") }}
             {% if is_incremental() %}
                 where raw_date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
@@ -30,7 +30,7 @@
             select distinct
                 raw_date,
                 sender as from_address
-            from {{ chain }}.prod_raw.ez_transactions
+            from {{ ref("ez_" ~ chain ~ "_transactions") }}
         ),
     {% elif chain == 'zksync' %}
         distinct_dates as (
@@ -111,7 +111,7 @@
         distinct_dates as (
             select distinct 
                 raw_date
-            from {{ chain }}.prod_raw.ez_transactions
+            from {{ ref("ez_" ~ chain ~ "_transactions") }}
             {% if is_incremental() %}
                 where raw_date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
@@ -120,7 +120,7 @@
             select distinct 
                 raw_date,
                 from_address
-            from {{ chain }}.prod_raw.ez_transactions
+            from {{ ref("ez_" ~ chain ~ "_transactions") }}
         ),
     {% endif %}
 


### PR DESCRIPTION
## :pushpin: References

Added refs to the rolling data macro so that rolling wau and mau is done after ez_transaction table is finished. 

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
