### PR TITLE
Add `ez_stablecoin_metrics` view for Reflexive

### DIFF
--- a/models/common/__common__sources.yml
+++ b/models/common/__common__sources.yml
@@ -4,3 +4,4 @@ sources:
     database: pc_dbt_db
     tables:
       - name: fact_coingecko_token_date_adjusted_gold
+      - name: agg_daily_stablecoin_metrics

--- a/models/common/ez_stablecoin_metrics.sql
+++ b/models/common/ez_stablecoin_metrics.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        snowflake_warehouse="COMMON",
+        database="common",
+        schema="core",
+    )
+}}
+
+select 
+    date,
+    total_supply,
+    txns,
+    dau,
+    transfer_volume,
+    chain,
+    symbol,
+    contract_address
+from {{ source("PC_DBT_DB_UPSTREAM", "agg_daily_stablecoin_metrics") }} as agg_daily_stablecoin_metrics


### PR DESCRIPTION
Just adding top-line metrics right now, they don't need more than this 