### PR TITLE
Enable partial parsing in all actions workflows

### DIFF
--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -17,4 +17,6 @@ runs:
     - name: Download DBT Manifest
       shell: bash
       run: |
-        wget https://artemis-xyz.github.io/dbt/manifest.json
+        wget https://artemis-xyz.github.io/dbt/partial_parse.msgpack
+        mkdir -p target/
+        mv partial_parse.msgpack target/

--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -2,12 +2,19 @@ name: init dbt
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-python@v5
+      with:
+        cache: 'pip'
+        cache-dependency-path: 'requirements.txt'
+
     - name: Set up dependencies
+      shell: bash
       run: |
         pip install pip==23.1.2
         pip install pip-tools==6.13.0
         pip install -r requirements.txt
 
     - name: Download DBT Manifest
+      shell: bash
       run: |
         wget https://artemis-xyz.github.io/dbt/manifest.json

--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -1,0 +1,13 @@
+name: init dbt
+runs:
+  using: "composite"
+  steps:
+    - name: Set up dependencies
+      run: |
+        pip install pip==23.1.2
+        pip install pip-tools==6.13.0
+        pip install -r requirements.txt
+
+    - name: Download DBT Manifest
+      run: |
+        wget https://artemis-xyz.github.io/dbt/manifest.json

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,11 +25,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up dependencies
-        run: |
-          pip install pip==23.1.2
-          pip install pip-tools==6.13.0
-          pip install -r requirements.txt
+      - name: Init dbt
+        uses: ./.github/actions/init-dbt
 
       - name: Compile
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,8 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "artemis-xyz.github.io"
 
-      - name: Set up dependencies
-        run: |
-          pip install pip==23.1.2
-          pip install pip-tools==6.13.0
-          pip install -r requirements.txt
+      - name: Init dbt
+        uses: ./.github/actions/init-dbt
 
       - name: Generate docs
         run: |

--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -49,15 +49,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Set up dependencies
-        run: |
-          pip install pip==23.1.2
-          pip install pip-tools==6.13.0
-          pip install -r requirements.txt
-
-      - name: Download manifest.json
-        run: |
-          wget https://artemis-xyz.github.io/dbt/manifest.json
+      - name: Init dbt
+        uses: ./.github/actions/init-dbt
 
       - name: Show results of changed models
         run: |


### PR DESCRIPTION
## Summary
- Enable partial parsing on dbt steps 
  - Get latest dbt manifest from docsite
- Abstract repeated pip + manifest download code into `init-dbt` workflow
- Turn on python dependency [caching](https://github.com/actions/setup-python/tree/main?tab=readme-ov-file#caching-packages-dependencies) like we have in the BE repo

## Test Plan
- Deleted `target` folder 
- `dbt parse` and "no saved manifest found" 
<img width="656" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/d362d95c-e565-4b2f-8398-c46ae0545eef">

- Ran commands to download from GH pages, partial parsing works

<img width="675" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/ebc2738b-e75e-4c17-8246-f92828f9bb76">
