### PR TITLE
Paypal: EZ Token Transfers Solana and Ethereum

### DIFF
--- a/macros/transfers/get_token_transfer_filtered.sql
+++ b/macros/transfers/get_token_transfer_filtered.sql
@@ -1,56 +1,135 @@
-{% macro get_token_transfer_filtered(chain, limit_number=1000, blacklist=('')) %}
+{% macro get_token_transfer_filtered(chain, limit_number=1000, blacklist=(''), whitelist=(''), include_full_history="FALSE" ) %}
 With
-    dex_swap_liquidity_pairs as (-- all pairs with non-zero liquidity
-        select distinct
-            token_in, 
-            token_out,
-            sum(amount_in_usd) as amount_in_usd
-        from {{ chain }}_flipside.defi.ez_dex_swaps 
-        where (amount_in_usd is not null and amount_out_usd is not null) and
-            (amount_in_usd > 0 and amount_out_usd > 0) and
-            abs(
-                ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
-                - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)
-            )
-            < 1
-        group by token_in, token_out
-        order by amount_in_usd desc
-        limit {{ limit_number }}
-    ),
-    tokens as (
-        select distinct token_in as token
-        from {{ chain }}_flipside.defi.ez_dex_swaps 
-        where lower(token_in) in (select lower(token_in) from dex_swap_liquidity_pairs)
-        union
-        select distinct token_out as token
-        from {{ chain }}_flipside.defi.ez_dex_swaps 
-        where lower(token_out) in (select lower(token_out) from dex_swap_liquidity_pairs)
-    )
-    select 
-        block_timestamp,
-        block_number,
-        tx_hash,
-        event_index as index,
-        from_address,
-        to_address,
-        amount_precise as amount,
-        contract_address as token_address,
-        amount_usd
-    from {{ chain }}_flipside.core.ez_token_transfers
-    where 
-        amount_usd is not null 
-            and token_address in (select token from tokens) 
+    {% if chain == "solana" %}
+        dex_swap_liquidity_pairs as (
+            select 
+                t1.swap_from_mint as token_in, 
+                t1.swap_to_mint as token_out,
+                sum(swap_from_amount_usd) as amount_in_usd
+            from solana_flipside.defi.ez_dex_swaps t1
+            where (swap_from_amount_usd is not null and swap_to_amount_usd is not null) 
+                and (swap_from_amount_usd > 0 and swap_to_amount_usd > 0)
+                and abs(
+                    ln(coalesce(nullif(swap_from_amount_usd, 0), 1)) / ln(10)
+                    - ln(coalesce(nullif(swap_to_amount_usd, 0), 1)) / ln(10)
+                )
+                < 1
+                group by token_in, token_out
+                order by amount_in_usd desc
+                limit {{ limit_number }}
+        )
+        , tokens as (
+            select distinct swap_from_mint as token
+            from solana_flipside.defi.ez_dex_swaps
+            where lower(swap_from_mint) in (select lower(token_in) from dex_swap_liquidity_pairs)
+            union
+            select distinct swap_to_mint as token
+            from solana_flipside.defi.ez_dex_swaps
+            where lower(swap_to_mint) in (select lower(token_out) from dex_swap_liquidity_pairs)
+            {% if whitelist is string %}
+                union 
+                select '{{ whitelist }}' as token
+            {% elif whitelist | length > 1 %}
+                union
+                select distinct token_address as token
+                from values {{whitelist}} as t(token_address)
+            {% endif %}
+        )
+        , token_prices as (
+            select
+                hour::date as date,
+                token_address,
+                avg(price) as price
+            from solana_flipside.price.ez_prices_hourly
+            group by date, token_address
+        ) 
+        select 
+            t2.block_timestamp,
+            t1.block_id as block_number,
+            t1.tx_id as tx_hash,
+            t1.index,
+            t1.tx_from as from_address,
+            t1.tx_to as to_address,
+            t1.amount,
+            mint as token_address,
+            coalesce(amount * price, 0) as amount_usd
+        from solana_flipside.core.fact_transfers t1
+        inner join solana_flipside.core.fact_blocks t2 using(block_id)
+        left join token_prices t5 on t1.mint = t5.token_address and t2.block_timestamp::date = t5.date
+        where mint <> 'So11111111111111111111111111111111111111112'
+            {% if include_full_history=="FALSE" %}
+                and t1.tx_from != t1.tx_to
+                and lower(t1.tx_from) != lower('1nc1nerator11111111111111111111111111111111') -- Burn address of solana
+                and lower(t1.tx_to) != lower('1nc1nerator11111111111111111111111111111111')
+            {% endif %}
+            {% if is_incremental() %} 
+                and block_timestamp >= (
+                    select dateadd('day', -3, max(block_timestamp))
+                    from {{ this }}
+                )
+            {% endif %}
+    {% else %}
+        dex_swap_liquidity_pairs as (-- all pairs with non-zero liquidity
+            select distinct
+                token_in, 
+                token_out,
+                sum(amount_in_usd) as amount_in_usd
+            from {{ chain }}_flipside.defi.ez_dex_swaps 
+            where (amount_in_usd is not null and amount_out_usd is not null) and
+                (amount_in_usd > 0 and amount_out_usd > 0) and
+                abs(
+                    ln(coalesce(nullif(amount_in_usd, 0), 1)) / ln(10)
+                    - ln(coalesce(nullif(amount_out_usd, 0), 1)) / ln(10)
+                )
+                < 1
+            group by token_in, token_out
+            order by amount_in_usd desc
+            limit {{ limit_number }}
+        )
+        , tokens as (
+            select distinct token_in as token
+            from {{ chain }}_flipside.defi.ez_dex_swaps 
+            where lower(token_in) in (select lower(token_in) from dex_swap_liquidity_pairs)
+            union
+            select distinct token_out as token
+            from {{ chain }}_flipside.defi.ez_dex_swaps 
+            where lower(token_out) in (select lower(token_out) from dex_swap_liquidity_pairs)
+            {% if whitelist is string %}
+                union 
+                select '{{ whitelist }}' as token
+            {% elif whitelist | length > 1 %}
+                union
+                select distinct token_address as token
+                from values {{whitelist}} as t(token_address)
+            {% endif %}
+            
+        )
+        select 
+            block_timestamp,
+            block_number,
+            tx_hash,
+            event_index as index,
+            from_address,
+            to_address,
+            amount_precise as amount,
+            contract_address as token_address,
+            amount_usd
+        from {{ chain }}_flipside.core.ez_token_transfers
+        where token_address in (select token from tokens) 
             {% if blacklist is string %} and lower(token_address) != lower('{{ blacklist }}')
             {% elif blacklist | length > 1 %} and token_address not in {{ blacklist }} --make sure you pass in lower
             {% endif %}
