### PR TITLE
Upload partial_parse.msgpack to docsite

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,8 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "artemis-xyz.github.io"
 
-      - name: Set up dependencies
-        run: |
-          pip install pip==23.1.2
-          pip install pip-tools==6.13.0
-          pip install -r requirements.txt
+      - name: Init dbt
+        uses: ./.github/actions/init-dbt
 
       - name: Generate docs
         run: |
@@ -40,7 +37,7 @@ jobs:
           dbt docs generate --threads 16
           git diff
           mkdir generated_dbt_docs
-          mv "target/index.html" "target/manifest.json" "target/catalog.json" generated_dbt_docs
+          mv "target/index.html" "target/manifest.json" "target/catalog.json" "target/partial_parse.msgpack" generated_dbt_docs
 
       - name: Push to Github Pages repo
         uses: cpina/github-action-push-to-another-repository@v1.7.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,8 +28,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: "artemis-xyz.github.io"
 
-      - name: Init dbt
-        uses: ./.github/actions/init-dbt
+      - name: Set up dependencies
+        run: |
+          pip install pip==23.1.2
+          pip install pip-tools==6.13.0
+          pip install -r requirements.txt
 
       - name: Generate docs
         run: |


### PR DESCRIPTION
## Summary
- Necessary for https://github.com/Artemis-xyz/dbt/pull/216 to enable partial parsing

## Test Plan
- Partial parse file is around 1/2 the size of the dbt manifest so should be fine to upload 
<img width="560" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/3f25115b-56fc-4c29-9b90-6177d7e31da4">

- File is generated by `dbt docs generate` command. 
  - Ran `rm -rf target/` and then `dbt docs generate` and file was present within a fresh `target` folder
