### PR TITLE
Update naming of TON Metrics

### DIFF
--- a/models/staging/ton/fact_ton_daa_txns_gas_gas_usd_revenue_revenue_native.sql
+++ b/models/staging/ton/fact_ton_daa_txns_gas_gas_usd_revenue_revenue_native.sql
@@ -12,6 +12,3 @@ from {{ ref("fact_ton_txns")}} t1
 left join {{ ref("fact_ton_daa")}} t2 using(date)
 left join {{ ref("fact_ton_gas_gas_usd")}} t3 using(date)
 left join {{ ref("fact_ton_revenue_revenue_native")}} t4 using(date)
-
-
-    


### PR DESCRIPTION
## :pushpin: References

Switch from Ton Apps to just regularly named metrics in dbt model.

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
