### PR TITLE
Customer 911: updating tables to fix issue with near and tron

### DIFF
--- a/macros/metrics/get_p2p_metrics.sql
+++ b/macros/metrics/get_p2p_metrics.sql
@@ -3,6 +3,7 @@
         date
         , p2p_native_transfer_volume
         , p2p_token_transfer_volume
+        , p2p_stablecoin_transfer_volume
         , p2p_transfer_volume
     from {{ ref("fact_" ~ chain ~ "_p2p_transfer_volume") }}
 {% endmacro %}

--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -67,12 +67,12 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -68,7 +68,7 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     total_staked_native,
     total_staked_usd,
     issuance,
@@ -76,7 +76,7 @@ select
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from staking_data
 left join fundamental_data on staking_data.date = fundamental_data.date

--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -58,12 +58,12 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from fundamental_data
 left join defillama_data on fundamental_data.date = defillama_data.date

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -85,7 +85,7 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     
     censored_blocks,
     semi_censored_blocks,
@@ -103,7 +103,7 @@ select
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume,
     blob_fees_native,
     blob_fees,

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -76,12 +76,12 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -77,12 +77,12 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     nft_trading_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date

--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -175,7 +175,7 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     total_staked_native,
     total_staked_usd,
     issuance,

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -57,11 +57,11 @@ select
     p2p_stablecoin_txns,
     p2p_stablecoin_dau,
     p2p_stablecoin_mau,
-    p2p_stablecoin_transfer_volume,
+    stablecoin_data.p2p_stablecoin_transfer_volume,
     p2p_native_transfer_volume,
     p2p_token_transfer_volume,
     p2p_transfer_volume,
-    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
+    coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume,
     coalesce(dex_volumes, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date

--- a/models/staging/tron/fact_tron_p2p_token_transfers.sql
+++ b/models/staging/tron/fact_tron_p2p_token_transfers.sql
@@ -4,4 +4,4 @@
     )
 }}
 
-{{ filter_p2p_token_transfers("tron", blacklist=('TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4', 'TSSMHYeV2uE9qYH95DqyoCuNCzEL1NvU3S')) }}
+{{ filter_p2p_token_transfers("tron", blacklist=('TAFjULxiVgT4qWk6UZwjqwZXTSaGaqnVp4', 'TSSMHYeV2uE9qYH95DqyoCuNCzEL1NvU3S', 'TR95WcjR78Y4puyv8BkbFuxaf4WcvmmPpd')) }}


### PR DESCRIPTION
1. Fixing materialization of near by adding `p2p_stablecoin_transfer_volume` to `get_p2p_metrics`. Need to fix the other ez metric tables that also support `get_p2p_metrics` because `get_stablecoin_metrics` also supports this metric.
2. Fixing Tron p2p token transfers to by adding another blacklisted address.

## Testing:
These are all the chains that support p2p metrics:
<img width="439" alt="Screenshot 2024-09-06 at 5 54 33 PM" src="https://github.com/user-attachments/assets/dd2d08d3-e1b7-4a9d-8fb3-776e44ee894b">
Re-materialize all the tables: (solana failed but I rematerialized it) 
<img width="1226" alt="Screenshot 2024-09-06 at 5 55 15 PM" src="https://github.com/user-attachments/assets/578cccab-a18e-4140-ba5e-1f21b4f175e6">
