### PR TITLE
Stablecoin V2: Split up macros and Test with Base 

### DIFF
--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -1,7 +1,6 @@
 {% macro p2p_stablecoin_transfers(chain) %}
 with 
-    stablecoin_transfers as (select * from fact_{{ chain }}_stablecoin_transfers),
-
+    stablecoin_transfers as (select * from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }}),
     {% if chain in ("tron", "solana", "near") %}
          distinct_peer_address as (
             select address

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -1,0 +1,165 @@
+{% macro stablecoin_balances(chain) %}
+    -- This macro takes our balances table and forward fills the values for each address for each stablecoin
+
+    -- Use this for a backfill, 
+    -- It is important to backfill 6 months at a time otherwise the query will
+    -- take > 4 hours on an XL to run
+    -- Make sure to set to '' after backfill is complete
+
+    {% set backfill_date = '2021-01-01' %}
+with
+    stablecoin_balances as (
+        select 
+            block_timestamp
+            , lower(t1.contract_address) as contract_address
+            , symbol
+            , lower(address) as address
+            {% if chain in ('solana') %}
+                , amount_unadj / pow(10, num_decimals) as stablecoin_supply
+            {% else %}
+                , balance_token / pow(10, num_decimals) as stablecoin_supply
+            {% endif %}
+        from {{ ref("fact_" ~ chain ~ "_address_balances_by_token")}} t1
+        inner join {{ ref("fact_" ~ chain ~ "_stablecoin_contracts")}} t2
+            on lower(t1.contract_address) = lower(t2.contract_address)
+        where block_timestamp < to_date(sysdate())
+            {% if chain == 'tron' %}
+                and lower(address) != lower('t9yd14nj9j7xab4dbgeix9h8unkkhxuwwb') --Tron Burn Address
+                and stablecoin_supply > 0
+            {% endif %}
+            {% if backfill_date != '' %}
+                and block_timestamp < '{{ backfill_date }}'
+            {% endif %}
+        {% if is_incremental() %}
+                and block_timestamp >= (select dateadd('day', -1, max(date)) from {{ this }})
+        {% endif %}
+    )
+    {% if is_incremental() %}
+        , stale_stablecoin_balances as (
+            select 
+                date as block_timestamp
+                , t.contract_address
+                , t.symbol
+                , t.address
+                , t.stablecoin_supply
+            from {{this}} t
+            left join (
+                select distinct address, contract_address
+                from stablecoin_balances
+            ) sb on t.address = sb.address and t.contract_address = sb.contract_address
+            where date >= (select dateadd('day', -1, max(date)) from {{ this }})
+            and sb.address is null and sb.contract_address is null
+        )
+    {% endif %}
+    , heal_balance_table as (
+        select
+            block_timestamp
+            , contract_address
+            , symbol
+            , address
+            , stablecoin_supply
+        from stablecoin_balances
+        {% if is_incremental() %}
+            union
+            select 
+                block_timestamp
+                , contract_address
+                , symbol
+                , address
+                , stablecoin_supply
+            from stale_stablecoin_balances
+        {% endif %}
+    ) 
+    , date_range as (
+        select 
+            min(block_timestamp)::date as date
+            , contract_address
+            , symbol
+            , address
+        from heal_balance_table
+        group by contract_address, address, symbol
+        
+        union all   
+        
+        select
+            dateadd(day, 1, date) as date
+            , contract_address
+            , symbol
+            , address
+        from date_range
+        where date < dateadd(day, -1, to_date(sysdate()))
+        {% if backfill_date != '' %}
+            and date < dateadd(day, -1, '{{ backfill_date }}')
+        {% endif %}
+    )
+    , balances as (
+        select 
+            block_timestamp::date as date
+            , contract_address
+            , symbol
+            , address
+            , stablecoin_supply
+        from (
+            select 
+                block_timestamp
+                , contract_address
+                , symbol
+                , address
+                , stablecoin_supply
+                , row_number() over (partition by block_timestamp::date, contract_address, address, symbol order by block_timestamp desc) AS rn
+            from heal_balance_table
+        )
+        where rn = 1
+    )
+    , historical_supply_by_address_balances as (
+        select
+            date
+            , address
+            , contract_address
+            , symbol
+            , coalesce(
+                stablecoin_supply, 
+                LAST_VALUE(balances.stablecoin_supply ignore nulls) over (
+                    partition by contract_address, address, symbol
+                    order by date
+                    rows between unbounded preceding and current row
+                ) 
+            )  as stablecoin_supply
+        from date_range
+        left join balances using (date, contract_address, symbol, address)
+        {% if is_incremental() %}
+                where date >= (select dateadd('day', -1, max(date)) from {{ this }})
+        {% endif %}
+    )
+    , stablecoin_balances_with_price as (
+        select
+            st.date
+            , address
+            , st.contract_address
+            , st.symbol
+            , stablecoin_supply as stablecoin_supply_native
+            , stablecoin_supply * coalesce(
+                d.token_current_price, 1
+            ) as stablecoin_supply
+        from historical_supply_by_address_balances st
+        left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
+                on lower(st.contract_address) = lower(c.contract_address)
+        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+            on lower(c.coingecko_id) = lower(d.token_id)
+            and st.date = d.date::date
+        {% if is_incremental() %}
+                where st.date >= (select dateadd('day', -1, max(date)) from {{ this }})
+        {% endif %}
+    )
+select
+    date
+    , address
+    , contract_address
+    , symbol
+    , stablecoin_supply_native
+    , stablecoin_supply
+    , '{{ chain }}' as chain
+    , date || '-' || address || '-' || contract_address as unique_id
+from stablecoin_balances_with_price
+
+{% endmacro %}

--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -1,0 +1,140 @@
+{% macro stablecoin_metrics(chain) %}
+    with
+        stablecoin_supply as (
+            select
+                date
+                , contract_address
+                , symbol
+                , address
+                , stablecoin_supply
+                , unique_id
+            from {{ ref("fact_" ~ chain ~ "_stablecoin_balances")}}
+        )
+        , all_metrics as (
+            select 
+                date
+                , contract_address
+                , symbol
+                , from_address
+                , stablecoin_transfer_volume
+                , stablecoin_daily_txns
+                , unique_id
+            from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_all")}}
+        )
+        , artemis_metrics as (
+            select 
+                date
+                , contract_address
+                , symbol
+                , from_address
+                , stablecoin_transfer_volume as artemis_stablecoin_transfer_volume
+                , stablecoin_daily_txns as artemis_stablecoin_daily_txns
+                , unique_id
+            from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_artemis")}}
+        )
+        , p2p_metrics as (
+            select 
+                date
+                , contract_address
+                , symbol
+                , from_address
+                , stablecoin_transfer_volume as p2p_stablecoin_transfer_volume
+                , stablecoin_daily_txns as p2p_stablecoin_daily_txns
+                , unique_id
+            from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_p2p")}}
+        )
+        , chain_stablecoin_metrics as (
+            select
+                date
+                , contract_address
+                , symbol
+                , from_address
+                , stablecoin_transfer_volume
+                , stablecoin_daily_txns
+                , artemis_stablecoin_transfer_volume
+                , artemis_stablecoin_daily_txns
+                , p2p_stablecoin_transfer_volume
+                , p2p_stablecoin_daily_txns
+                , stablecoin_supply
+                , unique_id
+            from stablecoin_supply
+            left join all_metrics using (unique_id)
+            left join artemis_metrics using (unique_id)
+            left join p2p_metrics using (unique_id)
+        )
+        , filtered_contracts as (
+            select * from {{ ref("dim_contracts_gold")}} where chain = '{{ chain }}'
+        )
+        , tagged_chain_stablecoin_metrics as (
+            select
+                date
+                --From Address Identifers
+                , from_address
+                , filtered_contracts.name as contract_name
+                , coalesce(filtered_contracts.name, chain_stablecoin_metrics.from_address) as contract
+                , filtered_contracts.friendly_name as application
+                , dim_apps_gold.icon as icon
+                , filtered_contracts.app as app
+                , case 
+                    when filtered_contracts.sub_category = 'Market Maker' then filtered_contracts.sub_category
+                    when filtered_contracts.sub_category = 'Exchange' then filtered_contracts.sub_category
+                    else filtered_contracts.category 
+                end as category
+                , case 
+                    {% if chain not in ('solana', 'tron', 'near') %}
+                        when 
+                            from_address not in (select contract_address from {{ ref("dim_" ~ chain ~ "_contract_addresses")}}) 
+                            then 1
+                        else 0 
+                    {% else %}
+                        when 
+                            from_address in (select address from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }})
+                            then 1
+                        else 0 
+                    {% endif %}
+                end as is_wallet
+                --Stablecoin Identifiers
+                , chain_stablecoin_metrics.contract_address
+                , chain_stablecoin_metrics.symbol
+                --Metrics
+                , stablecoin_transfer_volume
+                , stablecoin_daily_txns
+                , artemis_stablecoin_transfer_volume
+                , artemis_stablecoin_daily_txns
+                , p2p_stablecoin_transfer_volume
+                , p2p_stablecoin_daily_txns
+                , stablecoin_supply
+                , unique_id
+            from chain_stablecoin_metrics
+            left join filtered_contracts
+                on lower(chain_stablecoin_metrics.from_address) = lower(filtered_contracts.address)
+            left join {{ref("dim_apps_gold")}} dim_apps_gold 
+                on filtered_contracts.app = dim_apps_gold.namespace
+        )
+    select
+        date
+        , from_address
+        , contract_name
+        , contract
+        , application
+        , icon
+        , app
+        , category
+        , is_wallet
+
+        , contract_address
+        , symbol
+
+        , stablecoin_transfer_volume
+        , stablecoin_daily_txns
+        , artemis_stablecoin_transfer_volume
+        , artemis_stablecoin_daily_txns
+        , p2p_stablecoin_transfer_volume
+        , p2p_stablecoin_daily_txns
+        --issue with float precision
+        , round(stablecoin_supply, 3) as stablecoin_supply
+        , '{{ chain }}' as chain
+        , unique_id || '-' || chain as unique_id
+    from tagged_chain_stablecoin_metrics
+
+{% endmacro %}

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -1,0 +1,72 @@
+{% macro stablecoin_metrics_all(chain) %}
+with
+    stablecoin_transfers as (
+        select 
+            block_timestamp
+            , tx_hash
+            , from_address
+            , contract_address
+            , symbol
+            , transfer_volume
+            , to_address
+        from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
+        {% if is_incremental() %} 
+            where block_timestamp >= (
+                select dateadd('day', -3, max(date))
+                from {{ this }}
+            )
+        {% endif %} 
+    )
+    , stablecoin_metrics as (
+        select
+            block_timestamp::date as date
+            , stablecoin_transfers.from_address::string as from_address
+            , stablecoin_transfers.contract_address as contract_address
+            , stablecoin_transfers.symbol as symbol
+            , sum(transfer_volume) as stablecoin_transfer_volume
+            , sum(
+                case
+                    when stablecoin_transfers.from_address is not null
+                    then 1
+                    else 0
+                end
+            ) as stablecoin_daily_txns
+        from stablecoin_transfers
+        group by 1, 2, 3, 4
+    )
+    , results_dollar_denom as (
+        select
+            stablecoin_metrics.date
+            , stablecoin_metrics.contract_address
+            , stablecoin_metrics.symbol
+            , from_address
+            , stablecoin_transfer_volume * coalesce(
+                d.token_current_price, 1
+            ) as stablecoin_transfer_volume
+            , stablecoin_daily_txns
+        from stablecoin_metrics
+        left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
+            on lower(stablecoin_metrics.contract_address) = lower(c.contract_address)
+        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+            on lower(c.coingecko_id) = lower(d.token_id)
+            and stablecoin_metrics.date = d.date::date
+    )
+    select
+        date
+        , from_address
+        , contract_address
+        , symbol
+        , stablecoin_transfer_volume
+        , stablecoin_daily_txns
+        , '{{ chain }}' as chain
+        , date || '-' || from_address || '-' || contract_address as unique_id
+    from results_dollar_denom
+    where date < to_date(sysdate())
+    {% if is_incremental() %} 
+        and block_timestamp >= (
+            select dateadd('day', -3, max(date))
+            from {{ this }}
+        )
+    {% endif %} 
+
+{% endmacro %}

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -1,0 +1,111 @@
+{% macro stablecoin_metrics_artemis(chain) %}
+with
+    stablecoin_transfers as (
+        select 
+            block_timestamp
+            , tx_hash
+            , from_address
+            , contract_address
+            , symbol
+            , transfer_volume
+            , to_address
+        from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
+        {% if is_incremental() %} 
+            where block_timestamp >= (
+                select dateadd('day', -3, max(date))
+                from {{ this }}
+            )
+        {% endif %} 
+    )
+    filtered_contracts as (
+        select * from {{ ref("dim_contracts_gold")}} where chain = '{{ chain }}'
+    ),
+    artemis_mev_filtered as (
+        select
+            st.*
+            , coalesce(dl.app,'other') as from_app
+            , coalesce(dlt.app,'other') as to_app
+            , coalesce(dl.sub_category,'other') as from_category
+            , coalesce(dlt.sub_category,'other') as to_category
+        from stablecoin_transfers st
+        left join filtered_contracts dl on lower(st.from_address) = lower(dl.address)
+        left join filtered_contracts dlt on lower(st.to_address) = lower(dlt.address)
+        where lower(from_app) != 'mev' or lower(to_app) != 'mev'
+    ),
+    artemis_cex_filters as (
+        select distinct tx_hash
+        from artemis_mev_filtered
+        where from_app = to_app
+            and lower(from_category) in ('exchange', 'market maker') 
+    ),
+    artemis_ranked_transfer_filter as (
+        select 
+            artemis_mev_filtered.*,
+            row_number() over (partition by tx_hash order by transfer_volume desc) AS rn
+        from artemis_mev_filtered
+        where tx_hash not in (select tx_hash from artemis_cex_filters)
+    ),
+    artemis_max_transfer_filter as (
+        select 
+            block_timestamp
+            , tx_hash
+            , contract_address
+            , symbol
+            , from_address
+            , to_address
+            , transfer_volume as artemis_stablecoin_transfer_volume
+        from artemis_ranked_transfer_filter
+        where rn = 1
+    ),
+    stablecoin_metrics as (
+        select
+            block_timestamp::date as date
+            , from_address
+            , contract_address
+            , symbol
+            , sum(
+                case
+                    when from_address is not null
+                    then 1
+                    else 0
+                end
+            ) as artemis_stablecoin_daily_txns
+            , sum(artemis_stablecoin_transfer_volume) as artemis_stablecoin_transfer_volume
+        from artemis_max_transfer_filter
+        group by 1, 2, 3, 4
+    ),
+    , results_dollar_denom as (
+        select
+            stablecoin_metrics.date
+            , stablecoin_metrics.contract_address
+            , stablecoin_metrics.symbol
+            , from_address
+            , stablecoin_transfer_volume * coalesce(
+                d.token_current_price, 1
+            ) as stablecoin_transfer_volume
+            , stablecoin_daily_txns
+        from stablecoin_metrics
+        left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
+            on lower(stablecoin_metrics.contract_address) = lower(c.contract_address)
+        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+            on lower(c.coingecko_id) = lower(d.token_id)
+            and stablecoin_metrics.date = d.date::date
+    )
+    select
+        date
+        , from_address
+        , contract_address
+        , symbol
+        , stablecoin_transfer_volume
+        , stablecoin_daily_txns
+        , '{{ chain }}' as chain
+        , date || '-' || from_address || '-' || contract_address as unique_id
+    from results_dollar_denom
+    where date < to_date(sysdate())
+    {% if is_incremental() %} 
+        and block_timestamp >= (
+            select dateadd('day', -3, max(date))
+            from {{ this }}
+        )
+    {% endif %} 
+{% endmacro %}

