### PR TITLE
simplified jupiter ez by chain table as part of fix

### DIFF
--- a/models/projects/jupiter/ez_jupiter_metrics_by_chain.sql
+++ b/models/projects/jupiter/ez_jupiter_metrics_by_chain.sql
@@ -8,27 +8,4 @@
     )
 }}
 
-with
-    fees_data as (
-        select date, fees
-        from {{ ref("fact_jupiter_fees_silver") }}
-    ),
-    perps_data as (
-        select date, volume, traders, txns
-        from {{ ref("fact_jupiter_perps_silver")}}
-    ),
-    price_data as ({{ get_coingecko_metrics("jupiter-exchange-solana") }})
-select
-    fees_data.date as date,
-    'solana' as chain,
-    fees_data.fees as fees,
-    volume as trading_volume,
-    traders as unique_traders,
-    txns,
-    price,
-    market_cap,
-    fdmc
-from fees_data
-left join perps_data on perps_data.date = fees_data.date
-left join price_data on fees_data.date = price_data.date
-where fees_data.date < to_date(sysdate())
+select * from {{ref("ez_jupiter_metrics")}}


### PR DESCRIPTION
Small fix removing unneccessary SQL since Jupiter is only on one chain. Made this change as I was investigating why some jupiter data was stale -> table was omitted from `daily_jupiter_job`

Data in `jupiter.prod_core.ez_metrics_by_chain` looks as expected.
<img width="1496" alt="Screenshot 2024-09-24 at 9 14 42 AM" src="https://github.com/user-attachments/assets/edab0d43-c7dd-4c62-b88e-0cae15684bd3">
