### PR TITLE
Remove Blast stablecoin from data pipeline

### DIFF
--- a/models/metrics/stablecoins/breakdowns/daily/agg_blast_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_blast_stablecoin_breakdown_daily.sql
@@ -1,5 +1,0 @@
--- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
--- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
--- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
-{{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
-{{ agg_chain_stablecoin_breakdown("blast", "day") }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_stablecoin_breakdown_daily.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_stablecoin_breakdown_daily.sql
@@ -7,7 +7,6 @@ with
                     ref("agg_arbitrum_stablecoin_breakdown_daily"),
                     ref("agg_avalanche_stablecoin_breakdown_daily"),
                     ref("agg_base_stablecoin_breakdown_daily"),
-                    ref("agg_blast_stablecoin_breakdown_daily"),
                     ref("agg_bsc_stablecoin_breakdown_daily"),
                     ref("agg_celo_stablecoin_breakdown_daily"),
                     ref("agg_ethereum_stablecoin_breakdown_daily"),

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_blast_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_blast_stablecoin_breakdown_monthly.sql
@@ -1,5 +1,0 @@
--- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
--- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
--- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
-{{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
-{{ agg_chain_stablecoin_breakdown("blast", "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_stablecoin_breakdown_monthly.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_stablecoin_breakdown_monthly.sql
@@ -7,7 +7,6 @@ with
                     ref("agg_arbitrum_stablecoin_breakdown_monthly"),
                     ref("agg_avalanche_stablecoin_breakdown_monthly"),
                     ref("agg_base_stablecoin_breakdown_monthly"),
-                    ref("agg_blast_stablecoin_breakdown_monthly"),
                     ref("agg_bsc_stablecoin_breakdown_monthly"),
                     ref("agg_celo_stablecoin_breakdown_monthly"),
                     ref("agg_ethereum_stablecoin_breakdown_monthly"),

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_blast_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_blast_stablecoin_breakdown_weekly.sql
@@ -1,5 +1,0 @@
--- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
--- depends_on: {{ ref('fact_blast_address_balances_by_token') }}
--- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
-{{ config(materialized="table", snowflake_warehouse="STABLECOIN_LG_2") }}
-{{ agg_chain_stablecoin_breakdown("blast", "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_stablecoin_breakdown_weekly.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_stablecoin_breakdown_weekly.sql
@@ -7,7 +7,6 @@ with
                     ref("agg_arbitrum_stablecoin_breakdown_weekly"),
                     ref("agg_avalanche_stablecoin_breakdown_weekly"),
                     ref("agg_base_stablecoin_breakdown_weekly"),
-                    ref("agg_blast_stablecoin_breakdown_weekly"),
                     ref("agg_bsc_stablecoin_breakdown_weekly"),
                     ref("agg_celo_stablecoin_breakdown_weekly"),
                     ref("agg_ethereum_stablecoin_breakdown_weekly"),

--- a/models/metrics/stablecoins/metrics/agg_blast_stablecoin_metrics.sql
+++ b/models/metrics/stablecoins/metrics/agg_blast_stablecoin_metrics.sql
@@ -1,3 +1,0 @@
--- depends_on: {{ ref('fact_blast_stablecoin_contracts') }}
--- depends_on: {{ ref('fact_blast_stablecoin_transfers') }}
-{{ config(materialized="table") }} {{ agg_chain_stablecoin_metrics("blast") }}

--- a/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics_silver.sql
+++ b/models/metrics/stablecoins/metrics/agg_daily_stablecoin_metrics_silver.sql
@@ -7,7 +7,6 @@ with
                     ref("agg_arbitrum_stablecoin_metrics"),
                     ref("agg_avalanche_stablecoin_metrics"),
                     ref("agg_base_stablecoin_metrics"),
-                    ref("agg_blast_stablecoin_metrics"),
                     ref("agg_bsc_stablecoin_metrics"),
                     ref("agg_celo_stablecoin_metrics"),
                     ref("agg_ethereum_stablecoin_metrics"),

--- a/models/projects/blast/core/ez_blast_metrics.sql
+++ b/models/projects/blast/core/ez_blast_metrics.sql
@@ -12,7 +12,6 @@
 with
     fundamental_data as ({{ get_fundamental_data_for_chain("blast") }}),
     defillama_data as ({{ get_defillama_metrics("blast") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("blast") }}),
     contract_data as ({{ get_contract_metrics("blast") }}),
     -- NOTE, this says l1 data cost, but that's inaccurate
     -- its both data and execution cost, but I'm following convention for now and we don't publish 

--- a/models/staging/blast/agg_blast_daily_stablecoin_metrics_breakdown.sql
+++ b/models/staging/blast/agg_blast_daily_stablecoin_metrics_breakdown.sql
@@ -1,9 +1,0 @@
-{{
-    config(
-        materialized="incremental",
-        unique_key=["date", "contract_address", "from_address"],
-        snowflake_warehouse="STABLECOIN_V2_LG_2",
-    )
-}}
-
-{{ agg_daily_stablecoin_metrics_breakdown("blast") }}


### PR DESCRIPTION
## :pushpin: References

Remove Blast Stablecoin from our Stablecoin v2 pipeline:
daily, weekly, monthly breakdown
aggregated daily blast data
we will still have the fact_blast_stablecoin_transfers + fact_blast_address_balances if we ever want to build v2. 

Data will be stale until we put it back in our stablecoin pipeline. 

production is affected (no data is showing) but it doesnt crash the front end! 


https://app.artemis.xyz/stablecoins?chain=blast

<img width="1911" alt="Screenshot 2024-08-08 at 2 21 31 PM" src="https://github.com/user-attachments/assets/cb62ff78-749d-4576-952c-462c5d4a1cac">


## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