-        and to_address != from_address 
-        and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
-        and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
-        {% if is_incremental() %} 
-            and block_timestamp >= (
-                select dateadd('day', -3, max(block_timestamp))
-                from {{ this }}
-            )
-        {% endif %}
-
+            {% if include_full_history=="FALSE" %}
+                and amount_usd is not null 
+                and to_address != from_address 
+                and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+                and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
+            {% endif %}
+            {% if is_incremental() %} 
+                and block_timestamp >= (
+                    select dateadd('day', -3, max(block_timestamp))
+                    from {{ this }}
+                )
+            {% endif %}
+    {% endif %}
 {% endmacro %}

--- a/models/projects/ethereum/raw/ez_ethereum_token_transfers.sql
+++ b/models/projects/ethereum/raw/ez_ethereum_token_transfers.sql
@@ -1,0 +1,46 @@
+{{
+    config(
+        materialized="table",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="ETHEREUM",
+        database="ethereum",
+        schema="raw",
+        alias="ez_token_transfers",
+    )
+}}
+
+{{ 
+    get_token_transfer_filtered(
+        'ethereum'
+        , limit_number=300
+        , blacklist=(
+            "0x130914e1b240a7f4c5d460b7d3a2fd3846b576fa",
+            "0x087b81c5312bcb45179a05aff5aec5cdddc789b6",
+            "0x62cc7d1790e5a9470be22ae9f14065cbfe44bf10",
+            "0xddb3422497e61e13543bea06989c0789117555c5",
+            "0x630d98424efe0ea27fb1b3ab7741907dffeaad78",
+            "0x8c3ee4f778e282b59d42d693a97b80b1ed80f4ee",
+            "0x3f7aff0ef20aa2e646290dfa4e67611b2220c597",
+            "0xc89b4a8a121dd3e726fe7515e703936cf83e3350",
+            "0xbd4b2dd8fbcecb2af5904ff5f218037b0f693275",
+            "0x4d67edef87a5ff910954899f4e5a0aaf107afd42",
+            "0x84fa8f52e437ac04107ec1768764b2b39287cb3e",
+            "0xa2253b08b04a61441c0cba8e83226ac4f69405b7",
+            "0x33d6064f0dfb62462a74049f30909ddd4f683ba2",
+            "0x432d03d11a324b90ba14141d4bc75b68d2350bb8",
+            "0x04a5198063e45d84b1999516d3228167146417a6",
+            "0x15f20f9dfdf96ccf6ac96653b7c0abfe4a9c9f0f",
+            "0xdfef6416ea3e6ce587ed42aa7cb2e586362cbbfa",
+            "0xbe77212a6c7f55567470c2c95aff7b0b0e0c3ef5",
+            "0xd2b274cfbf9534f56b59ad0fb7e645e0354f4941",
+            "0x2b591e99afe9f32eaa6214f7b7629768c40eeb39",
+            "0xba12222222228d8ba445958a75a0704d566bf2c8"
+        )
+        , whitelist=(
+            "0xc5f0f7b66764f6ec8c8dff7ba683102295e16409",
+            "0x0c10bf8fcb7bf5412187a595ab97a3609160b5c6",
+            "0x853d955acef822db058eb8505911ed77f175b99e"
+        )
+        , include_full_history="TRUE"
+    ) 
+}}

--- a/models/projects/solana/raw/ez_solana_token_transfers.sql
+++ b/models/projects/solana/raw/ez_solana_token_transfers.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+        snowflake_warehouse="SOLANA",
+        database="solana",
+        schema="raw",
+        alias="ez_token_transfers",
+    )
+}}
+
+{{ 
+    get_token_transfer_filtered(
+        'solana'
+        , limit_number=200
+        , blacklist=(
+            "o1Mw5Y3n68o8TakZFuGKLZMGjm72qv4JeoZvGiCLEvK", 
+            "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt",
+            "GiBrdw1tF8nuJxWuhTp83ULEMY9uJkYUHQUBzwfEnw5R",
+            "B584xmGMbrJz2FewT6fxNx64vQ74zrbQijHHijszSa7K",
+            "NLBLjgKvSVtiporRdVEcyssTyr5oPRmjeajVJ4EGW9B"
+        )
+        , include_full_history="TRUE"
+    ) 
+}}


### PR DESCRIPTION
1. Updating filtered token transfers to have full data including mint and burns
2. Adding `ez_token_transfers` for ethereum and solana