### PR TITLE
Solana P2P Token Transfers

### DIFF
--- a/macros/p2p/filter_p2p_token_transfers.sql
+++ b/macros/p2p/filter_p2p_token_transfers.sql
@@ -31,7 +31,7 @@
                         swap_from_amount_usd as amount_in_usd
                     from solana_flipside.defi.ez_dex_swaps t1
                     where (swap_from_amount_usd is not null and swap_to_amount_usd is not null) 
-                        and (swap_from_amount_usd <> 0 and swap_to_amount_usd <> 0) and
+                        and (swap_from_amount_usd <> 0 and swap_to_amount_usd <> 0)
                         and abs(
                             ln(coalesce(nullif(swap_from_amount_usd, 0), 1)) / ln(10)
                             - ln(coalesce(nullif(swap_to_amount_usd, 0), 1)) / ln(10)

--- a/macros/p2p/filter_p2p_token_transfers.sql
+++ b/macros/p2p/filter_p2p_token_transfers.sql
@@ -28,10 +28,10 @@
                     select 
                         t1.swap_from_mint as token_in, 
                         t1.swap_to_mint as token_out,
-                        swap_from_amount_usd as amount_in_usd
+                        sum(swap_from_amount_usd) as amount_in_usd
                     from solana_flipside.defi.ez_dex_swaps t1
                     where (swap_from_amount_usd is not null and swap_to_amount_usd is not null) 
-                        and (swap_from_amount_usd <> 0 and swap_to_amount_usd <> 0)
+                        and (swap_from_amount_usd > 0 and swap_to_amount_usd > 0)
                         and abs(
                             ln(coalesce(nullif(swap_from_amount_usd, 0), 1)) / ln(10)
                             - ln(coalesce(nullif(swap_to_amount_usd, 0), 1)) / ln(10)


### PR DESCRIPTION
1. Fixing sql errors in solana p2p token transfers filter after flipside changed the schema