### PR TITLE
Stablecoin V2: BSC and Pricing

### DIFF
--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -135,12 +135,12 @@ with
             , st.symbol
             , stablecoin_supply as stablecoin_supply_native
             , stablecoin_supply * coalesce(
-                d.token_current_price, 1
+                d.shifted_token_price_usd, 1
             ) as stablecoin_supply
         from historical_supply_by_address_balances st
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
                 on lower(st.contract_address) = lower(c.contract_address)
-        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+        left join {{ ref( "fact_coingecko_token_date_adjusted_gold") }} d
             on lower(c.coingecko_id) = lower(d.token_id)
             and st.date = d.date::date
     )

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -41,13 +41,13 @@ with
             , stablecoin_metrics.symbol
             , from_address
             , stablecoin_transfer_volume * coalesce(
-                d.token_current_price, 1
+                d.shifted_token_price_usd, 1
             ) as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
             on lower(stablecoin_metrics.contract_address) = lower(c.contract_address)
-        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+        left join {{ ref( "fact_coingecko_token_date_adjusted_gold") }} d
             on lower(c.coingecko_id) = lower(d.token_id)
             and stablecoin_metrics.date = d.date::date
     )

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -81,13 +81,13 @@ with
             , stablecoin_metrics.symbol
             , from_address
             , stablecoin_transfer_volume * coalesce(
-                d.token_current_price, 1
+                d.shifted_token_price_usd, 1
             ) as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
             on lower(stablecoin_metrics.contract_address) = lower(c.contract_address)
-        left join {{ ref( "fact_coingecko_token_realtime_data") }} d
+        left join {{ ref( "fact_coingecko_token_date_adjusted_gold") }} d
             on lower(c.coingecko_id) = lower(d.token_id)
             and stablecoin_metrics.date = d.date::date
     )

--- a/models/staging/bsc/fact_bsc_p2p_stablecoin_transfers.sql
+++ b/models/staging/bsc/fact_bsc_p2p_stablecoin_transfers.sql
@@ -1,0 +1,9 @@
+--depends_on: {{ ref("fact_bsc_stablecoin_transfers") }}
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+    )
+}}
+
+{{ p2p_stablecoin_transfers("bsc") }}

--- a/models/staging/bsc/fact_bsc_stablecoin_balances.sql
+++ b/models/staging/bsc/fact_bsc_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("bsc")}}

--- a/models/staging/bsc/fact_bsc_stablecoin_metrics_all.sql
+++ b/models/staging/bsc/fact_bsc_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("bsc")}}

--- a/models/staging/bsc/fact_bsc_stablecoin_metrics_artemis.sql
+++ b/models/staging/bsc/fact_bsc_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_artemis("bsc")}}

--- a/models/staging/bsc/fact_bsc_stablecoin_metrics_p2p.sql
+++ b/models/staging/bsc/fact_bsc_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("bsc")}}


### PR DESCRIPTION
1. Fix Stablecoin Pricing by using historical coingecko pricing table rather than real time table
2. Add BSC balances, and metric tables. 

To do: 
1. Finish backing filling BSC on prod
2. create `ez_bsc_stablecoin` table