### PR TITLE
Fidelity: AAVE

### DIFF
--- a/macros/lending/aave_deposits_borrows_lender_revenue.sql
+++ b/macros/lending/aave_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,95 @@
+{% macro aave_deposits_borrows_lender_revenue(chain, protocol, contract_address, raw_table, healed_raw_table) %}
+with
+    unioned as (
+        --Earlier this year aave data was borked. In order to heal the data without doing a complete backfill
+        --we pull from the older avve tables. The extract logic is the exact same as the current table (raw_table)
+        {% if healed_raw_table is defined %}
+            select *
+            from landing_database.prod_landing.{{healed_raw_table}}
+            union all
+        {% endif %}
+        select *
+        from {{ source("PROD_LANDING", raw_table) }}
+    ),
+    dates as (
+        select
+            extraction_date,
+            to_timestamp(trunc(flat_json.value:"day"::timestamp, 'day')) as date
+        from unioned t1, lateral flatten(input => parse_json(source_json)) as flat_json
+        group by date, extraction_date
+    ),
+    max_extraction_per_day as (
+        select date, max(extraction_date) as extraction_date
+        from dates
+        group by date
+        order by date
+    ),
+    flattened_json as (
+        select
+            extraction_date,
+            to_timestamp(trunc(flat_json.value:"day"::timestamp, 'day')) as date,
+            flat_json.value:"underlying_token"::string as underlying_token,
+            flat_json.value:"underlying_token_price"::float as underlying_token_price,
+            flat_json.value:"borrows"::float as borrows,
+            flat_json.value:"borrows_usd"::float as borrows_usd,
+            flat_json.value:"supply"::float as supply,
+            flat_json.value:"supply_usd"::float as supply_usd
+        from unioned, lateral flatten(input => parse_json(source_json)) as flat_json
+    ),
+    map_reduce_json as (
+        select t1.*
+        from flattened_json t1
+        left join max_extraction_per_day t2 on t1.date = t2.date
+        where t1.extraction_date = t2.extraction_date
+    )
+    , average_liquidity_rate as (
+        select
+            block_timestamp::date as date
+            , decoded_log:reserve::string as reserve
+            , min_by(decoded_log:liquidityIndex::float / 1e27, block_timestamp) as first_liquidity_index
+            , max_by(decoded_log:liquidityIndex::float / 1e27, block_timestamp) as last_liquidity_index
+        from {{ chain }}_flipside.core.ez_decoded_event_logs
+        where contract_address = lower('{{ contract_address }}')
+            and event_name = 'ReserveDataUpdated'
+        group by 1, 2
+    )
+    , liquidity_daily_rate as (
+        select
+            date
+            , reserve
+            , first_liquidity_index
+            , last_liquidity_index
+            , (last_liquidity_index / first_liquidity_index) - 1 as daily_rate
+        from average_liquidity_rate
+    )
+    , data as (
+        select 
+            map_reduce_json.date
+            , reserve
+            , underlying_token_price
+            , underlying_token
+            , supply
+            , supply_usd
+            , coalesce(supply_usd * daily_rate, 0) as revenue
+            , borrows
+            , borrows_usd
+        from map_reduce_json
+        left join liquidity_daily_rate 
+            on map_reduce_json.date = liquidity_daily_rate.date
+            and lower(map_reduce_json.underlying_token) = lower(liquidity_daily_rate.reserve)
+        order by date 
+    )
+select 
+    date
+    , underlying_token as token_address
+    , '{{ chain }}' as chain
+    , '{{ protocol }}' as app
+    , avg(underlying_token_price) as underlying_token_price
+    , sum(borrows) as borrows
+    , sum(borrows_usd) as borrows_usd
+    , sum(supply) as supply
+    , sum(supply_usd) as supply_usd
+    , sum(revenue) as revenue
+from data
+group by 1, 2
+{% endmacro %}

