### PR TITLE
Stablecoin V2: EVM Models

### DIFF
--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -1,11 +1,18 @@
-{{ config(materialized="table") }}
+{{ config(materialized="table", snowflake_warehouse="STABLECOIN_V2_LG") }}
 with
     daily_data as (
         {{
             dbt_utils.union_relations(
                 relations=[
-                    ref("agg_ethereum_daily_stablecoin_metrics_breakdown"),
                     ref("agg_base_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_blast_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_arbitrum_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_optimism_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_avalanche_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_polygon_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_ethereum_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_tron_daily_stablecoin_metrics_breakdown"),
+                    ref("agg_bsc_daily_stablecoin_metrics_breakdown"),
                 ]
             )
         }}

--- a/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
@@ -40,5 +40,10 @@ from
             (
                 '0xdAC17F958D2ee523a2206206994597C13D831ec7',
                 '0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503'
+            ),
+            -- Un-released Supply 
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x5754284f345afc66a98fbb0a0afe71e0f007b949'
             )
     ) as results(contract_address, premint_address)

--- a/models/staging/arbitrum/agg_arbitrum_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/arbitrum/agg_arbitrum_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="STABLECOIN_V2_LG",
     )
 }}
 

--- a/models/staging/avalanche/agg_avalanche_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/avalanche/agg_avalanche_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG_2",
+        snowflake_warehouse="STABLECOIN_V2_LG",
     )
 }}
 

--- a/models/staging/base/agg_base_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/base/agg_base_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="STABLECOIN_V2_LG",
     )
 }}
 

--- a/models/staging/blast/agg_blast_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/blast/agg_blast_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG_2",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
     )
 }}
 

--- a/models/staging/bsc/agg_bsc_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/bsc/agg_bsc_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="STABLECOIN_V2_LG",
     )
 }}
 

--- a/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/ethereum/agg_ethereum_daily_stablecoin_metrics_breakdown.sql
@@ -2,8 +2,8 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
     )
 }}
 
-{{ agg_daily_stablecoin_metrics_breakdown("ethereum", "FLIPSIDE") }}
+{{ agg_daily_stablecoin_metrics_breakdown("ethereum") }}

--- a/models/staging/optimism/agg_optimism_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/optimism/agg_optimism_daily_stablecoin_metrics_breakdown.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="BALANCES_LG_2",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
     )
 }}
 

--- a/models/staging/tron/agg_tron_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/tron/agg_tron_daily_stablecoin_metrics_breakdown.sql
@@ -2,8 +2,8 @@
     config(
         materialized="incremental",
         unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="STABLECOIN_V2_LG_2",
+        snowflake_warehouse="STABLECOIN_V2_LG",
     )
 }}
 
-{{ agg_daily_stablecoin_metrics_breakdown("polygon") }}
+{{ agg_daily_stablecoin_metrics_breakdown("tron") }}


### PR DESCRIPTION
1. Runnin the lineage `stablecoin_balances` --> `daily_stablecoin_metrics_breakdown` for the following chains:
`ethereum`
`bsc`
`arbitrum`
`avalanche`
`base`
`blast`
`optimism`
`polygon`
`tron`
2. Create 2 new warehouses for the new stablecoin jobs. This will help us track the currently spend of stablecoin v2
3. Update the Stablecoin v2 macros to no longer rely on flipside's tags
## To Do
1. The backfill for the `daily_stablecoin_metrics_breakdown` tables for each chain can take >15 hours (ex. `bsc`). For solana this will need to be optimized.
2. Stablecoin balances by sector currently don't add up to the correct supply (ex. Optimism). This issue is coming from the underlying balanances table. It may be worth it to create separate stablecoin balances tables as there is `n` know cases to take into account. Instead of trying to do this for all coins on a chain and having an unknown amount of cases to take into account.