### PR TITLE
adding metis fundamental metrics

### DIFF
--- a/models/projects/metis/core/ez_metis_metrics.sql
+++ b/models/projects/metis/core/ez_metis_metrics.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized = "table",
+        snowflake_warehouse = "METIS",
+        database = "METIS",
+        schema = "CORE",
+        alias = "ez_metrics"
+    )
+}}
+
+with fees as (
+    select
+        date,
+        fees_usd
+    from {{ref("fact_metis_fees")}}
+),
+txns as (
+    select
+        date,
+        txns
+    from {{ref("fact_metis_txns")}}
+)
+, daus as (
+    select
+        date,
+        dau
+    from {{ref("fact_metis_dau")}}
+)
+
+select
+    coalesce(fees.date, txns.date, daus.date) as date,
+    dau,
+    txns,
+    fees_usd as fees
+from fees
+left join txns on fees.date = txns.date
+left join daus on fees.date = daus.date 

--- a/models/staging/metis/__metis__sources.yml
+++ b/models/staging/metis/__metis__sources.yml
@@ -1,0 +1,10 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_metis_trading_volume
+      - name: raw_metis_txns
+      - name: raw_metis_gas_used
+      - name: raw_metis_avg_gas_price
+      - name: raw_metis_dau

--- a/models/staging/metis/fact_metis_dau.sql
+++ b/models/staging/metis/fact_metis_dau.sql
@@ -1,0 +1,3 @@
+{{
+    convert_routescan_api_daus_for_chain(chain="metis")
+}}

--- a/models/staging/metis/fact_metis_fees.sql
+++ b/models/staging/metis/fact_metis_fees.sql
@@ -1,0 +1,15 @@
+
+with prices as (
+    select
+        date(hour) as date,
+        avg(price) as price
+    from ethereum_flipside.price.ez_prices_hourly
+    where lower(token_address) = lower('0x9e32b13ce7f2e80a01932b42553652e053d6ed8e')
+    group by 1
+)
+select
+    f.date,
+    f.fees_native * p.price as fees_usd
+from {{ref("fact_metis_fees_native")}} f
+left join prices p on p.date = f.date
+where date(f.date) < to_date(sysdate())

--- a/models/staging/metis/fact_metis_fees_native.sql
+++ b/models/staging/metis/fact_metis_fees_native.sql
@@ -1,0 +1,3 @@
+{{
+    convert_routescan_api_fees_native_for_chain(chain="metis")
+}}

--- a/models/staging/metis/fact_metis_txns.sql
+++ b/models/staging/metis/fact_metis_txns.sql
@@ -1,0 +1,3 @@
+{{
+    convert_routescan_api_txns_for_chain(chain="metis")
+}}


### PR DESCRIPTION
Adding Metis fundamental metrics models: fees, daus, daily_txns.
Added ez metrics table.

daily_metis_job successfully materializes all assets:
<img width="1247" alt="Screenshot 2024-09-06 at 10 54 29 AM" src="https://github.com/user-attachments/assets/990141f9-3e4b-403e-a6e9-798729014595">
