### PR TITLE
Stablecoin V2: Fixing cKES metrics

### DIFF
--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -68,7 +68,7 @@ with
                 t1.to_address,
                 t1.amount,
                 coalesce(
-                    pc_dbt_db.prod.FACT_COINGECKO_TOKEN_DATE_ADJUSTED_GOLD.shifted_token_price_usd * transfer_volume, 1 * transfer_volume
+                    pc_dbt_db.prod.FACT_COINGECKO_TOKEN_DATE_ADJUSTED_GOLD.shifted_token_price_usd * transfer_volume, case when pc_dbt_db.prod.FACT_{{ chain }}_STABLECOIN_CONTRACTS.coingecko_id = 'celo-kenyan-shilling' then 0.0077 else 1 end * transfer_volume
                 ) as amount_usd
             from stablecoin_transfers t1
             join pc_dbt_db.prod.FACT_{{ chain }}_STABLECOIN_CONTRACTS 

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -143,7 +143,11 @@ with
             , st.symbol
             , stablecoin_supply as stablecoin_supply_native
             , stablecoin_supply * coalesce(
-                d.shifted_token_price_usd, 1
+                d.shifted_token_price_usd, 
+                case 
+                    when lower(c.coingecko_id) = lower('celo-kenyan-shilling') then 0.0077 
+                    else 1 
+                end
             ) as stablecoin_supply
         from historical_supply_by_address_balances st
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -45,7 +45,7 @@ with
             , stablecoin_metrics.symbol
             , from_address
             , stablecoin_transfer_volume * coalesce(
-                d.shifted_token_price_usd, 1
+                d.shifted_token_price_usd, case when c.coingecko_id = 'celo-kenyan-shilling' then 0.0077 else 1 end
             ) as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -85,7 +85,7 @@ with
             , stablecoin_metrics.symbol
             , from_address
             , stablecoin_transfer_volume * coalesce(
-                d.shifted_token_price_usd, 1
+                d.shifted_token_price_usd, case when c.coingecko_id = 'celo-kenyan-shilling' then 0.0077 else 1 end
             ) as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics


### PR DESCRIPTION
1. cKES does not have pricing for every day. This is an issue because based on our stablecoin logic we assume when no price the value is 1 dollar. In order to fix this, i make cKES set to the average price for all the days that we have data for. This is hardcoded for now. As we add more stablecoins we may be able to calculate this dynamically. I would say this is not worth it to do it now.


<img width="1083" alt="Screenshot 2024-08-08 at 7 22 09 PM" src="https://github.com/user-attachments/assets/c89f9777-6e5d-4aa0-bcfd-cba3c3fbc3c8">

<img width="1008" alt="Screenshot 2024-08-08 at 7 23 25 PM" src="https://github.com/user-attachments/assets/9e5c9ad5-dec7-4758-a790-6e5a4b8a33e0">
