### PR TITLE
Adding adding Bridge Flows data to art share

### DIFF
--- a/models/common/ez_bridge_flows_metrics.sql
+++ b/models/common/ez_bridge_flows_metrics.sql
@@ -1,0 +1,19 @@
+{{ 
+    config(
+        snowflake_warehouse="COMMON",
+        database="common",
+        schema="core",
+        materialized='table'
+    )
+}}
+
+select 
+    date
+    , source_chain
+    , destination_chain
+    , app
+    , sum(amount_usd) as transfer_volume
+from {{ ref('agg_daily_bridge_flows_metrics_silver') }} 
+where amount_usd > 0
+group by date, source_chain, destination_chain, app
+order by date desc


### PR DESCRIPTION
Arbitrum wants access to the flows data. Adding it to Art Share

To Do:
1. Rerun the pipeline on dagster