### PR TITLE
Across: Remove support for Lisk

### DIFF
--- a/models/dimensions/dim_chain_ids.sql
+++ b/models/dimensions/dim_chain_ids.sql
@@ -26,5 +26,6 @@ from
             (25, 'cronos'),
             (81457, 'blast'),
             (534352, 'scroll'),
-            (34443, 'mode')
+            (34443, 'mode'),
+            (1135, 'lisk')
     ) as t(id, chain)

--- a/models/staging/across/fact_across_transfers.sql
+++ b/models/staging/across/fact_across_transfers.sql
@@ -82,3 +82,6 @@ select
     input_token
 from {{ ref("fact_across_v3_transfers") }}
 where destination_chain_id != 0  -- a bug
+-- Artemis currently does not support lisk chain and OP l2
+    and destination_chain_id != 1125 
+    and origin_chain_id != 1125


### PR DESCRIPTION
### Summary
Across is currently testing the support of `lisk` (chain id 1135). Though the support has not been implemented by across yet. We also don't currently support `Lisk` as a chain. Instead of having 1/2 of the volume we explicitly remove support for `lisk`, so that we can have complete support for across over the current chains supported. 

### Future work
Once Across has officially added support for `lisk` we will need to add an extraction step similar to `zksync` or `linea`.
### Test plan
Tested the materialization of the files changed.
<img width="1261" alt="Screenshot 2024-07-06 at 5 54 14 PM" src="https://github.com/Artemis-xyz/dbt/assets/78228475/856a6477-6e24-4764-aa24-b204ac328dc9">
