### PR TITLE
Fixing cKES pricing on v1 tables

### DIFF
--- a/macros/stablecoins/agg_chain_stablecoin_breakdown.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_breakdown.sql
@@ -127,12 +127,20 @@
                 category,
                 results.symbol,
                 stablecoin_transfer_volume * coalesce(
-                    fact_coingecko_token_realtime_data.token_current_price, 1
+                    fact_coingecko_token_realtime_data.token_current_price,
+                    case 
+                        when lower(fact_{{ chain }}_stablecoin_contracts.coingecko_id) = lower('celo-kenyan-shilling') then 0.0077 
+                        else 1 
+                    end
                 ) as stablecoin_transfer_volume,
                 stablecoin_daily_txns,
                 stablecoin_dau,
                 stablecoin_supply * coalesce(
-                    fact_coingecko_token_realtime_data.token_current_price, 1
+                    fact_coingecko_token_realtime_data.token_current_price, 
+                    case 
+                        when lower(fact_{{ chain }}_stablecoin_contracts.coingecko_id) = lower('celo-kenyan-shilling') then 0.0077 
+                        else 1 
+                    end
                 ) as stablecoin_supply,
                 chain
             from results

--- a/macros/stablecoins/agg_chain_stablecoin_metrics.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_metrics.sql
@@ -67,7 +67,11 @@
                 -- TODO: Refactor to support weird currencies. Currently assumes
                 -- everything is $1 if not found
                 coalesce(
-                    fact_coingecko_token_date_adjusted_gold.shifted_token_price_usd, 1
+                    fact_coingecko_token_date_adjusted_gold.shifted_token_price_usd, 
+                    case 
+                        when lower(fact_{{ chain }}_stablecoin_contracts.coingecko_id) = lower('celo-kenyan-shilling') then 0.0077 
+                        else 1 
+                    end
                 ) as price,
                 total_supply * price as total_supply,
                 txns,


### PR DESCRIPTION
1. Added cKES to stablecoin v1 but pricing does not exist everyday
2. In order to fix this we calculated the average over the entire time range manually. Going forward we can change this from a hard code to more dynamic