### PR TITLE
Stablecoins: Ton and Artemis Filter

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -170,23 +170,12 @@
     select
         date
         , from_address
-        -- There is currently an issue with ton data
-        -- In order to fix this in the short term we need to remove all tags.
-        {% if chain == 'ton' %}
-            , null as contract_name
-            , null as contract
-            , null as application
-            , null as icon
-            , null as app
-            , null as category
-        {% else %}
-            , contract_name
-            , contract
-            , application
-            , icon
-            , app
-            , category
-        {% endif %}
+        , contract_name
+        , contract
+        , application
+        , icon
+        , app
+        , category
         
         , is_wallet
 

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -34,7 +34,7 @@ with
         from stablecoin_transfers st
         left join filtered_contracts dl on lower(st.from_address) = lower(dl.address)
         left join filtered_contracts dlt on lower(st.to_address) = lower(dlt.address)
-        where lower(from_app) != 'mev' or lower(to_app) != 'mev'
+        where lower(from_app) != 'mev' and lower(to_app) != 'mev'
     ),
     artemis_cex_filters as (
         select distinct tx_hash


### PR DESCRIPTION
1. Updating Ton data to remove the temporary fix of setting tags to null
2. Updating Stablecoin Artemis Filter. There was an error in the model where we should be making sure the to **and** from addresses are not MEV rather than using an `or` and only removing when one is MEV.

To Do:
1. This will require a complete backfill of all the ez metrics tables. I will start with the lower touch chains like `base`, `celo`, `ton` to verify that this is correct and then move to the more expensive chains like `ethereum`, `bsc` and `tron`
2. I may time this to also add the two new stablecoins `AUSD` and `FDUSD`