--- a/macros/lending/aave_ecosystem_incentives.sql
+++ b/macros/lending/aave_ecosystem_incentives.sql
@@ -1,0 +1,69 @@
+{% macro aave_v3_ecosystem_incentives(chain, contract_address, protocol) %}
+with
+event_logs as(
+    select 
+        block_timestamp
+        , decoded_log:amount::float as amount
+        , decoded_log:reward::string as asset
+    from {{chain}}_flipside.core.ez_decoded_event_logs
+    where contract_address = lower('{{contract_address}}')
+        and event_name = 'RewardsClaimed'
+)
+, event_logs_priced as (
+    select 
+        block_timestamp::date as date
+        , asset
+        , amount / pow(10, decimals) as amount_nominal
+        , amount_nominal * price as amount_usd
+    from  event_logs
+    left join {{chain}}_flipside.price.ez_prices_hourly p
+        on date_trunc(hour, block_timestamp) = hour
+        and lower(asset) = lower(token_address)
+)
+select
+    date
+    , '{{chain}}' as chain
+    , '{{protocol}}' as protocol
+    , asset as token_address
+    , sum(coalesce(amount_nominal, 0)) as amount_nominal
+    , sum(coalesce(amount_usd, 0)) as amount_usd
+from event_logs_priced
+group by 1, 4
+{% endmacro %}
+
+{% macro aave_v2_ecosystem_incentives(chain, contract_address, protocol) %}
+with
+event_logs as (
+    select 
+        block_timestamp
+        , case 
+            when '{{chain}}' = 'etherum' then '0x4da27a545c0c5B758a6BA100e3a049001de870f5' 
+            when '{{chain}}' = 'avalanche' then '0x63a72806098Bd3D9520cC43356dD78afe5D386D9'
+            else '0x63a72806098Bd3D9520cC43356dD78afe5D386D9'
+        end as asset
+        , decoded_log:amount::float as amount
+    from ethereum_flipside.core.ez_decoded_event_logs
+    where contract_address = lower('{{contract_address}}')
+        and event_name = 'RewardsClaimed'
+)
+, prices as ({{get_coingecko_price_with_latest('aave')}})
+, event_logs_priced as (
+    select 
+        block_timestamp::date as date
+        , asset as token_address
+        , amount
+        , amount / 1E18 as amount_nominal
+        , amount_nominal * price as amount_usd
+    from  event_logs
+    left join prices on block_timestamp::date = date
+)
+select
+    date
+    , '{{chain}}' as chain
+    , '{{protocol}}' as protocol
+    , token_address
+    , sum(coalesce(amount_nominal, 0)) as amount_nominal
+    , sum(coalesce(amount_usd, 0)) as amount_usd
+from event_logs_priced
+group by 1, 4
+{% endmacro %}

--- a/macros/lending/aave_reserve_factor_revenue.sql
+++ b/macros/lending/aave_reserve_factor_revenue.sql
@@ -1,0 +1,78 @@
+{% macro aave_v3_reserve_factor_revenue(chain, contract_address, protocol) %}
+with
+revenue_events as (
+    select 
+        block_timestamp
+        , decoded_log:reserve::string as token_address
+        , decoded_log:amountMinted::float as amount
+    from {{chain}}_flipside.core.ez_decoded_event_logs
+    where contract_address = lower('{{contract_address}}')
+        and event_name = 'MintedToTreasury'
+        and block_timestamp >= '2024-06-08'
+        and block_timestamp < '2024-07-28'
+)
+, revenue_events_usd as (
+    select
+        block_timestamp::date as date
+        , revenue_events.token_address
+        , (amount / pow(10, decimals)) as amount_nominal
+        , amount_nominal * price as amount_usd
+    from revenue_events
+    left join {{chain}}_flipside.price.ez_prices_hourly p
+        on date_trunc(hour, block_timestamp) = hour 
+        and lower(revenue_events.token_address) = lower(p.token_address)
+)
+
+select 
+    date
+    , token_address
+    , sum(coalesce(amount_nominal, 0)) as reserve_factor_revenue_nominal
+    , sum(coalesce(amount_usd, 0)) as reserve_factor_revenue_usd
+from revenue_events_usd
+where date < to_date(sysdate())
+group by 1, 2
+{% endmacro %}
+
+
+{% macro aave_v2_reserve_factor_revenue(chain, contract_address, protocol) %}
+with
+    dim_streams as (
+        select distinct
+            decoded_log:streamId::number as stream_id
+            , decoded_log:tokenAddress::string as token_address
+        from {{chain}}_flipside.core.ez_decoded_event_logs
+        where contract_address = lower('{{contract_address}}')
+            and event_name = 'CreateStream'
+    )
+    , withdraw_from_stream_events as (
+        select
+            block_timestamp
+            , decoded_log:streamId::number as stream_id
+            , decoded_log:amount::float as amount
+        from {{chain}}_flipside.core.ez_decoded_event_logs
+        where contract_address = lower('{{contract_address}}')
+            and event_name = 'WithdrawFromStream'
+    )
+    , protocol_revenue as (
+        select
+            withdraw_from_stream_events.block_timestamp
+            , dim_streams.token_address
+            , coalesce(amount / pow(10, decimals), 0) as amount_nominal
+            , coalesce(amount_nominal * price, 0) as amount_usd
+        from withdraw_from_stream_events
+        left join dim_streams on dim_streams.stream_id = withdraw_from_stream_events.stream_id
+        left join {{chain}}_flipside.price.ez_prices_hourly p
+            on date_trunc(hour, block_timestamp) = hour 
+            and lower(dim_streams.token_address) = lower(p.token_address)
+    )
+select
+    block_timestamp::date as date
+    , '{{chain}}' as chain
+    , '{{protocol}}' as protocol
+    , token_address
+    , sum(coalesce(amount_nominal, 0)) as reserve_factor_revenue_nominal
+    , sum(coalesce(amount_usd, 0)) as reserve_factor_revenue_usd
+from protocol_revenue
+where date < to_date(sysdate())
+group by 1, 4
+{% endmacro %}

