### PR TITLE
Stablecoin V2.5: Stablecoin and Sector Breakdown 

### DIFF
--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -1,6 +1,10 @@
-{% macro stablecoin_breakdown(breakdowns=[]) %}
+{% macro stablecoin_breakdown(breakdowns=[], granularity='daily') %}
 select
-    date
+    {% if granularity == 'daily' %}
+        date
+    {% elif granularity == 'monthly' %}
+        date_trunc('month', date) as date
+    {% endif %}
     {% for breakdown in breakdowns %}
         , {{ breakdown }}
     {% endfor %}

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_category_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_category_symbol.sql
@@ -1,0 +1,3 @@
+{{ config(materialized="table", snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+
+{{stablecoin_breakdown(["symbol", "category"])}}


### PR DESCRIPTION
1. Create a stablecoin breakdown for Stablecoin and Sector to allow for someone to choose a specific stablecoin(s) when on the all chains page