### PR TITLE
P2P Stablecoins

### DIFF
--- a/models/staging/arbitrum/fact_arbitrum_p2p_stablecoin_transfers.sql
+++ b/models/staging/arbitrum/fact_arbitrum_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_arbitrum_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/avalanche/fact_avalanche_p2p_stablecoin_transfers.sql
+++ b/models/staging/avalanche/fact_avalanche_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_avalanche_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/base/fact_base_p2p_stablecoin_transfers.sql
+++ b/models/staging/base/fact_base_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_base_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/ethereum/fact_ethereum_p2p_stablecoin_transfers.sql
+++ b/models/staging/ethereum/fact_ethereum_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_ethereum_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/near/fact_near_p2p_stablecoin_transfers.sql
+++ b/models/staging/near/fact_near_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_near_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/optimism/fact_optimism_p2p_stablecoin_transfers.sql
+++ b/models/staging/optimism/fact_optimism_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_optimism_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/polygon/fact_polygon_p2p_stablecoin_transfers.sql
+++ b/models/staging/polygon/fact_polygon_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_polygon_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/solana/fact_solana_p2p_stablecoin_transfers.sql
+++ b/models/staging/solana/fact_solana_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_solana_stablecoin_transfers") }}
 {{
     config(
         materialized="incremental",

--- a/models/staging/tron/fact_tron_p2p_stablecoin_transfers.sql
+++ b/models/staging/tron/fact_tron_p2p_stablecoin_transfers.sql
@@ -1,3 +1,4 @@
+--depends_on: {{ ref("fact_tron_stablecoin_transfers") }}
 {{
     config(
         materialized="table",


### PR DESCRIPTION
1. There is an issue with the current lineage for stablecoins where the p2p transfers should rely on the transfers table: https://artemisxyz.slack.com/archives/C04EJTAAYQK/p1719952728832099
<img width="360" alt="Screenshot 2024-07-03 at 2 23 51 PM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/dd75c68a-2306-49e8-b1ed-20d7b9f6408f">

2. Forcing the dependency so that dagster is aware

<img width="851" alt="Screenshot 2024-07-03 at 2 24 38 PM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/0841bfd6-1a81-426a-9d0b-813ed400378a">