--- a/models/projects/aave/__aave__sources.yml
+++ b/models/projects/aave/__aave__sources.yml
@@ -15,3 +15,5 @@ sources:
       - name: raw_aave_v3_harmony_borrows_deposits_revenue
       - name: raw_aave_v3_metis_borrows_deposits_revenue
       - name: raw_aave_v3_base_borrows_deposits_revenue
+      - name: raw_aave_v3_gnosis_borrows_deposits_revenue
+      - name: raw_aave_v3_bsc_borrows_deposits_revenue

--- a/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_arbitrum_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('arbitrum', 'AAVE V3', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'raw_aave_v3_arbitrum_borrows_deposits_revenue', 'raw_aave_v3_lending_arbitrum')}}

--- a/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_arbitrum_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('arbitrum', '0x929EC64c34a17401F460460D4B9390518E5B473e', 'AAVE V3')}}

--- a/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/arbitrum/fact_aave_v3_arbitrum_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_arbitrum_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('arbitrum', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'AAVE V3')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_avalanche_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('avalanche', 'AAVE V2', '0x4F01AeD16D97E3aB5ab2B501154DC9bb0F1A5A2C', 'raw_aave_v2_avalanche_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_avalanche_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v2_ecosystem_incentives('avalanche', '0x01D83Fe6A10D2f2B7AF17034343746188272cAc9', 'AAVE V2')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v2_avalanche_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_avalanche_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v2_reserve_factor_revenue('avalanche', '0x467b92aF281d14cB6809913AD016a607b5ba8A36', 'AAVE V2')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_avalanche_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('avalanche', 'AAVE V3', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'raw_aave_v3_avalanche_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_avalanche_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('avalanche', '0x929EC64c34a17401F460460D4B9390518E5B473e', 'AAVE V3')}}

--- a/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/avalanche/fact_aave_v3_avalanche_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_avalanche_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('avalanche', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'AAVE V3')}}

--- a/models/projects/aave/raw/base/fact_aave_v3_base_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/base/fact_aave_v3_base_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_base_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('base', 'AAVE V3', '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5', 'raw_aave_v3_base_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/base/fact_aave_v3_base_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/base/fact_aave_v3_base_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_base_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('base', '0xf9cc4F0D883F1a1eb2c253bdb46c254Ca51E1F44', 'AAVE V3')}}

--- a/models/projects/aave/raw/base/fact_aave_v3_base_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/base/fact_aave_v3_base_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_base_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('base', '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5', 'AAVE V3')}}

