### PR TITLE
Stablecoin V2: Solana and Clustering

### DIFF
--- a/macros/address_balances/address_balances_by_token.sql
+++ b/macros/address_balances/address_balances_by_token.sql
@@ -26,6 +26,7 @@
             -- TRON USDT supply for the address below is negative to begin with, this means its first transfer is out 
             -- not in, the data at the beginning of tron is pretty iffy and the block explorer seems to fail the closer you
             -- get to the genesis block. it is only max negative by $10 over its history so I am giving it an inital supply of 10000000/1e6 USDT
+            -- THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC is the contract creator
             -- https://tronscan.org/#/tools/advanced-filter?type=transfer&secondType=20&times=1530417600000%2C1556769599999&fromAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&toAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&token=TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t&imgUrl=https%3A%2F%2Fstatic.tronscan.org%2Fproduction%2Flogo%2Fusdtlogo.png&tokenName=Tether%20USD&tokenAbbr=USDT&relation=or
                 union all
                 select  address, contract_address, block_timestamp, flow

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -11,11 +11,11 @@ with
     stablecoin_balances as (
         select 
             block_timestamp
-            , lower(t1.contract_address) as contract_address
+            , t1.contract_address
             , symbol
-            , lower(address) as address
+            , address
             {% if chain in ('solana') %}
-                , amount_unadj / pow(10, num_decimals) as stablecoin_supply
+                , amount as stablecoin_supply
             {% else %}
                 , balance_token / pow(10, num_decimals) as stablecoin_supply
             {% endif %}

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="table") }}
+{{ config(materialized="table", cluster_by=['chain']) }}
 select
     date
     , contract_address

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -10,6 +10,7 @@ with
                     ref("ez_avalanche_stablecoin_metrics_by_address"),
                     ref("ez_polygon_stablecoin_metrics_by_address"),
                     ref("ez_ethereum_stablecoin_metrics_by_address"),
+                    ref("ez_solana_stablecoin_metrics_by_address"),
                 ]
             )
         }}

--- a/models/projects/solana/core/ez_solana_stablecoin_metrics_by_address.sql
+++ b/models/projects/solana/core/ez_solana_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        database="solana",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("solana")}}

--- a/models/staging/solana/fact_solana_stablecoin_metrics_all.sql
+++ b/models/staging/solana/fact_solana_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("solana")}}

--- a/models/staging/solana/fact_solana_stablecoin_metrics_artemis.sql
+++ b/models/staging/solana/fact_solana_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_artemis("solana")}}

--- a/models/staging/solana/fact_solana_stablecoin_metrics_p2p.sql
+++ b/models/staging/solana/fact_solana_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("solana")}}


### PR DESCRIPTION
1. Adding `solana` stablecoin models
2. Adding clustering to the final Stablecoin Table. This should help with response times on the frontend. If this does not speed it up fast enough then we may want to create new breakdown tables or cluster by other keys:
https://docs.snowflake.com/en/user-guide/tables-clustering-keys#benefits-of-defining-clustering-keys-for-very-large-tables