### PR TITLE
Fixed WAU zksync data

### DIFF
--- a/models/projects/zksync/core/ez_zksync_metrics.sql
+++ b/models/projects/zksync/core/ez_zksync_metrics.sql
@@ -30,7 +30,7 @@ select
     fundamental_data.chain,
     dau,
     mau,
-    wau
+    wau,
     txns,
     gas as fees_native,
     gas_usd as fees,


### PR DESCRIPTION
## :pushpin: References

Not sure why this didnt fail the pipeline, but we were missing a comma. 

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