--- a/models/projects/aave/raw/bsc/fact_aave_v3_bsc_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/bsc/fact_aave_v3_bsc_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_bsc_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('bsc', 'AAVE V3', '0x6807dc923806fE8Fd134338EABCA509979a7e0cB', 'raw_aave_v3_bsc_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/bsc/fact_aave_v3_bsc_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/bsc/fact_aave_v3_bsc_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_bsc_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('bsc', '0xC206C2764A9dBF27d599613b8F9A63ACd1160ab4', 'AAVE V3')}}

--- a/models/projects/aave/raw/bsc/fact_aave_v3_bsc_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/bsc/fact_aave_v3_bsc_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_bsc_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('bsc', '0x6807dc923806fE8Fd134338EABCA509979a7e0cB', 'AAVE V3')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_dao_balancer_trading_fees.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_dao_balancer_trading_fees.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_dao_balancer_trading_fees",
+    )
+}}
+
+with
+swaps as (
+    select 
+        block_timestamp
+        , decoded_log:tokenIn::string as token_address
+        , decoded_log:tokenAmountIn::float * 0.001 as amount
+    from ethereum_flipside.core.ez_decoded_event_logs 
+    where contract_address = lower('0xC697051d1C6296C24aE3bceF39acA743861D9A81') 
+        and event_name = 'LOG_SWAP'
+)
+, swap_revenue as (
+    select
+        block_timestamp::date as date
+        , swaps.token_address
+        , coalesce(amount / pow(10, decimals), 0) as amount_nominal
+        , coalesce(amount_nominal * price, 0) as amount_usd
+    from swaps
+    left join ethereum_flipside.price.ez_prices_hourly p
+        on date_trunc(hour, block_timestamp) = hour 
+        and lower(swaps.token_address) = lower(p.token_address)
+)
+select
+    date
+    , token_address
+    , 'AAVE DAO' as protocol
+    , 'ethereum' as chain
+    , sum(coalesce(amount_nominal, 0)) as trading_fees_nominal
+    , sum(coalesce(amount_usd, 0)) as trading_fees_usd
+from swap_revenue 
+where date < to_date(sysdate())
+group by 1, 2
+order by 1 desc

--- a/models/projects/aave/raw/ethereum/fact_aave_dao_safety_incentives.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_dao_safety_incentives.sql
@@ -1,0 +1,38 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_dao_safety_incentives",
+    )
+}}
+
+with 
+    logs as (
+        select 
+            block_timestamp
+            , decoded_log:amount::float / 1E18 as amount_nominal
+        from ethereum_flipside.core.ez_decoded_event_logs 
+        where contract_address = lower('0x4da27a545c0c5B758a6BA100e3a049001de870f5')
+            and event_name = 'RewardsClaimed'
+    )
+    , prices as ({{get_coingecko_price_with_latest('aave')}})
+    , priced_logs as (
+        select
+            block_timestamp::date as date
+            , '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9' as token_address
+            , amount_nominal
+            , amount_nominal * price as amount_usd
+        from logs
+        left join price on block_timestamp::date = date
+    )
+select
+    date
+    , token_address
+    , 'AAVE DAO' as protocol
+    , 'ethereum' as chain
+    , sum(coalesce(amount_nominal, 0)) as amount_nominal
+    , sum(coalesce(amount_usd, 0)) as amount_usd
+from priced_logs
+group by 1, 2

--- a/models/projects/aave/raw/ethereum/fact_aave_gho_treasury_revenue.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_gho_treasury_revenue.sql
@@ -1,0 +1,41 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_gho_treasury_revenue",
+    )
+}}
+
+with
+event_logs as (
+    select 
+        block_timestamp
+        , '0x' || substr(topics[2]::string, 27, 40) as asset
+        , pc_dbt_db.prod.hex_to_int(data) as amount
+    from ethereum_flipside.core.fact_event_logs 
+    where contract_address = lower('0x00907f9921424583e7ffBfEdf84F92B7B2Be4977')
+        and topics[0]::string = '0xb29fcda740927812f5a71075b62e132bead3769a455319c29b9a1cc461a65475'
+)
+, priced_logs as (
+    select
+        block_timestamp::date as date
+        , asset
+        , amount / pow(10, decimals) as amount_nominal
+        , amount_nominal * price as amount_usd
+    from event_logs
+    left join ethereum_flipside.price.ez_prices_hourly
+        on date_trunc(hour, block_timestamp) = hour
+        and lower(asset) = lower(token_address)
+)
+select
+    date
+    , 'AAVE GHO' as protocol
+    , 'ethereum' as chain
+    , asset as token_address
+    , sum(coalesce(amount_nominal, 0)) as amount_nominal
+    , sum(coalesce(amount_usd, 0)) as amount_usd
+from priced_logs
+group by 1, 4
+order by 1 desc

