### PR TITLE
Stablecoin V2: Tagging to Exchange --> CEX, Update P2P to Remove Intra-CEX

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -1,4 +1,5 @@
 {% macro stablecoin_metrics(chain) %}
+    {% set backfill_date = '' %}
     with
         stablecoin_supply as (
             select
@@ -19,6 +20,13 @@
             {% if is_incremental() %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
+            {% if backfill_date != '' %}
+                {% if is_incremental() %}
+                    and date < '{{ backfill_date }}'
+                {% else %}
+                    where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
         )
         , all_metrics as (
             select 
@@ -32,6 +40,13 @@
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_all")}}
             {% if is_incremental() %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
+            {% endif %}
+            {% if backfill_date != '' %}
+                {% if is_incremental() %}
+                    and date < '{{ backfill_date }}'
+                {% else %}
+                    where date < '{{ backfill_date }}'
+                {% endif %}
             {% endif %}
         )
         , artemis_metrics as (
@@ -47,6 +62,13 @@
             {% if is_incremental() %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
+            {% if backfill_date != '' %}
+                {% if is_incremental() %}
+                    and date < '{{ backfill_date }}'
+                {% else %}
+                    where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
         )
         , p2p_metrics as (
             select 
@@ -60,6 +82,13 @@
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_p2p")}}
             {% if is_incremental() %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
+            {% endif %}
+            {% if backfill_date != '' %}
+                {% if is_incremental() %}
+                    and date < '{{ backfill_date }}'
+                {% else %}
+                    where date < '{{ backfill_date }}'
+                {% endif %}
             {% endif %}
         )
         , chain_stablecoin_metrics as (
@@ -96,7 +125,7 @@
                 , filtered_contracts.app as app
                 , case 
                     when filtered_contracts.sub_category = 'Market Maker' then filtered_contracts.sub_category
-                    when filtered_contracts.sub_category = 'Exchange' then filtered_contracts.sub_category
+                    when filtered_contracts.sub_category = 'CEX' then filtered_contracts.sub_category
                     else filtered_contracts.category 
                 end as category
                 , case 

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -36,7 +36,7 @@ with
         select distinct tx_hash
         from artemis_mev_filtered
         where from_app = to_app
-            and lower(from_category) in ('exchange', 'market maker') 
+            and lower(from_category) in ('cex', 'market maker') 
     ),
     artemis_ranked_transfer_filter as (
         select 


### PR DESCRIPTION
1. Remove Intra-CEX from p2p Transfers. 
2. Also want Exchange to be more clear, change tagging to CEX rather than Exchange
## Test
<img width="1130" alt="Screenshot 2024-07-19 at 12 16 12 PM" src="https://github.com/user-attachments/assets/1e114c27-c314-4f98-8d6e-290247649d75">

<img width="1244" alt="Screenshot 2024-07-19 at 12 16 35 PM" src="https://github.com/user-attachments/assets/4f76416e-bfd9-4026-91f7-518a391e1a53">
