### PR TITLE
Stablecoins (TON): Updating stablecoin metrics for ton

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -170,12 +170,24 @@
     select
         date
         , from_address
-        , contract_name
-        , contract
-        , application
-        , icon
-        , app
-        , category
+        -- There is currently an issue with ton data
+        -- In order to fix this in the short term we need to remove all tags.
+        {% if chain == 'ton' %}
+            , null as contract_name
+            , null as contract
+            , null as application
+            , null as icon
+            , null as app
+            , null as category
+        {% else %}
+            , contract_name
+            , contract
+            , application
+            , icon
+            , app
+            , category
+        {% endif %}
+        
         , is_wallet
 
         , contract_address


### PR DESCRIPTION
1. There is an issue with Ton stablecoin transfers where we are missing some of the transfers. I am currently talking with Ton Apps to try and get this fixed. This is meant to be a short term fix to remove the category breakdown for ton. The outcome will be that the Ton breakdown by category will only show `other`. 

### Ton stablecoin issue:
By removing the category breakdown we will show the same thing that is shown on the other `ton` stablecoin breakdowns.
<img width="1354" alt="Screenshot 2024-09-02 at 8 56 12 PM" src="https://github.com/user-attachments/assets/a4519719-dc8c-451d-85d2-f7b7aea3cbf9">

<img width="995" alt="Screenshot 2024-09-02 at 8 57 08 PM" src="https://github.com/user-attachments/assets/8ea43a5d-a725-4ce1-aa43-dad05b3b7e08">


