### PR TITLE
C911: Removing Same Chain Inflows and outflows

### DIFF
--- a/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
+++ b/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
@@ -88,3 +88,4 @@ select
     || category as unique_id
 from unioned
 where date < to_date(sysdate())
+    and source_chain != destination_chain


### PR DESCRIPTION
Because of across sometimes the destination chain can equal the source chain. This should be removed from the flows page because the value is not leaving a particular chain.