--- a/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_ethereum_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('ethereum', 'AAVE V2', '0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9', 'raw_aave_v2_ethereum_borrows_deposits_revenue', 'raw_aave_v2_lending_ethereum')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_ethereum_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v2_ecosystem_incentives('ethereum', '0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5', 'AAVE V2')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v2_ethereum_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_ethereum_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v2_reserve_factor_revenue('ethereum', '0x464C71f6c2F760DdA6093dCB91C24c39e5d6e18c', 'AAVE V2')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_ethereum_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('ethereum', 'AAVE V3', '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2', 'raw_aave_v3_ethereum_borrows_deposits_revenue', 'raw_aave_v3_lending_ethereum')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_ethereum_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('ethereum', '0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb', 'AAVE V3')}}

--- a/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/ethereum/fact_aave_v3_ethereum_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_ethereum_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('ethereum', '0x87870Bca3F3fD6335C3F4ce8392D69350B4fA4E2', 'AAVE V3')}}

--- a/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_gnosis_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('gnosis', 'AAVE V3', '0xb50201558B00496A145fE76f7424749556E326D8', 'raw_aave_v3_ethereum_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_gnosis_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('gnosis', '0xaD4F91D26254B6B0C6346b390dDA2991FDE2F20d', 'AAVE V3')}}

--- a/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/gnosis/fact_aave_v3_gnosis_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_gnosis_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('gnosis', '0xb50201558B00496A145fE76f7424749556E326D8', 'AAVE V3')}}

--- a/models/projects/aave/raw/optimism/fact_aave_v3_optimism_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/optimism/fact_aave_v3_optimism_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_optimism_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('optimism', 'AAVE V3', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'raw_aave_v3_optimism_borrows_deposits_revenue')}}

--- a/models/projects/aave/raw/optimism/fact_aave_v3_optimism_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/optimism/fact_aave_v3_optimism_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_optimism_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('optimism', '0x929EC64c34a17401F460460D4B9390518E5B473e', 'AAVE V3')}}

--- a/models/projects/aave/raw/optimism/fact_aave_v3_optimism_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/optimism/fact_aave_v3_optimism_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_optimism_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('optimism', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'AAVE V3')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v2_polygon_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v2_polygon_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_polygon_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('polygon', 'AAVE V2', '0x8dff5e27ea6b7ac08ebfdf9eb090f32ee9a30fcf', 'raw_aave_v2_polygon_borrows_deposits_revenue', 'raw_aave_v2_lending_polygon')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v2_polygon_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v2_polygon_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_polygon_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v2_ecosystem_incentives('polygon', '0x357D51124f59836DeD84c8a1730D72B749d8BC23', 'AAVE V2')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v2_polygon_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v2_polygon_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v2_poylgon_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v2_reserve_factor_revenue('polygon', '0xe8599F3cc5D38a9aD6F3684cd5CEa72f10Dbc383', 'AAVE V2')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v3_polygon_deposits_borrows_lender_revenue.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v3_polygon_deposits_borrows_lender_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_polygon_deposits_borrows_lender_revenue",
+    )
+}}
+
+{{ aave_deposits_borrows_lender_revenue('polygon', 'AAVE V3', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'raw_aave_v3_polygon_borrows_deposits_revenue', 'raw_aave_v3_lending_polygon')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v3_polygon_ecosystem_incentives.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v3_polygon_ecosystem_incentives.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_polygon_ecosystem_incentives",
+    )
+}}
+
+{{ aave_v3_ecosystem_incentives('polygon', '0x929EC64c34a17401F460460D4B9390518E5B473e', 'AAVE V3')}}

--- a/models/projects/aave/raw/polygon/fact_aave_v3_polygon_reserve_factor_revenue.sql
+++ b/models/projects/aave/raw/polygon/fact_aave_v3_polygon_reserve_factor_revenue.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="AAVE",
+        database="aave",
+        schema="raw",
+        alias="fact_v3_polygon_reserve_factor_revenue",
+    )
+}}
+
+{{ aave_v3_reserve_factor_revenue('polygon', '0x794a61358D6845594F94dc1DB02A252b5b4814aD', 'AAVE V3')}}


### PR DESCRIPTION
Adding the following for AAVE
1. Lending, Borrow and Deposit Revenue by pool
2. Ecosystem Incentives
3. GHO Data
4. Safety Incentives
5. Reserve Revenue

This PR must merge with `https://github.com/Artemis-xyz/gokustats-back-end/pull/2275` PR since in references assets created in the backend repo specifically the above PR.

## Test
Testing the macro for lending and borrows
<img width="1314" alt="Screenshot 2024-08-05 at 10 43 38 AM" src="https://github.com/user-attachments/assets/dc174342-0714-4025-a939-22892976f695">
