### PR TITLE
Update Ez Metric Dependencies: Polygon, Ethereum, Near

### DIFF
--- a/models/metrics/revenue/agg_daily_ethereum_revenue_gold.sql
+++ b/models/metrics/revenue/agg_daily_ethereum_revenue_gold.sql
@@ -1,3 +1,0 @@
-{{ config(materialized="table") }}
-select chain, date, native_token_burn, revenue
-from {{ ref("agg_daily_ethereum_revenue") }}

--- a/models/metrics/revenue/agg_daily_polygon_revenue_gold.sql
+++ b/models/metrics/revenue/agg_daily_polygon_revenue_gold.sql
@@ -1,3 +1,0 @@
-{{ config(materialized="table") }}
-select chain, date, native_token_burn, revenue
-from {{ ref("agg_daily_polygon_revenue") }}

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -22,7 +22,7 @@ with
     censored_block_metrics as ({{ get_censored_block_metrics("ethereum") }}),
     revenue_data as (
         select date, revenue, native_token_burn as revenue_native
-        from {{ ref("agg_daily_ethereum_revenue_gold") }}
+        from {{ ref("agg_daily_ethereum_revenue") }}
     ),
     github_data as ({{ get_github_metrics("ethereum") }}),
     contract_data as ({{ get_contract_metrics("ethereum") }}),

--- a/models/projects/near/core/ez_near_metrics.sql
+++ b/models/projects/near/core/ez_near_metrics.sql
@@ -14,7 +14,7 @@ with
     price_data as ({{ get_coingecko_metrics("near") }}),
     defillama_data as ({{ get_defillama_metrics("near") }}),
     revenue_data as (
-        select date, revenue_native, revenue from {{ ref("fact_near_revenue_gold") }}
+        select date, revenue_native, revenue from {{ ref("fact_near_revenue") }}
     ),
     github_data as ({{ get_github_metrics("near") }}),
     contract_data as ({{ get_contract_metrics("near") }}),

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -18,7 +18,7 @@ with
     contract_data as ({{ get_contract_metrics("polygon") }}),
     revenue_data as (
         select date, native_token_burn as revenue_native, revenue
-        from {{ ref("agg_daily_polygon_revenue_gold") }}
+        from {{ ref("agg_daily_polygon_revenue") }}
     ),
     nft_metrics as ({{ get_nft_metrics("polygon") }}),
     p2p_metrics as ({{ get_p2p_metrics("polygon") }}),

--- a/models/staging/near/fact_near_revenue_gold.sql
+++ b/models/staging/near/fact_near_revenue_gold.sql
@@ -1,5 +1,0 @@
-{{ config(materialized="table") }}
-
-select date, chain, revenue_native, revenue
-from {{ ref("fact_near_revenue") }}
-where date < to_date(sysdate())


### PR DESCRIPTION
Since we are no longer use the gold tables, I am updating the dependency to be on the "silver" table rather than the gold in the ez metric models.

<img width="1506" alt="Screenshot 2024-06-21 at 11 48 37 AM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/d242ff11-ede3-450e-89e0-a5c77aa08bde">

<img width="1512" alt="Screenshot 2024-06-21 at 11 49 31 AM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/d7e43da6-19d2-40c3-9ed9-2da412d03582">

<img width="1512" alt="Screenshot 2024-06-21 at 11 50 01 AM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/1c5299c5-66fd-43c1-99c5-86835df48926">


