### PR TITLE
Stablecoin V2.5: updating stablecoin pricing for non-usd stablecoins

### DIFF
--- a/macros/coingecko/avg_coingecko_price_7d.sql
+++ b/macros/coingecko/avg_coingecko_price_7d.sql
@@ -1,0 +1,7 @@
+{% macro avg_l7d_coingecko_price(coingecko_id) %}    
+    select
+        avg(shifted_token_price_usd) as avg_price_7d
+    from {{ref("fact_coingecko_token_date_adjusted_gold")}}
+    where coingecko_id = '{{ coingecko_id }}'
+        and date >= dateadd('day', -7,  to_date(sysdate())::date)
+{% endmacro %}

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -145,8 +145,11 @@ with
             , stablecoin_supply * coalesce(
                 d.shifted_token_price_usd, 
                 case 
-                    when lower(c.coingecko_id) = lower('celo-kenyan-shilling') then 0.0077 
-                    else 1 
+                    when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
+                    when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
+                    when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
+                    when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
+                    else 1
                 end
             ) as stablecoin_supply
         from historical_supply_by_address_balances st
@@ -167,5 +170,4 @@ select
     , date || '-' || address || '-' || contract_address as unique_id
 from stablecoin_balances_with_price
 where date < to_date(sysdate())
-
 {% endmacro %}

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -45,7 +45,14 @@ with
             , stablecoin_metrics.symbol
             , from_address
             , stablecoin_transfer_volume * coalesce(
-                d.shifted_token_price_usd, case when c.coingecko_id = 'celo-kenyan-shilling' then 0.0077 else 1 end
+                d.shifted_token_price_usd, 
+                case 
+                    when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
+                    when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
+                    when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
+                    when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
+                    else 1
+                end
             ) as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics


### PR DESCRIPTION
1. Calculate the price of a non USD backed stablecoin based on the last 7 day average of the current price