### PR TITLE
USDT Stablecoin Supply: Ethereum and Tron

### DIFF
--- a/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
@@ -1,0 +1,44 @@
+{{ config(materialized="table") }}
+-- Premint addresses for ethereum are representative of USDT that has been bridged to other L2s
+select contract_address, premint_address
+from
+    (
+        values
+            -- USDT
+            --  Polygon
+            --      Matic Bridge
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf'
+            ),
+            --      Wormhole
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x3ee18B2214AFF97000D974cf647E7C347E8fa585'
+            ),
+            --      Axelar
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x4F4495243837681061C4743b74B3eEdf548D56A5'
+            ),
+            -- Arbitrum
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0xcEe284F754E854890e311e3280b767F80797180d'
+            ),
+            -- Optimism
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1'
+            ),
+            -- Base
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x3154Cf16ccdb4C6d922629664174b904d80F2C35'
+            ),
+            -- BSC
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503'
+            )
+    ) as results(contract_address, premint_address)

--- a/models/metrics/stablecoins/contracts/fact_tron_stablecoin_premint_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_tron_stablecoin_premint_addresses.sql
@@ -1,0 +1,14 @@
+{{ config(materialized="table") }}
+-- Premint addresses for ethereum are representative of USDT that has been bridged to other L2s
+select contract_address, premint_address
+from
+    (
+        values
+            -- USDT
+            -- BSC
+            --      tron Bridge
+            (
+                'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+                'TT1DyeqXaaJkt6UhVYFWUXBXknaXnBudTK'
+            )
+    ) as results(contract_address, premint_address)

--- a/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
@@ -1,6 +1,7 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_ethereum_stablecoin_premint_addresses') }}
 {{ config(
-    materialized="incremental", 
+        materialized="table", 
         snowflake_warehouse="STABLECOIN_LG_2", 
         unique_key=["tx_hash", "index"],
     ) 

--- a/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_ethereum_stablecoin_transfers.sql
@@ -1,7 +1,7 @@
 -- depends_on: {{ ref('fact_ethereum_stablecoin_contracts') }}
 -- depends_on: {{ ref('fact_ethereum_stablecoin_premint_addresses') }}
 {{ config(
-        materialized="table", 
+        materialized="incremental", 
         snowflake_warehouse="STABLECOIN_LG_2", 
         unique_key=["tx_hash", "index"],
     ) 

--- a/models/metrics/stablecoins/transfers/fact_tron_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_tron_stablecoin_transfers.sql
@@ -1,4 +1,5 @@
 -- depends_on: {{ ref('fact_tron_stablecoin_contracts') }}
+-- depends_on: {{ ref('fact_tron_stablecoin_premint_addresses') }}
 {{ config(
     materialized="incremental", 
         snowflake_warehouse="STABLECOIN_LG_2", 


### PR DESCRIPTION
Stablecoin supply for Ethereum and Tron are being over counted for USDT. Supply is bridged to other L2s and BSC. We are over counting by not subtracting the bridges supply from Ethereum and Tron. 

https://artemisxyz.slack.com/archives/C061BU21THQ/p1720717489473519


## Test
<img width="910" alt="Screenshot 2024-07-14 at 12 07 02 PM" src="https://github.com/user-attachments/assets/e8184e27-a50c-4c6c-9c70-f7f888f79f35">

<img width="958" alt="Screenshot 2024-07-14 at 12 07 30 PM" src="https://github.com/user-attachments/assets/a1f2a8dc-a449-40cf-abc9-255ffe56252e">
