### PR TITLE
Stablecoin DQ Issue: Celo

### DIFF
--- a/macros/stablecoins/agg_chain_stablecoin_transfers.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_transfers.sql
@@ -220,12 +220,12 @@
                     from {{ ref("fact_"~chain~"_stablecoin_premint_addresses") }}
                 )
             as is_burn,
-            amount,
+            amount / pow(10, num_decimals) as amount,
             case
-                when is_mint then amount when is_burn then -1 * amount else 0
+                when is_mint then amount / pow(10, num_decimals) when is_burn then -1 * amount / pow(10, num_decimals) else 0
             end as inflow,
             case
-                when not is_mint and not is_burn then amount else 0
+                when not is_mint and not is_burn then amount / pow(10, num_decimals) else 0
             end as transfer_volume,
             t1.contract_address,
             contracts.symbol


### PR DESCRIPTION
Fixing stablecoin DQ issue for celo. When changing the transfers table I forgot to divide by 10**decimals