--- a/macros/stablecoins/stablecoin_metrics_p2p.sql
+++ b/macros/stablecoins/stablecoin_metrics_p2p.sql
@@ -1,0 +1,57 @@
+{% macro stablecoin_metrics_p2p(chain) %}
+with
+    stablecoin_transfers as (
+        select 
+            block_timestamp
+            , tx_hash
+            , from_address
+            , token_address as contract_address
+            , symbol
+            , amount_usd as transfer_volume
+            , to_address
+        from {{ ref("fact_" ~ chain ~ "_p2p_stablecoin_transfers")}} t
+        left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
+            on lower(t.token_address) = lower(c.contract_address)
+        {% if is_incremental() %} 
+            where block_timestamp >= (
+                select dateadd('day', -3, max(date))
+                from {{ this }}
+            )
+        {% endif %} 
+    )
+    , stablecoin_metrics as (
+        select
+            block_timestamp::date as date
+            , stablecoin_transfers.from_address::string as from_address
+            , stablecoin_transfers.contract_address as contract_address
+            , stablecoin_transfers.symbol as symbol
+            , sum(transfer_volume) as stablecoin_transfer_volume
+            , sum(
+                case
+                    when stablecoin_transfers.from_address is not null
+                    then 1
+                    else 0
+                end
+            ) as stablecoin_daily_txns
+        from stablecoin_transfers
+        group by 1, 2, 3, 4
+    )
+    
+    select
+        date
+        , from_address
+        , contract_address
+        , symbol
+        , stablecoin_transfer_volume
+        , stablecoin_daily_txns
+        , '{{ chain }}' as chain
+        , date || '-' || from_address || '-' || contract_address as unique_id
+    from stablecoin_metrics
+    where date < to_date(sysdate())
+    {% if is_incremental() %} 
+        and block_timestamp >= (
+            select dateadd('day', -3, max(date))
+            from {{ this }}
+        )
+    {% endif %} 
+{% endmacro %}

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -4,19 +4,33 @@ with
         {{
             dbt_utils.union_relations(
                 relations=[
-                    ref("agg_base_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_blast_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_arbitrum_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_optimism_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_avalanche_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_polygon_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_ethereum_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_tron_daily_stablecoin_metrics_breakdown"),
-                    ref("agg_bsc_daily_stablecoin_metrics_breakdown"),
+                    ref("ez_base_stablecoin_metrics_by_address"),
                 ]
             )
         }}
     )
