### PR TITLE
Stablecoins: Fix Ethereum Unique Key and use ref

### DIFF
--- a/macros/stablecoins/agg_daily_stablecoin_metrics_breakdown.sql
+++ b/macros/stablecoins/agg_daily_stablecoin_metrics_breakdown.sql
@@ -36,7 +36,7 @@ with
         {% endif %}
     ),
     filtered_contracts as (
-        select * from pc_dbt_db.prod.dim_contracts_gold where chain = '{{ chain }}'
+        select * from {{ ref("dim_contracts_gold")}} where chain = '{{ chain }}'
     ),
     artemis_contract_filters as (
         {% if label_source == 'ARTEMIS' %}

--- a/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
         snowflake_warehouse="BALANCES_LG",
     )

--- a/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
@@ -1,7 +1,7 @@
 {{
     config(
-        materialized="incremental",
-        unique_key=["date", "symbol", "from_address"],
+        materialized="table",
+        unique_key=["date", "contract_address", "from_address"],
         snowflake_warehouse="BALANCES_LG",
     )
 }}


### PR DESCRIPTION
1. Change ethereum unique key from symbol to `contract_address`
2. use `ref` in stablecoin marco for `dim_contracts_gold`