### PR TITLE
Stablecoins: Adding AUSD (ethereum) and Fixing Near Stablecoin Transfers

### DIFF
--- a/macros/stablecoins/agg_chain_stablecoin_transfers.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_transfers.sql
@@ -176,7 +176,7 @@
             to_address,
             from_address = 'system' or from_address is null as is_mint,
             to_address = 'system' or to_address is null as is_burn,
-            amount_raw_precise / 1E24 as amount,
+            amount_raw_precise / pow(10, num_decimals) as amount,
             case
                 when is_mint then 1 * amount
                 when is_burn then -1 * amount

--- a/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_contracts.sql
+++ b/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_contracts.sql
@@ -22,5 +22,6 @@ from
             ),
             ('PYUSD', '0x6c3ea9036406852006290770BEdFcAbA0e23A0e8', 6, 'paypal-usd', 0),
             ('EURC', '0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c', 6, 'euro-coin', 0),
-            ('USDP', '0x8e870d67f660d95d5be530380d0ec0bd388289e1', 18, 'paxos-standard', 0)
+            ('USDP', '0x8e870d67f660d95d5be530380d0ec0bd388289e1', 18, 'paxos-standard', 0),
+            ('AUSD', '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a', 6, 'agora-dollar', 0)
     ) as results(symbol, contract_address, num_decimals, coingecko_id, initial_supply)


### PR DESCRIPTION
1. Adding AUSD support on Ethereum. Already backfilled the data will show on the FE tomorrow morning.
2. Fixing near stablecoin transfers. There was a bug in the near stablecoin transfers where the amount was divided by 1e24. This is wrong for both USDC and USDT. This PR fixes this and divides by the correct decimals.