### PR TITLE
added ton stablecoin transfers symbol using url

### DIFF
--- a/models/staging/ton/fact_ton_stablecoin_transfers.sql
+++ b/models/staging/ton/fact_ton_stablecoin_transfers.sql
@@ -16,6 +16,7 @@ with raw_data as (
         , source_json:"from_type"::string as from_type
         , source_json:"to_address"::string as to_address
         , source_json:"to_type"::string as to_type
+        , source_json:"url"::string as url
         , source_json:"decimals"::int as decimal
         , source_json:"symbol"::string as symbol
     from
@@ -34,7 +35,7 @@ select
     , max_by(to_address, extraction_date) as to_address
     , max_by(to_type, extraction_date) as to_type
     , max_by(decimal, extraction_date) as decimal
-    , case when max_by(symbol, extraction_date) = 'USD₮' then 'USDT' else max_by(symbol, extraction_date) end as symbol
+    , case when (max_by(symbol, extraction_date) = 'USD₮' or max_by(url, extraction_date) = 'https://tether.to/usdt-ton.json')  then 'USDT' else max_by(symbol, extraction_date) end as symbol
 from raw_data
 where 
     from_address is not null and 


### PR DESCRIPTION
## :pushpin: References

Ton apps sometimes does not have symbols. Using url instead to verify that its tether. 

## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [x] `Compiles` in Github
- [x] `Show Changed Models` in Github matches expectations for what metric value should be
