### PR TITLE
Updating Datahub Warehouse

### DIFF
--- a/models/data_hubs/fact_daily_app_datahub.sql
+++ b/models/data_hubs/fact_daily_app_datahub.sql
@@ -1,4 +1,7 @@
-{{ config(materialized="table") }}
+{{ config(
+    materialized="table",
+    , snowflake_warehouse="PC_DBT_WH"
+) }}
 with
     app_datahub as (
         {{

--- a/models/data_hubs/fact_daily_app_datahub.sql
+++ b/models/data_hubs/fact_daily_app_datahub.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized="table",
-    , snowflake_warehouse="PC_DBT_WH"
+    snowflake_warehouse="PC_DBT_WH"
 ) }}
 with
     app_datahub as (


### PR DESCRIPTION
1. Right now all models that don't have a specified warehouse run on `small`, this seems to be causing issues for deploying when the small warehouse is queued. This should help fix this, by giving it a separate warehouse that is not used by the majority of models
<img width="1250" alt="Screenshot 2024-08-23 at 11 00 16 AM" src="https://github.com/user-attachments/assets/daadfa64-753e-487f-9fc2-a282a61371d3">
<img width="1320" alt="Screenshot 2024-08-23 at 11 00 36 AM" src="https://github.com/user-attachments/assets/49c58c12-73fe-4376-94df-2ad163e62bf7">
