### PR TITLE
Fixing Starknet

### DIFF
--- a/models/staging/starknet/fact_starknet_transactions.sql
+++ b/models/staging/starknet/fact_starknet_transactions.sql
@@ -58,6 +58,6 @@ left join prices on raw_date = prices.date and curr = t1.actual_fee_unit
 where coalesce(t1.sender_address_hex, t1.contract_address_hex) is not null
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and t2.block_timestamp
+        and t1.block_time
         >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
     {% endif %}


### PR DESCRIPTION
1. Starknet incremental run is borked because it is looking at a column that does not exist: `block_timestamp`
https://artemis.dagster.cloud/prod/runs/8d3d6051-dd72-406a-bcc8-3074efbdff4a?logFileKey=moyhrvtu&selection=%22run_dbt_d2c55%22&logs=query%3A%22run_dbt_d2c55%22

<img width="1512" alt="Screenshot 2024-08-20 at 9 31 37 AM" src="https://github.com/user-attachments/assets/de7c57c8-ecb0-4de0-8846-01afcad4f1b4">
