### PR TITLE
Stablecoin V2: Tron

### DIFF
--- a/models/projects/tron/core/ez_tron_stablecoin_metrics_by_address.sql
+++ b/models/projects/tron/core/ez_tron_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        database="tron",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("tron")}}

--- a/models/staging/tron/fact_tron_stablecoin_balances.sql
+++ b/models/staging/tron/fact_tron_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("tron")}}

--- a/models/staging/tron/fact_tron_stablecoin_metrics_all.sql
+++ b/models/staging/tron/fact_tron_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("tron")}}

--- a/models/staging/tron/fact_tron_stablecoin_metrics_artemis.sql
+++ b/models/staging/tron/fact_tron_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("tron")}}

--- a/models/staging/tron/fact_tron_stablecoin_metrics_p2p.sql
+++ b/models/staging/tron/fact_tron_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("tron")}}


### PR DESCRIPTION
1. The new stablecoin data relies on 5 different macros and files per chain.
    1. The filtered metric files: `stablecoin_metrics_p2p`, `stablecoin_metrics_artemis`, `stablecoin_metrics_all`
    2. The forward filled balances file: `stablecoin_balances`
    3. The final aggregated metric file: `stablecoin_metrics`
Stablecoin Pipeline:
<img width="910" alt="Screenshot 2024-07-22 at 8 56 34 AM" src="https://github.com/user-attachments/assets/d729a9ed-43fb-496a-b763-a752d1729503">

