### PR TITLE
Perpetuals

### DIFF
--- a/models/projects/aevo/core/ez_aevo_metrics_by_chain.sql
+++ b/models/projects/aevo/core/ez_aevo_metrics_by_chain.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AEVO",
+        database="aevo",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_aevo_trading_volume") }}
+    )
+select
+    date,
+    'aevo' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume
+from trading_volume_data
+where date < to_date(sysdate())

--- a/models/projects/apex/core/ez_apex_metrics_by_chain.sql
+++ b/models/projects/apex/core/ez_apex_metrics_by_chain.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="APEX",
+        database="apex",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_apex_trading_volume") }}
+    )
+select
+    date,
+    'apex' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume
+from trading_volume_data
+where date < to_date(sysdate())

--- a/models/projects/avantis/core/ez_avantis_metrics_by_chain.sql
+++ b/models/projects/avantis/core/ez_avantis_metrics_by_chain.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AVANTIS",
+        database="avantis",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_avantis_trading_volume_silver") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_avantis_unique_traders_silver") }}
+    )
+select
+    date,
+    'avantis' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/bluefin/core/ez_bluefin_metrics_by_chain.sql
+++ b/models/projects/bluefin/core/ez_bluefin_metrics_by_chain.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="BLUEFIN",
+        database="bluefin",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_bluefin_trading_volume_silver") }}
+    )
+select
+    date,
+    'bluefin' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume
+from trading_volume_data
+where date < to_date(sysdate())

--- a/models/projects/drift/core/ez_drift_metrics_by_chain.sql
+++ b/models/projects/drift/core/ez_drift_metrics_by_chain.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="DRIFT",
+        database="drift",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    drfit_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_drift_trading_volume") }}
+    )
+select
+    date,
+    'drift' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume
+from drfit_data
+where date < to_date(sysdate())

--- a/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="DYDX",
+        database="dydx",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume
+        from {{ ref("fact_dydx_trading_volume") }}
+        where market_pair is null
+    ),
+    unique_traders_data as (
+        select date, unique_traders
+        from {{ ref("fact_dydx_unique_traders") }}
+    )
+
+select 
+    unique_traders_data.date as date,
+    'dydx' as app,
+    'DeFi' as category,
+    'starkware' as chain,
+    trading_volume_data.trading_volume,
+    unique_traders_data.unique_traders
+from unique_traders_data
+left join trading_volume_data on unique_traders_data.date = trading_volume_data.date
+where unique_traders_data.date < to_date(sysdate())

--- a/models/projects/dydx_v4/core/ez_dydx_v4_metrics_by_chain.sql
+++ b/models/projects/dydx_v4/core/ez_dydx_v4_metrics_by_chain.sql
@@ -1,0 +1,45 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="DYDX",
+        database="dydx_v4",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume
+        from {{ ref("fact_dydx_v4_trading_volume") }}
+    ),
+    fees_data as (
+        select date, maker_fees, taker_fees, fees
+        from {{ ref("fact_dydx_v4_fees") }}
+    ),
+    chain_data as (
+        select date, trading_fees, txn_fees
+        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders
+        from {{ ref("fact_dydx_v4_unique_traders") }}
+    )
+
+select 
+    unique_traders_data.date as date,
+    'dydx_v4' as app,
+    'DeFi' as category,
+    'dydx_v4' as chain,
+    trading_volume,
+    unique_traders,
+    maker_fees,
+    taker_fees,
+    fees,
+    trading_fees,
+    txn_fees
+from trading_volume_data
+left join fees_data on trading_volume_data.date = fees_data.date
+left join chain_data on trading_volume_data.date = chain_data.date
+left join unique_traders_data on trading_volume_data.date = unique_traders_data.date
+where unique_traders_data.date < to_date(sysdate())

--- a/models/projects/gmx/core/ez_gmx_metrics_by_chain.sql
+++ b/models/projects/gmx/core/ez_gmx_metrics_by_chain.sql
@@ -1,0 +1,45 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GMX",
+        database="gmx",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data_v1 as (
+        select date, trading_volume, unique_traders, chain
+        from {{ ref("fact_gmx_trading_volume") }}
+        left join {{ ref("fact_gmx_unique_traders") }} using(date, chain)
+        where chain is not null
+    ),
+    v2_data as (
+        select date, trading_volume, unique_traders, chain
+        from {{ ref("fact_gmx_v2_trading_volume_unique_traders") }}
+        where chain is not null
+    ),
+    combined_data as (
+        select 
+            date,
+            chain,
+            sum(trading_volume) as trading_volume,
+            sum(unique_traders) as unique_traders
+        from (
+            select * from trading_volume_data_v1
+            union all
+            select * from v2_data
+        )
+        group by 1, 2
+    )
+
+select 
+    date as date,
+    'gmx' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from combined_data
+where date < to_date(sysdate())

