### PR TITLE
editing some metric names to better align with existing bridge metrics

### DIFF
--- a/models/projects/axelar/core/ez_axelar_metrics.sql
+++ b/models/projects/axelar/core/ez_axelar_metrics.sql
@@ -9,31 +9,41 @@
 }}
 
 with
-    fundamental_data as (
+    crosschain_data as (
+        select
+            date
+            , bridge_txns
+            , bridge_daa
+            , fees
+        from {{ ref("fact_axelar_crosschain_dau_txns_fees_volume") }}
+    )
+    , axelar_chain_data as (
         select
             date
             , txns
-            , dau
-            , fees
-        from {{ ref("fact_axelar_crosschain_dau_txns_fees_volume") }}
+            , daa as dau
+        from {{ ref("fact_axelar_daa_txns") }}
     )
     , github_data as ({{ get_github_metrics("Axelar Network") }})
     , price_data as ({{ get_coingecko_metrics("axelar") }})
 select 
-    fundamental_data.date
+    crosschain_data.date
     , 'axelar' as chain
-    , txns
-    , dau
-    , fees
-    , fees / txns as avg_txn_fee
-    , weekly_commits_core_ecosystem
-    , weekly_commits_sub_ecosystem
-    , weekly_developers_core_ecosystem
-    , weekly_developers_sub_ecosystem
-    , price
-    , market_cap
+    , crosschain_data.bridge_txns
+    , axelar_chain_data.dau
+    , axelar_chain_data.txns
+    , crosschain_data.bridge_daa
+    , crosschain_data.fees
+    , crosschain_data.fees / crosschain_data.bridge_txns as avg_txn_fee
+    , github_data.weekly_commits_core_ecosystem
+    , github_data.weekly_commits_sub_ecosystem
+    , github_data.weekly_developers_core_ecosystem
+    , github_data.weekly_developers_sub_ecosystem
+    , price_data.price
+    , price_data.market_cap
     , fdmc
-from fundamental_data
+from crosschain_data
+left join axelar_chain_data using (date)
 left join github_data using (date)
 left join price_data using (date)
-where fundamental_data.date < to_date(sysdate())
+where crosschain_data.date < to_date(sysdate())

--- a/models/projects/layerzero/core/ez_layerzero_metrics.sql
+++ b/models/projects/layerzero/core/ez_layerzero_metrics.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="view",
         snowflake_warehouse="LAYERZERO",
         database="layerzero",
         schema="core",
@@ -8,27 +8,12 @@
     )
 }}
 
-with fees as (
-    SELECT
-        date,
-        SUM(fees) as fees
-    FROM {{ ref('fact_layerzero_fees_by_chain') }}
-    GROUP BY 1
-)
-, dau_txns as (
-    SELECT
-        date,
-        SUM(dau) as dau,
-        SUM(txns) as txns
-    FROM {{ ref('fact_layerzero_dau_txns_by_chain') }}
-    GROUP BY 1
-)
 
 SELECT
-    coalesce(f.date, d.date) as date,
-    f.fees,
-    d.dau,
-    d.txns
-FROM dau_txns d
-LEFT JOIN fees f using (date)
-WHERE coalesce(f.date, d.date) < to_date(sysdate())
+    date,
+    sum(fees) as fees,
+    sum(bridge_daa) as bridge_daa,
+    sum(bridge_txns) as bridge_txns
+FROM {{ ref('ez_layerzero_metrics_by_chain') }}
+WHERE date < to_date(sysdate())
+GROUP BY 1

--- a/models/projects/layerzero/core/ez_layerzero_metrics_by_chain.sql
+++ b/models/projects/layerzero/core/ez_layerzero_metrics_by_chain.sql
@@ -28,8 +28,8 @@ SELECT
     coalesce(f.date, d.date) as date,
     f.chain,
     f.fees,
-    d.dau,
-    d.txns
+    d.dau as bridge_daa,
+    d.txns as bridge_txns
 FROM fees f
 JOIN dau_txns d using (date, chain)
 WHERE coalesce(f.date, d.date) < to_date(sysdate())

--- a/models/projects/wormhole/core/ez_wormhole_metrics.sql
+++ b/models/projects/wormhole/core/ez_wormhole_metrics.sql
@@ -21,7 +21,7 @@ with txns as (
 
 select
     coalesce(txns.date, daa.date) as date,
-    coalesce(txns.txns, 0) as txns,
+    coalesce(txns.txns, 0) as bridge_txns,
     coalesce(daa.bridge_daa, 0) as bridge_daa,
     0 as fees
 from txns

--- a/models/staging/axelar/fact_axelar_crosschain_dau_txns_fees_volume.sql
+++ b/models/staging/axelar/fact_axelar_crosschain_dau_txns_fees_volume.sql
@@ -6,9 +6,9 @@ max_extraction as (
 ,latest_data as (
     select 
         date(value:timestamp) as date
-        , value:users::number as dau
+        , value:users::number as bridge_daa
         , value:fee::number as fees
-        , value:num_txs::number as txns
+        , value:num_txs::number as bridge_txns
         , value:volume::number as volume
     from {{ source("PROD_LANDING", "raw_axelar_dau_txns_volume_fees") }},
     lateral flatten(input => parse_json(source_json):data)
@@ -17,9 +17,9 @@ max_extraction as (
 )
 select
     date
-    , dau
+    , bridge_daa
     , fees
-    , txns
+    , bridge_txns
     , volume
     , 'axelar' as chain
     , 'axelar' as app

--- a/models/staging/axelar/fact_axelar_daa_txns.sql
+++ b/models/staging/axelar/fact_axelar_daa_txns.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="view") }}
+{{ config(materialized="table") }}
 select
     block_timestamp::date as date,
     count(distinct tx_from) as daa,


### PR DESCRIPTION
After convo with Seb last week about the rationale behind some of the Bridge metric naming I wanted to align all bridging/crosschain messaging protocol metric names. The conversation resolved in our agreement that for certain types of protocols it makes sense to have more specific metric naming such that `DAU` becomes `BRIDGE_DAU`. 

To that end, this PR contains a number of changes to a some protocols:
1. Layerzero
- Changed `DAU` to `BRIDGE_DAU`
- ChangedTXNS` to `BRIDGE_TXNS`
- `ez_layerzero_metrics` converted to a `view`, and simply aggregates the `by_chain` data

2. Axelar
- Changed `DAU` to `BRIDGE_DAU`
- We now have a `DAU` metric which is all _Axelar chain_ unique from addresses, and `BRIDGE_DAU` which is cross-chain messages/bridge users as reported by Axelarscan.
- Same goes for `TXNS` and `BRIDGE_TXNS`
- `FEES` remain cross-chain fees

3. Wormhole
- Renamed `TXNS` to `BRIDGE_TXNS`