### PR TITLE
Stablecoin V2: Create Arbitrum Lineage, incremental `stablecoin_metrics`

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -16,6 +16,9 @@
                 {% endif %}
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_balances")}}
+            {% if is_incremental() %}
+                where date > (select dateadd('day', -3, max(date)) from {{ this }})
+            {% endif %}
         )
         , all_metrics as (
             select 
@@ -27,6 +30,9 @@
                 , stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_all")}}
+            {% if is_incremental() %}
+                where date > (select dateadd('day', -3, max(date)) from {{ this }})
+            {% endif %}
         )
         , artemis_metrics as (
             select 
@@ -38,6 +44,9 @@
                 , stablecoin_daily_txns as artemis_stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_artemis")}}
+            {% if is_incremental() %}
+                where date > (select dateadd('day', -3, max(date)) from {{ this }})
+            {% endif %}
         )
         , p2p_metrics as (
             select 
@@ -49,6 +58,9 @@
                 , stablecoin_daily_txns as p2p_stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_p2p")}}
+            {% if is_incremental() %}
+                where date > (select dateadd('day', -3, max(date)) from {{ this }})
+            {% endif %}
         )
         , chain_stablecoin_metrics as (
             select

--- a/models/projects/arbitrum/core/ez_arbitrum_stablecoin_metrics_by_address.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_stablecoin_metrics_by_address.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key="unique_id",
         database="arbitrum",
         schema="core",

--- a/models/projects/arbitrum/core/ez_arbitrum_stablecoin_metrics_by_address.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        database="arbitrum",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("arbitrum")}}

--- a/models/projects/base/core/ez_base_stablecoin_metrics_by_address.sql
+++ b/models/projects/base/core/ez_base_stablecoin_metrics_by_address.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key="unique_id",
         database="base",
         schema="core",

--- a/models/staging/arbitrum/fact_arbitrum_stablecoin_balances.sql
+++ b/models/staging/arbitrum/fact_arbitrum_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("arbitrum")}}

--- a/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_all.sql
+++ b/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("arbitrum")}}

--- a/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_artemis.sql
+++ b/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("arbitrum")}}

--- a/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_p2p.sql
+++ b/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="table",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("arbitrum")}}


### PR DESCRIPTION
1. Create the arbitrum lineage for the new stablecoin pipeline
2. Make the `stablecoin_metrics` macro incremental 

<img width="1373" alt="Screenshot 2024-07-18 at 3 47 05 PM" src="https://github.com/user-attachments/assets/bee71cdb-3311-425e-92c0-42bac370cc5f">
