### PR TITLE
Switch from pip -> uv

### DIFF
--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -12,11 +12,9 @@ runs:
     - name: Set up dependencies
       shell: bash
       run: |
-        source syncenv
         pip install uv==0.2.15
-        uv pip install pip==23.1.2
-        uv pip install pip-tools==6.13.0
-        uv pip install -r requirements.txt
+        uv pip install pip==23.1.2 pip-tools==6.13.0 --system
+        uv pip install -r requirements.txt --system
 
     - name: Download DBT Manifest
       shell: bash

--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -12,6 +12,7 @@ runs:
     - name: Set up dependencies
       shell: bash
       run: |
+        source syncenv
         pip install uv==0.2.15
         uv pip install pip==23.1.2
         uv pip install pip-tools==6.13.0

--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -2,17 +2,20 @@ name: init dbt
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
-      with:
-        cache: 'pip'
-        cache-dependency-path: 'requirements.txt'
-
+    # Open PR to actions/setup-python for supporting uv caching https://github.com/actions/setup-python/pull/818
+    # Related GH issue https://github.com/actions/setup-python/issues/822
+    #
+    # - uses: actions/setup-python@v5
+    #   with:
+    #     cache: 'pip'
+    #     cache-dependency-path: 'requirements.txt'
     - name: Set up dependencies
       shell: bash
       run: |
-        pip install pip==23.1.2
-        pip install pip-tools==6.13.0
-        pip install -r requirements.txt
+        pip install uv==0.2.15
+        uv pip install pip==23.1.2
+        uv pip install pip-tools==6.13.0
+        uv pip install -r requirements.txt
 
     - name: Download DBT Manifest
       shell: bash

--- a/.github/actions/init-dbt/action.yml
+++ b/.github/actions/init-dbt/action.yml
@@ -13,7 +13,6 @@ runs:
       shell: bash
       run: |
         pip install uv==0.2.15
-        uv pip install pip==23.1.2 pip-tools==6.13.0 --system
         uv pip install -r requirements.txt --system
 
     - name: Download DBT Manifest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Compile
         run: |
           dbt deps
-          dbt compile
+          dbt compile --threads 16

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	uv pip install -r requirements.txt && dbt deps
+	source syncenv && uv pip install -r requirements.txt && dbt deps
 
 # As of 4/2/2024, compile and test will be run via Github cloud agent.
 # Running locally without creds is not possible in Snowflake, but we are actively working on a solution.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
-	pip3 install -r requirements.txt && dbt deps
+	uv pip install -r requirements.txt && dbt deps
 
-# As of 4/2/2024, compile and test will be run via Github cloud agent. 
+# As of 4/2/2024, compile and test will be run via Github cloud agent.
 # Running locally without creds is not possible in Snowflake, but we are actively working on a solution.
 dbt-compile:
 	dbt compile


### PR DESCRIPTION
## Summary
- Porting over `pip` commands to `uv` ([github](https://github.com/astral-sh/uv?tab=readme-ov-file)), a drop-in replacement package manager + dependency resolver in order to improve build performance 
- Use of a virtualenv is typically required, but the `--system` Astral/uv team mentions in the [docs](https://github.com/astral-sh/uv?tab=readme-ov-file#installing-into-arbitrary-python-environments) that doing a system-level install is fine within a CI environment
- Increase # of threads used in the `dbt compile` step in CI from 4 -> 16 
 
## Test Plan
- Executed commands locally 
<img width="962" alt="image" src="https://github.com/Artemis-xyz/dbt/assets/29241719/40e12a89-03de-448f-88e7-14d69d03c1b6">

- dbt is installed + commands work in the CI environment for this PR