### PR TITLE
Stablecoins AUSD: Adding new stablecoin

### DIFF
--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -1,5 +1,7 @@
 {% macro stablecoin_metrics(chain) %}
     {% set backfill_date = '' %}
+    {% set new_stablecoin_address = '' %}
+
     with
         stablecoin_supply as (
             select
@@ -23,14 +25,21 @@
                 {% endif %}
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_balances")}}
-            {% if is_incremental() %}
+            {% if is_incremental() and new_stablecoin_address == '' %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
             {% if backfill_date != '' %}
-                {% if is_incremental() %}
+                {% if is_incremental() and new_stablecoin_address == '' %}
                     and date < '{{ backfill_date }}'
                 {% else %}
                     where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
+            {% if new_stablecoin_address != '' %}
+                {% if backfill_date != '' %}
+                    and lower(contract_address) = lower('{{ new_stablecoin_address }}')
+                {% else %}
+                    where lower(contract_address) = lower('{{ new_stablecoin_address }}')
                 {% endif %}
             {% endif %}
         )
@@ -44,14 +53,21 @@
                 , stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_all")}}
-            {% if is_incremental() %}
+            {% if is_incremental() and new_stablecoin_address == '' %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
             {% if backfill_date != '' %}
-                {% if is_incremental() %}
+                {% if is_incremental() and new_stablecoin_address == '' %}
                     and date < '{{ backfill_date }}'
                 {% else %}
                     where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
+            {% if new_stablecoin_address != '' %}
+                {% if backfill_date != '' %}
+                    and lower(contract_address) = lower('{{ new_stablecoin_address }}')
+                {% else %}
+                    where lower(contract_address) = lower('{{ new_stablecoin_address }}')
                 {% endif %}
             {% endif %}
         )
@@ -65,14 +81,21 @@
                 , stablecoin_daily_txns as artemis_stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_artemis")}}
-            {% if is_incremental() %}
+            {% if is_incremental() and new_stablecoin_address == '' %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
             {% if backfill_date != '' %}
-                {% if is_incremental() %}
+                {% if is_incremental() and new_stablecoin_address == '' %}
                     and date < '{{ backfill_date }}'
                 {% else %}
                     where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
+            {% if new_stablecoin_address != '' %}
+                {% if backfill_date != '' %}
+                    and lower(contract_address) = lower('{{ new_stablecoin_address }}')
+                {% else %}
+                    where lower(contract_address) = lower('{{ new_stablecoin_address }}')
                 {% endif %}
             {% endif %}
         )
@@ -86,14 +109,21 @@
                 , stablecoin_daily_txns as p2p_stablecoin_daily_txns
                 , unique_id
             from {{ ref("fact_" ~ chain ~ "_stablecoin_metrics_p2p")}}
-            {% if is_incremental() %}
+            {% if is_incremental() and new_stablecoin_address == '' %}
                 where date > (select dateadd('day', -1, max(date)) from {{ this }})
             {% endif %}
             {% if backfill_date != '' %}
-                {% if is_incremental() %}
+                {% if is_incremental() and new_stablecoin_address == '' %}
                     and date < '{{ backfill_date }}'
                 {% else %}
                     where date < '{{ backfill_date }}'
+                {% endif %}
+            {% endif %}
+            {% if new_stablecoin_address != '' %}
+                {% if backfill_date != '' %}
+                    and lower(contract_address) = lower('{{ new_stablecoin_address }}')
+                {% else %}
+                    where lower(contract_address) = lower('{{ new_stablecoin_address }}')
                 {% endif %}
             {% endif %}
         )

--- a/models/metrics/stablecoins/contracts/fact_avalanche_stablecoin_contracts.sql
+++ b/models/metrics/stablecoins/contracts/fact_avalanche_stablecoin_contracts.sql
@@ -14,5 +14,6 @@ from
             ),
             ('USDT', '0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7', 6, 'tether', 0),
             ('USDT', '0xc7198437980c041c805A1EDcbA50c1Ce5db95118', 6, 'tether', 0),
-            ('EURC', '0xc891eb4cbdeff6e073e859e987815ed1505c2acd', 6, 'euro-coin', 0)
+            ('EURC', '0xc891eb4cbdeff6e073e859e987815ed1505c2acd', 6, 'euro-coin', 0),
+            ('AUSD', '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a', 6, 'agora-dollar', 0)
     ) as results(symbol, contract_address, num_decimals, coingecko_id, initial_supply)


### PR DESCRIPTION
Adding a new stablecoin AUSD
1. Added code to both the balances macro and final macro to support adding a new stablecoin. This code forces the user to add the new stablecoin locally but setting the value of the address in `new_stablecoin_address`. This forces the backfill to happen locally for now.
2. I tested this with AUSD on avalanche and it work adding a full backfill of AUSD.


To Do:
Add support in the BE and FE for AUSD 