### PR TITLE
Added Ton Stablecoin Transfers + Aggregated Data

### DIFF
--- a/macros/stablecoins/agg_chain_stablecoin_metrics.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_metrics.sql
@@ -5,7 +5,7 @@
 -- 3. The table `{{ chain }}_flipside.core.fact_transactions` exists
 {% macro agg_chain_stablecoin_metrics(chain) %}
     with
-        transfer_transactions as (select * from fact_{{ chain }}_stablecoin_transfers),
+        transfer_transactions as (select * from {% if chain in ("ton") %} {{ chain }}.prod_raw.ez_stablecoin_transfers  {% else %} fact_{{ chain }}_stablecoin_transfers {% endif %}),
         deduped_flows as (
             select 
                 date,

--- a/models/metrics/stablecoins/metrics/agg_ton_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_ton_stablecoin_metrics.sql
@@ -1,0 +1,3 @@
+-- depends_on: {{ ref('fact_ton_stablecoin_contracts') }}
+-- depends_on: {{ ref('ez_ton_stablecoin_transfers') }}
+{{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("ton") }}

--- a/models/projects/ton/raw/ez_ton_stablecoin_transfers.sql
+++ b/models/projects/ton/raw/ez_ton_stablecoin_transfers.sql
@@ -1,0 +1,56 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="tx_hash",
+        snowflake_warehouse="TON",
+        database="ton",
+        schema="raw",
+        alias="ez_stablecoin_transfers",
+    )
+}}
+
+select
+    block_timestamp,
+    trunc(block_timestamp, 'day') as date,
+    tx_hash,
+    from_address,
+    to_address,
+    -- Mint: From: Premint, To: Contract
+    from_address in (
+        select distinct (premint_address)
+            from pc_dbt_db.prod.fact_ton_stablecoin_contracts
+        ) 
+        and to_address not in (
+        select distinct (premint_address)
+            from pc_dbt_db.prod.fact_ton_stablecoin_contracts
+        )
+    as is_mint,
+    -- BURN: From: Contract, To: Premint
+    from_address not in (
+        select distinct (premint_address)
+            from pc_dbt_db.prod.fact_ton_stablecoin_contracts
+        ) 
+        and to_address in (
+        select distinct (premint_address)
+            from pc_dbt_db.prod.fact_ton_stablecoin_contracts
+        )
+    as is_burn,
+    coalesce(amount / POWER(10, decimal), 0) as amount,
+    case
+        when is_mint then amount / POWER(10, decimal) when is_burn then -1 * amount / POWER(10, decimal) else 0
+    end as inflow,
+    case
+        when
+            not is_mint
+            and not is_burn
+        then amount / POWER(10, decimal)
+        else 0
+    end as transfer_volume,
+    fact_ton_stablecoin_contracts.symbol,
+    fact_ton_stablecoin_contracts.contract_address
+from 
+    {{ ref('fact_ton_stablecoin_transfers') }} as transfers
+left join
+    pc_dbt_db.prod.fact_ton_stablecoin_contracts
+    on lower(transfers.symbol)
+    = lower(fact_ton_stablecoin_contracts.symbol)

--- a/models/staging/ton/__ton__sources.yml
+++ b/models/staging/ton/__ton__sources.yml
@@ -8,3 +8,4 @@ sources:
       - name: raw_ton_revenue
       - name: raw_ton_txns
       - name: raw_ton_dex_volumes
+      - name: raw_ton_stablecoin_transfers

--- a/models/staging/ton/_test_fact_ton_stablecoin_transfers.yml
+++ b/models/staging/ton/_test_fact_ton_stablecoin_transfers.yml
@@ -1,0 +1,35 @@
+models:
+  - name: fact_ton_stablecoin_transfers
+    columns:
+      - name: amount
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: block_timestamp
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+          - dbt_expectations.expect_row_values_to_have_recent_data:
+              datepart: day
+              interval: 3
+              severity: error
+      - name: payload
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: from_address
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: to_address
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: decimal
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: symbol
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/staging/ton/fact_ton_stablecoin_contracts.sql
+++ b/models/staging/ton/fact_ton_stablecoin_contracts.sql
@@ -1,0 +1,14 @@
+{{ config(materialized="table") }}
+select symbol, contract_address, num_decimals, coingecko_id, initial_supply, premint_address
+from
+    (
+        values
+            (
+                'USD₮',
+                'EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs',
+                6,
+                'tether',
+                0,
+                'EQAj-peZGPH-cC25EAv4Q-h8cBXszTmkch6ba6wXC8BM4xdo'
+            )
+    ) as results(symbol, contract_address, num_decimals, coingecko_id, initial_supply, premint_address)

--- a/models/staging/ton/fact_ton_stablecoin_transfers.sql
+++ b/models/staging/ton/fact_ton_stablecoin_transfers.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="tx_hash",
+        snowflake_warehouse="TON",
+    )
+}}
+with raw_data as (
+    select
+        extraction_date
+        , source_json
+        , source_json:"amount"::bigint as amount
+        , source_json:"date_timestamp"::timestamp as timestamp
+        , source_json:"decoded_hash"::string as tx_hash
+        , PARSE_JSON(source_json:"decoded_value"::string) as payload
+        , source_json:"from_address"::string as from_address
+        , source_json:"to_address"::string as to_address
+        , source_json:"decimals"::int as decimal
+        , source_json:"symbol"::string as symbol
+    from
+        {{ source("PROD_LANDING", "raw_ton_stablecoin_transfers") }}
+    {% if is_incremental() %}
+        where source_json:"date_timestamp"::timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}
+)
+select 
+    tx_hash
+    , coalesce(max_by(amount, extraction_date), 0) as amount
+    , max_by(timestamp, extraction_date) as block_timestamp
+    , max_by(payload, extraction_date) as payload
+    , max_by(from_address, extraction_date) as from_address
+    , max_by(to_address, extraction_date) as to_address
+    , max_by(decimal, extraction_date) as decimal
+    , max_by(symbol, extraction_date) as symbol
+from raw_data
+where from_address is not null and to_address is not null and timestamp is not null
+group by tx_hash


### PR DESCRIPTION
## :pushpin: References

Created an ez_ton_stablecoin_transfers to use to build balances and aggregated data.

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
