### PR TITLE
Balances: Replace Nulls with Empty Strings

### DIFF
--- a/macros/address_balances/address_credits.sql
+++ b/macros/address_balances/address_credits.sql
@@ -1,5 +1,4 @@
 {% macro address_credits(chain, wrapped_native_token_address, native_token_address) %}
-
     select
         to_address as address,
         contract_address,
@@ -7,7 +6,7 @@
         cast(raw_amount as float) as credit,
         amount_usd as credit_usd,
         tx_hash,
-        '' as trace_index,
+        -1 as trace_index,
         event_index
     from {{ chain }}_flipside.core.ez_token_transfers
     where
@@ -17,6 +16,7 @@
             and block_timestamp
             >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
+        
 
     union all
 
@@ -28,7 +28,7 @@
         amount_usd as credit_usd,
         tx_hash,
         trace_index,
-        '' as event_index
+        -1 as event_index
     from {{ chain }}_flipside.core.ez_native_transfers
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -37,7 +37,7 @@
             and block_timestamp
             >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
-
+        
     {% if wrapped_native_token_address is defined %}
         union all
         select
@@ -47,7 +47,7 @@
             cast(decoded_log:"wad" as float) as credit,
             null as credit_usd,
             tx_hash,
-            '' as trace_index,
+            -1 as trace_index,
             event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where
@@ -73,8 +73,8 @@
             amount as credit,
             null as credit_usd,
             tx_hash,
-            '' as trace_index,
-            '' as event_index
+            -1 as trace_index,
+            -1 as event_index
         from ethereum_flipside.core.ez_native_transfers
         where to_address = lower('0x011B6E24FfB0B5f5fCc564cf4183C5BBBc96D515')
     {% endif %}
@@ -93,8 +93,8 @@
             cast(decoded_log:"amount" as float) / pow(10, 18) as credit,
             null as credit_usd,
             tx_hash,
-            '' as trace_index,
-            '' as event_index
+            -1 as trace_index,
+            -1 as event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where
             event_name = 'Deposit'

--- a/macros/address_balances/address_credits.sql
+++ b/macros/address_balances/address_credits.sql
@@ -7,7 +7,7 @@
         cast(raw_amount as float) as credit,
         amount_usd as credit_usd,
         tx_hash,
-        null as trace_index,
+        '' as trace_index,
         event_index
     from {{ chain }}_flipside.core.ez_token_transfers
     where
@@ -28,7 +28,7 @@
         amount_usd as credit_usd,
         tx_hash,
         trace_index,
-        null as event_index
+        '' as event_index
     from {{ chain }}_flipside.core.ez_native_transfers
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -47,7 +47,7 @@
             cast(decoded_log:"wad" as float) as credit,
             null as credit_usd,
             tx_hash,
-            null as trace_index,
+            '' as trace_index,
             event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where
@@ -73,8 +73,8 @@
             amount as credit,
             null as credit_usd,
             tx_hash,
-            null as trace_index,
-            null as event_index
+            '' as trace_index,
+            '' as event_index
         from ethereum_flipside.core.ez_native_transfers
         where to_address = lower('0x011B6E24FfB0B5f5fCc564cf4183C5BBBc96D515')
     {% endif %}
@@ -93,8 +93,8 @@
             cast(decoded_log:"amount" as float) / pow(10, 18) as credit,
             null as credit_usd,
             tx_hash,
-            null as trace_index,
-            null as event_index
+            '' as trace_index,
+            '' as event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where
             event_name = 'Deposit'

--- a/macros/address_balances/address_debits.sql
+++ b/macros/address_balances/address_debits.sql
@@ -7,8 +7,8 @@
         tx_fee * -1 as debit,
         null as debit_usd,
         tx_hash,
-        null as trace_index,
-        null as event_index
+        '' as trace_index,
+        '' as event_index
     from {{ chain }}_flipside.core.fact_transactions as t
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -27,7 +27,7 @@
         cast(raw_amount * -1 as float) as debit,
         amount_usd * -1 as debit_usd,
         tx_hash,
-        null as trace_index,
+        '' as trace_index,
         event_index
     from {{ chain }}_flipside.core.ez_token_transfers
     where
@@ -48,7 +48,7 @@
         amount_usd * -1 as debit_usd,
         tx_hash,
         trace_index,
-        null as event_index
+        '' as event_index
     from {{ chain }}_flipside.core.ez_native_transfers
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -68,7 +68,7 @@
             cast(decoded_log:"wad" as float) * -1 as debit,
             null as debit_usd,
             tx_hash,
-            null as trace_index,
+            '' as trace_index,
             event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where

--- a/macros/address_balances/address_debits.sql
+++ b/macros/address_balances/address_debits.sql
@@ -7,8 +7,8 @@
         tx_fee * -1 as debit,
         null as debit_usd,
         tx_hash,
-        '' as trace_index,
-        '' as event_index
+        -1 as trace_index,
+        -1 as event_index
     from {{ chain }}_flipside.core.fact_transactions as t
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -27,7 +27,7 @@
         cast(raw_amount * -1 as float) as debit,
         amount_usd * -1 as debit_usd,
         tx_hash,
-        '' as trace_index,
+        -1 as trace_index,
         event_index
     from {{ chain }}_flipside.core.ez_token_transfers
     where
@@ -48,7 +48,7 @@
         amount_usd * -1 as debit_usd,
         tx_hash,
         trace_index,
-        '' as event_index
+        -1 as event_index
     from {{ chain }}_flipside.core.ez_native_transfers
     where
         to_date(block_timestamp) < to_date(sysdate())
@@ -68,7 +68,7 @@
             cast(decoded_log:"wad" as float) * -1 as debit,
             null as debit_usd,
             tx_hash,
-            '' as trace_index,
+            -1 as trace_index,
             event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where


### PR DESCRIPTION
### Summary: 
All of our balances tables have duplicate rows. I have re-run op with a complete refresh and still today there are duplicate rows existing in the table. DBT does not allow for a column that creates a unique key to be null, otherwise it is not able to determine the unique rows
    This shows how the balances table for base has duplicate rows:
<img width="1178" alt="Screenshot 2024-07-23 at 4 42 00 PM" src="https://github.com/user-attachments/assets/ba25fa50-1452-453c-95f7-1dd2d63534ce">


2. In order to fix this I change the nulls in the credit and debits tables to empty strings. Going forward for all incremental tables it may be worth it to start using a single row representing the unique key (i.e. md5(<column1> || <column2> || ...) ) or using surrogate keys (https://docs.getdbt.com/blog/sql-surrogate-keys) (https://github.com/dbt-labs/dbt-utils?tab=readme-ov-file#generate_surrogate_key-source). This will ensure that there is a single column that has a unique key.
