### PR TITLE
Updating coingecko metadata

### DIFF
--- a/models/staging/coingecko/fact_coingecko_token_metadata.sql
+++ b/models/staging/coingecko/fact_coingecko_token_metadata.sql
@@ -56,7 +56,7 @@ with
 
 select fd.*, fc.token_categories, fh.token_homepage_link, fcu.token_chat_url
 from flattened_data fd
-join flattened_categories fc using (date, coingecko_token_id)
-join flattened_homepage fh using (date, coingecko_token_id)
-join flattened_chat_url fcu using (date, coingecko_token_id)
+left join flattened_categories fc using (date, coingecko_token_id)
+left join flattened_homepage fh using (date, coingecko_token_id)
+left join flattened_chat_url fcu using (date, coingecko_token_id)
 order by token_market_cap_rank asc


### PR DESCRIPTION
When the categories = `[]` with a coingecko token it is not included in the coingecko metadata table because the CTE does not contain a row for that token (`inner join`). This causes our metadata table to not contain all the tokens that we extract from coingecko as well as not allow us to tag some tokens to apps in sigma. By using a left join we continue to support tokens that do not have an empty array for the categories.