### PR TITLE
Github Open Source Workflow: Update show_changed_models

### DIFF
--- a/.github/workflows/show_changed_models.yml
+++ b/.github/workflows/show_changed_models.yml
@@ -15,6 +15,8 @@ concurrency:
 jobs:
   check-user:
     runs-on: ubuntu-latest
+    outputs:
+      skip_workflow: ${{ steps.check_user.outputs.skip_workflow }}
     steps:
       - name: Check out PR
         uses: actions/checkout@v3
@@ -38,7 +40,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: check-user
-    if: needs.check-user.outputs.skip_workflow == 'false'
+    if: ${{ needs.check-user.outputs.skip_workflow != true }}
     steps:
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
1. Workflow failed to run with open source contributor. https://github.com/Artemis-xyz/dbt/pull/535
2. This is becuase the output of the first job is not saved. This print shows that the next workflow should not be skipped.
<img width="1177" alt="Screenshot 2024-10-09 at 10 06 21 PM" src="https://github.com/user-attachments/assets/5d2af65e-97b7-435a-9a27-29ea0070c9d5">
3. This pr updated the output logic of the workflow to make sure that it is actually saved

To Do:
1. Find a way to test this 
