### PR TITLE
Stablecoin V2.5: Clean up stablecoin breakdown

### DIFF
--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -1,7 +1,6 @@
 {% macro stablecoin_breakdown(breakdowns=[], granularity='day') %}
 select
     date_trunc('{{granularity}}', date) as date_granularity
-    , date_trunc('{{granularity}}', date) as date
     {% for breakdown in breakdowns %}
         , {{ breakdown }}
     {% endfor %}
@@ -35,6 +34,6 @@ select
         , sum(case when is_wallet::number = 1 and date = date_trunc('{{granularity}}', date) then stablecoin_supply else 0 end) as p2p_stablecoin_supply
     {% endif %}
 from {{ ref("agg_daily_stablecoin_breakdown_silver") }}
-group by date_granularity, date {% for breakdown in breakdowns %}, {{ breakdown }} {% endfor %}
+group by date_granularity {% for breakdown in breakdowns %}, {{ breakdown }} {% endfor %}
 order by date_granularity
 {% endmacro %}


### PR DESCRIPTION
1. Removing the date param from stablecoin breakdown macro