### PR TITLE
P2P Tranfers: Tron

### DIFF
--- a/models/staging/tron/fact_tron_p2p_native_transfers.sql
+++ b/models/staging/tron/fact_tron_p2p_native_transfers.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key=["tx_hash", "index"],
     )
 }}

--- a/models/staging/tron/fact_tron_p2p_stablecoin_transfers.sql
+++ b/models/staging/tron/fact_tron_p2p_stablecoin_transfers.sql
@@ -1,7 +1,7 @@
 --depends_on: {{ ref("fact_tron_stablecoin_transfers") }}
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key=["tx_hash", "index"],
     )
 }}

--- a/models/staging/tron/fact_tron_p2p_token_transfers_silver.sql
+++ b/models/staging/tron/fact_tron_p2p_token_transfers_silver.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         unique_key=["tx_hash", "index"],
     )
 }}


### PR DESCRIPTION
1. Tron P2P transfer tables are doing a full refresh every time and taking > 1hr to run. These tables should be incremental. 
<img width="1316" alt="Screenshot 2024-07-22 at 10 49 17 PM" src="https://github.com/user-attachments/assets/1d9691b4-f066-40ed-a86a-bf341642298a">
