### PR TITLE
Fix Solana Stablecoins

### DIFF
--- a/macros/agg_chain_stablecoin_transfers.sql
+++ b/macros/agg_chain_stablecoin_transfers.sql
@@ -69,7 +69,6 @@
                 select distinct (lower(premint_address))
                     from fact_solana_stablecoin_premint_addresses
             )
-            and mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
             and succeeded = 'TRUE'
         UNION 
     -- CASE 2: Burns into non-premint addresses
@@ -102,7 +101,6 @@
                 select distinct (lower(premint_address))
                     from fact_solana_stablecoin_premint_addresses
             )
-            and mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
             and succeeded = 'TRUE'
         UNION
     -- CASE 3: Transfers between pre-mint and non-premint addresses (quasi-mint/burns)

--- a/macros/agg_chain_stablecoin_transfers.sql
+++ b/macros/agg_chain_stablecoin_transfers.sql
@@ -39,6 +39,73 @@
     -- TODO: Refactor to support native currencies. Currently assumes everything is $1
     -- b/c of perf issues when joining
     {% elif chain in ("solana") %}
+    -- CASE 1: Mints into non-premint addresses
+        select
+            block_timestamp,
+            trunc(block_timestamp, 'day') as date,
+            tx_id as tx_hash,
+            block_id as block_number,
+            0 as index,
+            '1nc1nerator11111111111111111111111111111111' as from_address,
+            token_account as to_address,
+            TRUE as is_mint,
+            FALSE as is_burn,
+            coalesce((mint_amount/ POW(10, decimal)), 0) as amount,
+            case
+                when is_mint then amount when is_burn then -1 * amount else 0
+            end as inflow,
+            0 as transfer_volume,
+            mint as contract_address,
+            fact_solana_stablecoin_contracts.symbol
+        from solana_flipside.defi.fact_token_mint_actions
+        join
+            fact_solana_stablecoin_contracts
+            on lower(solana_flipside.defi.fact_token_mint_actions.mint)
+            = lower(fact_solana_stablecoin_contracts.contract_address)
+        where
+            mint
+            in (select distinct contract_address from fact_solana_stablecoin_contracts)
+            and lower(token_account) not in (
+                select distinct (lower(premint_address))
+                    from fact_solana_stablecoin_premint_addresses
+            )
+            and mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+            and succeeded = 'TRUE'
+        UNION 
+    -- CASE 2: Burns into non-premint addresses
+        select
+            block_timestamp,
+            trunc(block_timestamp, 'day') as date,
+            tx_id as tx_hash,
+            block_id as block_number,
+            0 as index,
+            token_account as from_address,
+            '1nc1nerator11111111111111111111111111111111' as to_address,
+            FALSE as is_mint,
+            TRUE as is_burn,
+            coalesce((burn_amount/ POW(10, decimal)), 0) as amount,
+            case
+                when is_mint then amount when is_burn then -1 * amount else 0
+            end as inflow,
+            0 as transfer_volume,
+            mint as contract_address,
+            fact_solana_stablecoin_contracts.symbol
+        from solana_flipside.defi.fact_token_burn_actions
+        join
+            fact_solana_stablecoin_contracts
+            on lower(solana_flipside.defi.fact_token_burn_actions.mint)
+            = lower(fact_solana_stablecoin_contracts.contract_address)
+        where
+            mint
+            in (select distinct contract_address from fact_solana_stablecoin_contracts)
+            and lower(token_account) not in (
+                select distinct (lower(premint_address))
+                    from fact_solana_stablecoin_premint_addresses
+            )
+            and mint = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'
+            and succeeded = 'TRUE'
+        UNION
+    -- CASE 3: Transfers between pre-mint and non-premint addresses (quasi-mint/burns)
         select
             block_timestamp,
             trunc(block_timestamp, 'day') as date,
@@ -47,14 +114,27 @@
             index,
             tx_from as from_address,
             tx_to as to_address,
+            -- OUTSIDE OF EMPIRICAL MINT / BURNS 
+            -- Mint: From: Premint, To: Contract
             tx_from in (
                 select distinct (premint_address)
-                from fact_solana_stablecoin_premint_addresses
-            ) as is_mint,
-            tx_to in (
+                    from fact_solana_stablecoin_premint_addresses
+                ) 
+                and tx_to not in (
                 select distinct (premint_address)
-                from fact_solana_stablecoin_premint_addresses
-            ) as is_burn,
+                    from fact_solana_stablecoin_premint_addresses
+                )
+            as is_mint,
+            -- BURN: From: Contract, To: Premint
+            tx_from not in (
+                select distinct (premint_address)
+                    from fact_solana_stablecoin_premint_addresses
+                ) 
+                and tx_to in (
+                select distinct (premint_address)
+                    from fact_solana_stablecoin_premint_addresses
+                )
+            as is_burn,
             coalesce(amount, 0) as amount,
             case
                 when is_mint then amount when is_burn then -1 * amount else 0

--- a/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
@@ -1,7 +1,7 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 {{ config(
     materialized="incremental", 
-        snowflake_warehouse="STABLECOIN_LG_2", 
+        snowflake_warehouse="BAM_TRANSACTION_2XLG", 
         unique_key=["tx_hash", "index"],
     ) 
 }}

--- a/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_solana_stablecoin_transfers.sql
@@ -1,7 +1,7 @@
 -- depends_on: {{ ref('fact_solana_stablecoin_contracts') }}
 {{ config(
     materialized="incremental", 
-        snowflake_warehouse="BAM_TRANSACTION_2XLG", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
         unique_key=["tx_hash", "index"],
     ) 
 }}


### PR DESCRIPTION
- Logic rework. Previously we were assuming mints/burns could only happen in premints, so we were tracking net outflow from premints as supply.
- However, we discovered the above assumption is not true. 
- Consequently, new formula works as follows: 

`CIRC_SUPPLY = TOTAL MINTS OUTSIDE OF PRE-MINTS - TOTAL BURNS OUTSIDE OF PRE-MINTS + NET OUTFLOW OUT OF PRE-MINTS TO EOAs`