### PR TITLE
Stablecoins Cleanup: using macro to waterfall prices

### DIFF
--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -67,16 +67,7 @@ with
                 t1.from_address,
                 t1.to_address,
                 t1.amount,
-                transfer_volume * coalesce(
-                    p.shifted_token_price_usd, 
-                    case 
-                        when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
-                        when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
-                        when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
-                        when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
-                        else 1
-                    end
-                ) as amount_usd
+                transfer_volume * {{waterfall_stablecoin_prices('c', 'd')}} as amount_usd
             from stablecoin_transfers t1
             join {{ ref("fact_"~chain~"_stablecoin_contracts") }} c
                 on lower(t1.contract_address) = lower(c.contract_address)

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -147,16 +147,7 @@ with
             , st.contract_address
             , st.symbol
             , stablecoin_supply_native
-            , stablecoin_supply_native * coalesce(
-                d.shifted_token_price_usd, 
-                case 
-                    when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
-                    when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
-                    when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
-                    when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
-                    else 1
-                end
-            ) as stablecoin_supply
+            , stablecoin_supply_native * {{waterfall_stablecoin_prices('c', 'd')}} as stablecoin_supply
         from historical_supply_by_address_balances st
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
                 on lower(st.contract_address) = lower(c.contract_address)

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -44,16 +44,7 @@ with
             , stablecoin_metrics.contract_address
             , stablecoin_metrics.symbol
             , from_address
-            , stablecoin_transfer_volume * coalesce(
-                d.shifted_token_price_usd, 
-                case 
-                    when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
-                    when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
-                    when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
-                    when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
-                    else 1
-                end
-            ) as stablecoin_transfer_volume
+            , stablecoin_transfer_volume * {{waterfall_stablecoin_prices('c', 'd')}} as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -84,16 +84,7 @@ with
             , stablecoin_metrics.contract_address
             , stablecoin_metrics.symbol
             , from_address
-            , stablecoin_transfer_volume * coalesce(
-                d.shifted_token_price_usd, 
-                case 
-                    when c.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
-                    when c.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
-                    when c.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})
-                    when c.coingecko_id = 'celo-kenyan-shilling' then ({{ avg_l7d_coingecko_price('celo-kenyan-shilling') }})
-                    else 1
-                end
-            ) as stablecoin_transfer_volume
+            , stablecoin_transfer_volume * {{waterfall_stablecoin_prices('c', 'd')}} as stablecoin_transfer_volume
             , stablecoin_daily_txns
         from stablecoin_metrics
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c


### PR DESCRIPTION
1. Created macro in this PR to waterfall prices and maintain stablecoin prices for nonusd stablecoins in a single place. Implementing this marco in the other places in the code that it can be used. 

PR: https://github.com/Artemis-xyz/dbt/pull/518/files

Marco In main Repo: https://github.com/Artemis-xyz/dbt/blob/main/macros/coingecko/waterfall_stablecoin_prices.sql
