### PR TITLE
Stablecoin Deprecation: removing remaining dependencies on v1 stablecoins data

### DIFF
--- a/models/common/ez_stablecoin_metrics.sql
+++ b/models/common/ez_stablecoin_metrics.sql
@@ -9,12 +9,5 @@
 }}
 
 SELECT
-    date
-    , total_supply
-    , txns
-    , dau
-    , transfer_volume
-    , chain
-    , symbol
-    , contract_address
-FROM {{ref("agg_daily_stablecoin_metrics")}}
+    *
+FROM {{ref("agg_daily_stablecoin_breakdown_symbol_chain")}}

--- a/models/projects/celo/core/ez_celo_metrics.sql
+++ b/models/projects/celo/core/ez_celo_metrics.sql
@@ -1,4 +1,3 @@
---depends_on: {{ ref("agg_celo_stablecoin_metrics") }}
 {{
     config(
         materialized="table",


### PR DESCRIPTION
1. Removing dependency on stablecoin v1 data from all remaining models.
2. We can now begin to -rm -rf all v1 data


To Do:
Turn off stablecoin v1 job