### PR TITLE
Paypal: Adding Dim Contracts to Art Share 

### DIFF
--- a/models/common/dim_contracts.sql
+++ b/models/common/dim_contracts.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        snowflake_warehouse="COMMON",
+        database="common",
+        schema="core",
+        materialized='view'
+    )
+}}
+
+
+select
+    *
+from {{ref("dim_contracts_gold")}}


### PR DESCRIPTION
1. Paypal is using hex and needs access for dim_contracts_gold. Adding a view in the common database