### PR TITLE
Stablecoin V2: Tron and Ethereum Balances

### DIFF
--- a/macros/address_balances/address_credits_allium.sql
+++ b/macros/address_balances/address_credits_allium.sql
@@ -20,6 +20,7 @@
             and block_timestamp
             >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
+
     union all
     select
         to_address as address,
@@ -37,9 +38,10 @@
         {% endif %}
         {% if is_incremental() %}
             and block_timestamp
-            >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         and to_date(block_timestamp) < to_date(sysdate())
         and to_address <> from_address
+
 
 {% endmacro %}

--- a/macros/address_balances/address_debits_allium.sql
+++ b/macros/address_balances/address_debits_allium.sql
@@ -17,7 +17,7 @@
         and to_date(block_timestamp) < to_date(sysdate())
         {% if is_incremental() %}
             and block_timestamp
-            >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         and to_address <> from_address
     union all
@@ -38,7 +38,7 @@
         and to_date(block_timestamp) < to_date(sysdate())
         {% if is_incremental() %}
             and block_timestamp
-            >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         and to_address <> from_address
 

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -8,7 +8,6 @@ with
                     ref("ez_arbitrum_stablecoin_metrics_by_address"),
                     ref("ez_optimism_stablecoin_metrics_by_address"),
                     ref("ez_avalanche_stablecoin_metrics_by_address"),
-                    ref("ez_ethereum_stablecoin_metrics_by_address"),
                     ref("ez_polygon_stablecoin_metrics_by_address"),
                 ]
             )

--- a/models/staging/tron/fact_tron_address_credit_by_token.sql
+++ b/models/staging/tron/fact_tron_address_credit_by_token.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        unique_key=["unique_id"],
+        unique_key="unique_id",
         snowflake_warehouse="BALANCES_LG",
     )
 }}

--- a/models/staging/tron/fact_tron_address_debit_by_token.sql
+++ b/models/staging/tron/fact_tron_address_debit_by_token.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        unique_key=["unique_id"],
+        unique_key="unique_id",
         snowflake_warehouse="BALANCES_LG",
     )
 }}


### PR DESCRIPTION
1. Tron credits and debits tables had duplicates. In order to fix this I changed how dbt recognized the unique key and full refreshed all the tron tables
2. DAI within the maker protocol does not follow the traditional ERC20 standard. Instead the account system is done in the `vat`. This is the supply that is in the Dai Savings in this query: https://dune.com/queries/54599/108371. We have historically been under counting the total supply of DAI by about 2 billion. 
3. I am also removing ethereum from the final metric table because I have to re-backfill the balances which will most likely not be done by the time the job runs tonight.
<img width="1027" alt="Screenshot 2024-07-25 at 5 47 37 PM" src="https://github.com/user-attachments/assets/d0410971-13af-450d-80e0-c8ce76bdba1a">
