### PR TITLE
C911: fixing sui contracts

### DIFF
--- a/models/staging/sui/fact_sui_contracts_silver.sql
+++ b/models/staging/sui/fact_sui_contracts_silver.sql
@@ -10,15 +10,15 @@ with
         from {{ source("PROD_LANDING", "raw_sui_contracts") }}
         where extraction_date = (select max_date from max_extraction)
     )
-    select
+    select distinct
         value:"packageId"::string as package_id,
         value:"creator"::string as creator_address,
         value:"packageName"::string as package_name,
         lower(replace(value:"projectName"::string, ' ', '_')) as namespace,
         value:"projectName"::string as friendly_name,
         value:"projectImg"::string as project_img,
-        date(to_timestamp(value:"timestamp"::number / 1000)) as timestamp,
-        value:"transactions" as transactions,
+        date(to_timestamp(coalesce(value:"createTimestamp"::number, value:"timestamp"::number) / 1000)) as timestamp,
+        coalesce(value:"txsCount", value:"transactions") as transactions,
         value:"version"::number as version
     from sui_data, lateral flatten(input => data)
     order by transactions desc


### PR DESCRIPTION
Updating the extract step. The new extract step changes the schema. This PR updates that Schema. Incase we need to do a full refresh I `coalesce` to make sure we can still refresh the table properly. 

<img width="1335" alt="Screenshot 2024-10-05 at 6 25 55 PM" src="https://github.com/user-attachments/assets/bd2d9150-d67d-43f9-8aed-0674827f245e">
