### PR TITLE
Stablecoin V2: Polygon Address Credits and Ethereum

### DIFF
--- a/macros/address_balances/address_credits.sql
+++ b/macros/address_balances/address_credits.sql
@@ -1,4 +1,5 @@
 {% macro address_credits(chain, wrapped_native_token_address, native_token_address) %}
+    
     select
         to_address as address,
         contract_address,
@@ -17,7 +18,6 @@
             >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         
-
     union all
 
     select
@@ -38,7 +38,7 @@
             >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         
-    {% if wrapped_native_token_address is defined %}
+    {% if wrapped_native_token_address is defined and chain not in ('polygon')%}
         union all
         select
             decoded_log:"dst"::string as address,
@@ -77,6 +77,7 @@
             -1 as event_index
         from ethereum_flipside.core.ez_native_transfers
         where to_address = lower('0x011B6E24FfB0B5f5fCc564cf4183C5BBBc96D515')
+
     {% endif %}
 
     -- Some EVM Chains has a specific contract address for their native token (polygon) 
@@ -94,7 +95,7 @@
             null as credit_usd,
             tx_hash,
             -1 as trace_index,
-            -1 as event_index
+            event_index
         from {{ chain }}_flipside.core.ez_decoded_event_logs
         where
             event_name = 'Deposit'
@@ -105,6 +106,7 @@
                 and block_timestamp
                 >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
             {% endif %}
+
     {% endif %}
 -- Not included is staking fees (need to do more research and would be chains specific)
 {% endmacro %}

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -9,8 +9,6 @@ with
                     ref("ez_optimism_stablecoin_metrics_by_address"),
                     ref("ez_avalanche_stablecoin_metrics_by_address"),
                     ref("ez_ethereum_stablecoin_metrics_by_address"),
-                    ref("ez_polygon_stablecoin_metrics_by_address"),
-                    ref("ez_tron_stablecoin_metrics_by_address"),
                 ]
             )
         }}


### PR DESCRIPTION
## Summary
1. Add `ethereum` to final stablecoin v2 metrics table
2. Fix Polygon address credits:
Polygon deposits of the wrapped token are already included in the ez_token_transfers. Run sql below to verify:
```
select 
    block_timestamp
    ,tx_hash
    ,event_index
    , contract_address
    , decoded_log
    , null from_address
    ,null to_address
    ,null amount
    ,null amount_precise
from polygon_flipside.core.ez_decoded_event_logs 
where event_name ='Deposit' and  tx_hash = '0xe3542014a72ed6ce39f3678aaa49aeb0a92c094492e1f3b702372b61c6814981'
union all
select 
    block_timestamp
    ,tx_hash
    ,event_index
    , contract_address
    , null as decoded_log
    , from_address
    ,to_address
    ,amount
    ,amount_precise
from polygon_flipside.core.ez_token_transfers
    where tx_hash = '0xe3542014a72ed6ce39f3678aaa49aeb0a92c094492e1f3b702372b61c6814981'
    and event_index = 480
```