### PR TITLE
Stablecoin V2: BSC

### DIFF
--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -12,6 +12,7 @@ with
                     ref("ez_ethereum_stablecoin_metrics_by_address"),
                     ref("ez_solana_stablecoin_metrics_by_address"),
                     ref("ez_tron_stablecoin_metrics_by_address"),
+                    ref("ez_bsc_stablecoin_metrics_by_address"),
                 ]
             )
         }}

--- a/models/projects/bsc/core/ez_bsc_stablecoin_metrics_by_address.sql
+++ b/models/projects/bsc/core/ez_bsc_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        database="bsc",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("bsc")}}


### PR DESCRIPTION
1. Adding BSC final table to silver table

To do:
1. Run `ez_bsc_table`