### PR TITLE
Customer 911: Fixing incremental run logic

### DIFF
--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -2,7 +2,11 @@
 select
     date_trunc('{{granularity}}', date) as date_granularity
     {% for breakdown in breakdowns %}
-        , {{ breakdown }}
+        {% if breakdown in ('application', 'category') %}
+            , coalesce({{ breakdown }}, 'Unlabeled') as {{ breakdown }}
+        {% else %}
+            , {{ breakdown }}
+        {% endif %}
     {% endfor %}
     , count(distinct case when stablecoin_daily_txns > 0 then from_address end) as stablecoin_dau
     , sum(stablecoin_transfer_volume) as stablecoin_transfer_volume
@@ -35,7 +39,7 @@ select
     {% endif %}
 from {{ ref("agg_daily_stablecoin_breakdown_silver") }}
 {% if is_incremental() %}
-    where date >= (select dateadd('{{granularity}}', -3, max(date_granularity)) from {{ this }})
+    where date >= (select dateadd('{{granularity}}', -5, max(date_granularity)) from {{ this }})
 {% endif %}
 {% if 'application' in breakdowns %}
     {% if not is_incremental() %}


### PR DESCRIPTION
Stablecoins symbol by sector is borked because the incremental run is not good a unifying null rows. This PR fixes this issue by making the null category or application be unlabeled rather than `null`. 
<img width="1027" alt="Screenshot 2024-10-02 at 4 49 56 PM" src="https://github.com/user-attachments/assets/0552c168-fb74-4dfc-92c2-6d9dbb04b8f6">
