### PR TITLE
Stablecoin V2: Artemis Filter

### DIFF
--- a/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_artemis.sql
+++ b/models/staging/arbitrum/fact_arbitrum_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("arbitrum")}}
+{{stablecoin_metrics_artemis("arbitrum")}}

--- a/models/staging/avalanche/fact_avalanche_stablecoin_metrics_artemis.sql
+++ b/models/staging/avalanche/fact_avalanche_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("avalanche")}}
+{{stablecoin_metrics_artemis("avalanche")}}

--- a/models/staging/base/fact_base_stablecoin_metrics_artemis.sql
+++ b/models/staging/base/fact_base_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("base")}}
+{{stablecoin_metrics_artemis("base")}}

--- a/models/staging/ethereum/fact_ethereum_stablecoin_metrics_artemis.sql
+++ b/models/staging/ethereum/fact_ethereum_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("ethereum")}}
+{{stablecoin_metrics_artemis("ethereum")}}

--- a/models/staging/optimism/fact_optimism_stablecoin_metrics_artemis.sql
+++ b/models/staging/optimism/fact_optimism_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("optimism")}}
+{{stablecoin_metrics_artemis("optimism")}}

--- a/models/staging/polygon/fact_polygon_stablecoin_metrics_artemis.sql
+++ b/models/staging/polygon/fact_polygon_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("polygon")}}
+{{stablecoin_metrics_artemis("polygon")}}

--- a/models/staging/tron/fact_tron_stablecoin_metrics_artemis.sql
+++ b/models/staging/tron/fact_tron_stablecoin_metrics_artemis.sql
@@ -7,4 +7,4 @@
 }}
 
 
-{{stablecoin_metrics_p2p("tron")}}
+{{stablecoin_metrics_artemis("tron")}}


### PR DESCRIPTION
1. The artemis stablecoin metric files were using the wrong macro `stablecoin_metrics_p2p` --> `stablecoin_metrics_artemis`