### PR TITLE
Use new warehouses for balances computation so we don't max out warehouse concurrency limit

### DIFF
--- a/models/staging/optimism/agg_optimism_stablecoin_balances.sql
+++ b/models/staging/optimism/agg_optimism_stablecoin_balances.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["address", "contract_address", "date"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="BALANCES_LG_2",
     )
 }}
 

--- a/models/staging/polygon/agg_polygon_stablecoin_balances.sql
+++ b/models/staging/polygon/agg_polygon_stablecoin_balances.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["address", "contract_address", "date"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="BALANCES_LG_2",
     )
 }}
 

--- a/models/staging/tron/agg_tron_stablecoin_balances.sql
+++ b/models/staging/tron/agg_tron_stablecoin_balances.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["address", "contract_address", "date"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="BALANCES_LG_2",
     )
 }}
 


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