-select *, date::string || '-' || chain || '-' || symbol || from_address || contract_address as unique_id
+select 
+    date
+    , from_address
+    , contract_name
+    , contract
+    , application
+    , icon
+    , app
+    , category
+    , is_wallet
+
+    , contract_address
+    , symbol
+
+    , stablecoin_transfer_volume
+    , stablecoin_daily_txns
+    , artemis_stablecoin_transfer_volume
+    , artemis_stablecoin_daily_txns
+    , p2p_stablecoin_transfer_volume
+    , p2p_stablecoin_daily_txns
+    , stablecoin_supply
+    , chain
+    , unique_id
 from daily_data
 where date < to_date(sysdate())

--- a/models/projects/base/core/ez_base_stablecoin_metrics_by_address.sql
+++ b/models/projects/base/core/ez_base_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        database="base",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("base")}}

--- a/models/staging/base/fact_base_stablecoin_balances.sql
+++ b/models/staging/base/fact_base_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("base")}}

--- a/models/staging/base/fact_base_stablecoin_metrics_all.sql
+++ b/models/staging/base/fact_base_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("base")}}

--- a/models/staging/base/fact_base_stablecoin_metrics_artemis.sql
+++ b/models/staging/base/fact_base_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("base")}}

--- a/models/staging/base/fact_base_stablecoin_metrics_p2p.sql
+++ b/models/staging/base/fact_base_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("base")}}


### PR DESCRIPTION
1. The marcos on the stablecoin v2 pipeline are not robust. If there is an issue with the data it can take > 15hrs to backfill. By splitting up the marcos it is also easier to edit the models and fix issues with different chains. 
2. i.e. Known issues of the old monolithic model: Stablecoin supply doesn't add up properly, Incremental run on macro table borks old data. 

These this structure relies on 5 models for each chain. We split up each filter to have its own macro (`all`, `artemis`, `p2p`) as well as give stablecoin supply and the final metrics its own marco. This makes is more robust to edit specific sections of the data.

I test these macros with `base`: https://app.artemis.xyz/stablecoins-v2. 

## To Do:
1. The marcos will need to be incremental, I will build this functionality out when we need it
2. Stablecoin balances for `optimism` and other chains will need to be fixed.