### PR TITLE
Customer 911: fixing `agg_weekly_stablecoin_breakdown_category_chain`

### DIFF
--- a/models/metrics/stablecoins/breakdowns/agg_weekly_stablecoin_breakdown_category_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_weekly_stablecoin_breakdown_category_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity" "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
 
 {{stablecoin_breakdown(["chain", "category"], "week")}}


### PR DESCRIPTION
I forgot a comma in the config which caused the job to throw an error