### PR TITLE
Optimize Coingecko Realtime Query

### DIFF
--- a/models/data_hubs/fact_coingecko_token_realtime_datahub.sql
+++ b/models/data_hubs/fact_coingecko_token_realtime_datahub.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="table", snowflake_warehouse="PROD_REALTIME_DATAHUB") }}
+{{ config(materialized="table", snowflake_warehouse="X_SMALL") }}
 select *
 from {{ ref("fact_coingecko_token_realtime_data") }}

--- a/models/staging/coingecko/fact_coingecko_token_realtime_data.sql
+++ b/models/staging/coingecko/fact_coingecko_token_realtime_data.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="table", snowflake_warehouse="PROD_REALTIME_DATAHUB") }}
+{{ config(materialized="table", snowflake_warehouse="X_SMALL") }}
 with
     realtime_token_data as (
         select extraction_date::date as date, parse_json(source_json) as data


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists
- Comparing row counts between new and old queries 
- Switch `PROD_REALTIME_DATAHUB` wh to `XS`
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/9638d920-0383-4ccb-baa0-bc5288e76cf0">
- Can delete this warehouse as well

Old vs. new query
![image](https://github.com/user-attachments/assets/8e1460eb-0ec5-4656-9786-67b28a335d82)
![image](https://github.com/user-attachments/assets/0611441e-5be1-4959-bbbc-fb9a8787ff06)


## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
