### PR TITLE
pin numpy version to 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ dbt-extractor==0.5.1
 dbt-semantic-interfaces==0.4.3
 dbt-snowflake==1.7.1
 pandas==2.0.2
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- Numpy `2.0` was released today ([pypi history](https://pypi.org/project/numpy/#history))
- Having the unpinned dependency causes an issue with the dbt snowflake adapter ([dbt slack](https://getdbt.slack.com/archives/CJN7XRF1B/p1718637552783169?thread_ts=1718637120.186429&cid=CJN7XRF1B)), this causes our CI runs to fail at the `dbt deps` step

## Test Plan
- `dbt deps` succeeds off of a fresh CI run