### PR TITLE
Stablecoin V2: Celo Stablecoin Supply

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -12,7 +12,7 @@
                         when lower(address) in (select lower(premint_address) from {{ref("fact_"~chain~"_stablecoin_bridge_addresses")}}) then 0
                         else stablecoin_supply
                     end as stablecoin_supply
-                {% elif chain in ('solana') %}
+                {% elif chain in ('solana', 'celo') %}
                     , case
                         when 
                             lower(address) in (select lower(premint_address) from {{ref("fact_"~chain~"_stablecoin_premint_addresses")}}) then 0

--- a/models/metrics/stablecoins/contracts/fact_celo_stablecoin_premint_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_celo_stablecoin_premint_addresses.sql
@@ -1,0 +1,12 @@
+{{ config(materialized="table") }}
+-- Premint addresses for ethereum are representative of USDT that has been bridged to other L2s
+select contract_address, premint_address
+from
+    (
+        values
+            -- Un-released Supply 
+            (
+                '0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e',
+                '0x5754284f345afc66a98fbb0a0afe71e0f007b949'
+            )
+    ) as results(contract_address, premint_address)


### PR DESCRIPTION
There are two issue with the celo stablecoin supply:
1. cUSD is borked (Came from a borked `dim_celo_current_balances` table
2. USDT has a significant premint (Created a `fact_celo_stablecoin_premint_addresses`)
This PR fixes both of these issues
<img width="993" alt="Screenshot 2024-08-20 at 10 56 44 AM" src="https://github.com/user-attachments/assets/a807dfe5-2c04-43b4-8346-a61244f47488">