--- a/models/projects/gmx/core/ez_gmx_metrics_by_version.sql
+++ b/models/projects/gmx/core/ez_gmx_metrics_by_version.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GMX",
+        database="gmx",
+        schema="core",
+        alias="ez_metrics_by_version",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume
+        from {{ ref("fact_gmx_trading_volume") }}
+        where chain is null
+    ),
+    unique_traders_data as (
+        select date, unique_traders
+        from {{ ref("fact_gmx_unique_traders") }}
+        where chain is null
+    ),
+    v1_data as (
+        select 
+            t1.date, 
+            trading_volume, 
+            unique_traders, 
+            'GMX v1' as version
+        from  trading_volume_data t1
+        left join unique_traders_data t2 on t1.date = t2.date
+    ),
+    v2_data as (
+        select 
+            date, 
+            trading_volume, 
+            unique_traders, 
+            'GMX v2' as version
+        from {{ ref("fact_gmx_v2_trading_volume_unique_traders") }}
+        where chain is null
+    )
+   
+select 
+    date,
+    'gmx' as app,
+    'DeFi' as category,
+    version,
+    trading_volume,
+    unique_traders
+from v2_data
+where date < to_date(sysdate())
+union all
+select 
+    date ,
+    'gmx' as app,
+    'DeFi' as category,
+    version,
+    trading_volume,
+    unique_traders  
+from v1_data
+where date < to_date(sysdate())

--- a/models/projects/holdstation/core/ez_holdstation_metrics_by_chain.sql
+++ b/models/projects/holdstation/core/ez_holdstation_metrics_by_chain.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="HOLDSTATION",
+        database="holdstation",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_holdstation_trading_volume") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_holdstation_unique_traders") }}
+    )
+select
+    date,
+    'holdstation' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="HYPERLIQUID",
+        database="hyperliquid",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_hyperliquid_trading_volume") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_hyperliquid_unique_traders") }}
+    )
+select
+    date,
+    'hyperliquid' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/ktx_finance/core/ez_ktx_finance_metrics_by_chain.sql
+++ b/models/projects/ktx_finance/core/ez_ktx_finance_metrics_by_chain.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="KTX_FINANCE",
+        database="ktx_finance",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_ktx_finance_trading_volume") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_ktx_finance_unique_traders") }}
+    )
+select
+    date,
+    'ktx_finance' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/level_finance/core/ez_level_finance_metrics_by_chain.sql
+++ b/models/projects/level_finance/core/ez_level_finance_metrics_by_chain.sql
@@ -1,0 +1,32 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="LEVEL_FINANCE",
+        database="level_finance",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_level_finance_trading_volume") }}
+        where chain is not null
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_level_finance_unique_traders") }}
+        where chain is not null
+    )
+
+select 
+    date as date,
+    'level_finance' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date > '2022-12-10' and date < to_date(sysdate())

--- a/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics_by_chain.sql
+++ b/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics_by_chain.sql
@@ -1,0 +1,39 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="PERPETUAL_PROTOCOL",
+        database="perpetual_protocol",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_perpetual_protocol_trading_volume") }}
+        where chain is not null
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_perpetual_protocol_unique_traders") }}
+        where chain is not null
+    ),
+    fees_data as (
+        select date, fees, chain
+        from {{ ref("fact_perpetual_protocol_fees") }}
+        where chain is not null
+    )
+select
+    date as date,
+    'perpetual_protocol' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders,
+    fees
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+left join fees_data using(date, chain)
+where date > '2021-11-25' and date < to_date(sysdate())

--- a/models/projects/rabbit_x/core/ez_rabbit_x_metrics_by_chain.sql
+++ b/models/projects/rabbit_x/core/ez_rabbit_x_metrics_by_chain.sql
@@ -1,0 +1,31 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="RABBIT_X",
+        database="rabbit_x",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, 'starknet' as chain
+        from {{ ref("fact_rabbitx_trading_volume") }}
+        where market_pair is null
+    ),
+    unique_traders_data as (
+        select date, unique_traders, 'starknet' as chain
+        from {{ ref("fact_rabbitx_unique_traders") }}
+    )
+select 
+    date,
+    'rabbit-x' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from trading_volume_data
+left join unique_traders_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/synthetix/core/ez_synthetix_metrics_by_chain.sql
+++ b/models/projects/synthetix/core/ez_synthetix_metrics_by_chain.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="SYNTHETIX",
+        database="synthetix",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_synthetix_trading_volume") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_synthetix_unique_traders") }}
+    )
+select
+    date,
+    'synthetix' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())

--- a/models/projects/vertex/core/ez_vertex_metrics_by_chain.sql
+++ b/models/projects/vertex/core/ez_vertex_metrics_by_chain.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="VERTEX",
+        database="vertex",
+        schema="core",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+
+with
+    trading_volume_data as (
+        select date, trading_volume, chain
+        from {{ ref("fact_vertex_trading_volume") }}
+    ),
+    unique_traders_data as (
+        select date, unique_traders, chain
+        from {{ ref("fact_vertex_unique_traders") }}
+    )
+select
+    date,
+    'vertex' as app,
+    'DeFi' as category,
+    chain,
+    trading_volume,
+    unique_traders
+from unique_traders_data
+left join trading_volume_data using(date, chain)
+where date < to_date(sysdate())


### PR DESCRIPTION
1. Create the ez_metric_tables for most of the perpetual protocols. The following list are the perpetual protocols that do NOT have an ez_metric table yet:
`gains`
`mux`