### PR TITLE
DEX Models: Fixing Compliation Bugs in ez_swap tables

### DIFF
--- a/models/projects/frax/raw/ez_frax_dex_swaps.sql
+++ b/models/projects/frax/raw/ez_frax_dex_swaps.sql
@@ -29,6 +29,6 @@ select
     dex_swaps.token_1_symbol,
     dex_swaps.trading_volume,
     dex_swaps.trading_fees,
-    dex_swaps.gas_cost_native,
+    dex_swaps.gas_cost_native
 from dex_swaps
 where dex_swaps.block_timestamp::date < to_date(sysdate())

--- a/models/projects/quickswap/raw/ez_quickswap_dex_swaps.sql
+++ b/models/projects/quickswap/raw/ez_quickswap_dex_swaps.sql
@@ -29,6 +29,6 @@ select
     dex_swaps.token_1_symbol,
     dex_swaps.trading_volume,
     dex_swaps.trading_fees,
-    dex_swaps.gas_cost_native,
+    dex_swaps.gas_cost_native
 from dex_swaps
 where dex_swaps.block_timestamp::date < to_date(sysdate())

--- a/models/projects/sushiswap/raw/ez_sushiswap_dex_swaps.sql
+++ b/models/projects/sushiswap/raw/ez_sushiswap_dex_swaps.sql
@@ -38,6 +38,6 @@ select
     dex_swaps.token_1_symbol,
     dex_swaps.trading_volume,
     dex_swaps.trading_fees,
-    dex_swaps.gas_cost_native,
+    dex_swaps.gas_cost_native
 from dex_swaps
 where dex_swaps.block_timestamp::date < to_date(sysdate())

--- a/models/projects/trader_joe/raw/ez_trader_joe_dex_swaps.sql
+++ b/models/projects/trader_joe/raw/ez_trader_joe_dex_swaps.sql
@@ -35,6 +35,6 @@ select
     dex_swaps.token_1_symbol,
     dex_swaps.trading_volume,
     dex_swaps.trading_fees,
-    dex_swaps.gas_cost_native,
+    dex_swaps.gas_cost_native
 from dex_swaps
 where dex_swaps.block_timestamp::date < to_date(sysdate())


### PR DESCRIPTION
There was an extra comma in the ez_swap table for the following dex's:
`quickswap`
`frax`
`sushiswap`
`trader_joe`