### PR TITLE
replacing old Axelar data with Axelarscan data

### DIFF
--- a/models/projects/axelar/core/ez_axelar_metrics.sql
+++ b/models/projects/axelar/core/ez_axelar_metrics.sql
@@ -13,8 +13,9 @@ with
         select
             date
             , txns
-            , daa as dau
-        from {{ ref("fact_axelar_daa_txns") }}
+            , dau
+            , fees
+        from {{ ref("fact_axelar_crosschain_dau_txns_fees_volume") }}
     )
     , github_data as ({{ get_github_metrics("Axelar Network") }})
     , price_data as ({{ get_coingecko_metrics("axelar") }})
@@ -23,6 +24,7 @@ select
     , 'axelar' as chain
     , txns
     , dau
+    , fees
     , weekly_commits_core_ecosystem
     , weekly_commits_sub_ecosystem
     , weekly_developers_core_ecosystem

--- a/models/staging/axelar/__axelar__sources.yml
+++ b/models/staging/axelar/__axelar__sources.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_axelar_dau_txns_volume_fees

--- a/models/staging/axelar/fact_axelar_crosschain_dau_txns_fees_volume.sql
+++ b/models/staging/axelar/fact_axelar_crosschain_dau_txns_fees_volume.sql
@@ -1,0 +1,26 @@
+with
+max_extraction as (
+    select max(extraction_date) as max_date
+    from {{ source("PROD_LANDING", "raw_axelar_dau_txns_volume_fees") }}
+)
+,latest_data as (
+    select 
+        date(value:timestamp) as date
+        , value:users::number as dau
+        , value:fee::number as fees
+        , value:num_txs::number as txns
+        , value:volume::number as volume
+    from {{ source("PROD_LANDING", "raw_axelar_dau_txns_volume_fees") }},
+    lateral flatten(input => parse_json(source_json):data)
+    where extraction_date = (select max_date from max_extraction)
+    and value:timestamp <> 0
+)
+select
+    date
+    , dau
+    , fees
+    , txns
+    , volume
+    , 'axelar' as chain
+    , 'axelar' as app
+from latest_data


### PR DESCRIPTION
Add DBT models for Axelar fundamental data from Axelarscan API.

Successful test run: http://127.0.0.1:3000/runs/35011b76-3641-49f8-8595-9b2ff1b47827
