### PR TITLE
Turned Data Freshness to error instead of warn

### DIFF
--- a/models/staging/sui/_test_fact_sui_transactions.yml
+++ b/models/staging/sui/_test_fact_sui_transactions.yml
@@ -12,4 +12,3 @@
         - dbt_expectations.expect_row_values_to_have_recent_data:
             datepart: day
             interval: 3
-            severity: warn


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
