### PR TITLE
Stablecoin V2: Tron and Solana

### DIFF
--- a/macros/address_balances/address_balances_by_token.sql
+++ b/macros/address_balances/address_balances_by_token.sql
@@ -22,6 +22,26 @@
                     where block_timestamp > (select max(block_timestamp) from {{ this }})
                 {% endif %}
             {% endif %}
+            {% if chain in ('tron') %}
+            -- TRON USDT supply for the address below is negative to begin with, this means its first transfer is out 
+            -- not in, the data at the beginning of tron is pretty iffy and the block explorer seems to fail the closer you
+            -- get to the genesis block. it is only max negative by $10 over its history so I am giving it an inital supply of 10000000/1e6 USDT
+            -- https://tronscan.org/#/tools/advanced-filter?type=transfer&secondType=20&times=1530417600000%2C1556769599999&fromAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&toAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&token=TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t&imgUrl=https%3A%2F%2Fstatic.tronscan.org%2Fproduction%2Flogo%2Fusdtlogo.png&tokenName=Tether%20USD&tokenAbbr=USDT&relation=or
+                union all
+                select  address, contract_address, block_timestamp, flow
+                from (
+                    values
+                        (
+                            'THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC'
+                            , 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t'
+                            , '2019-04-16 07:00:00.000'::timestamp
+                            , 10000000
+                        )
+                    ) as t(address, contract_address, block_timestamp, flow)
+                {% if is_incremental() %}
+                    where block_timestamp > (select max(block_timestamp) from {{ this }})
+                {% endif %}
+            {% endif %}
             
         ),
         credit_debits_and_latest_balances as (

--- a/models/staging/solana/fact_solana_stablecoin_balances.sql
+++ b/models/staging/solana/fact_solana_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("solana")}}


### PR DESCRIPTION
1. A single `tron` address has a negative balance of about $10 at maximum. This is because its first transfer is out rather than in. In order to fix this, I am adding 100000/1E6 to `THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC` 
2. Solana Token Balances are very far off. Instead of doing digging into what is causing it (Not sure it is worth the time), I am switching us over to rely on `flipside` similar to what we do for Ethereum. For stablecoins see the image below but we are over counting by a significant amount.  <img width="771" alt="Screenshot 2024-07-31 at 2 15 03 PM" src="https://github.com/user-attachments/assets/6ea3bcf0-53c6-4f3c-9ecf-ca087ad5534e">
