### PR TITLE
Uniswap: adding dex token prices for uniswap

### DIFF
--- a/macros/decentralized_exchanges/fact_dex_priced_tokens.sql
+++ b/macros/decentralized_exchanges/fact_dex_priced_tokens.sql
@@ -1,0 +1,60 @@
+{% macro fact_dex_priced_tokens(app, version, chain) %}
+    with
+        stablecoin_dex_swaps as (
+            select
+                block_timestamp
+                , tx_hash
+                , event_index
+                , token0
+                , token0_symbol
+                , case
+                    when lower(token0) in (select lower(contract_address) from {{ref("fact_" ~chain~"_stablecoin_contracts")}}) then 'TRUE'
+                    else 'FALSE'
+                end as token0_is_stablecoin
+                , token0_amount
+                , token1
+                , token1_symbol
+                , case 
+                    when lower(token1) in (select lower(contract_address) from {{ref("fact_" ~chain~"_stablecoin_contracts")}}) then 'TRUE'
+                    else 'FALSE'
+                end as token1_is_stablecoin
+                , token1_amount
+            from {{ ref("fact_"~app~"_"~version~"_"~chain~"_swap_events") }} dex_model
+            where (
+                lower(token0) in (select lower(contract_address) from {{ref("fact_" ~chain~"_stablecoin_contracts")}})
+                or 
+                lower(token1) in (select lower(contract_address) from {{ref("fact_" ~chain~"_stablecoin_contracts")}})
+            )
+            and token0_amount > 0 and token1_amount > 0
+            {% if is_incremental() %}
+                and block_timestamp >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+            {% endif %}
+        )
+
+    select
+        block_timestamp
+        , event_index
+        , tx_hash
+        , '{{chain}}' as chain
+        , '{{app}}' as app
+        , '{{version}}' as version
+        , '{{chain}}' || '-' || '{{app}}' || '-' || '{{version}}' as source
+        , case 
+            when token0_is_stablecoin = 'TRUE' then token1_symbol || '/' || token0_symbol
+            when token1_is_stablecoin = 'TRUE' then token0_symbol || '/' || token1_symbol
+        end as pair
+        , case 
+            when token0_is_stablecoin = 'TRUE' then token1
+            when token1_is_stablecoin = 'TRUE' then token0
+        end as token_address
+        , case 
+            when token0_is_stablecoin = 'TRUE' then token1_symbol
+            when token1_is_stablecoin = 'TRUE' then token0_symbol
+        end as symbol
+        , case
+            when token0_is_stablecoin = 'TRUE' then token0_amount/token1_amount
+            when token1_is_stablecoin = 'TRUE' then token1_amount/token0_amount
+        end as price
+    from stablecoin_dex_swaps
+
+{% endmacro %}

--- a/macros/decentralized_exchanges/fact_uniswap_fork_swap_events.sql
+++ b/macros/decentralized_exchanges/fact_uniswap_fork_swap_events.sql
@@ -1,0 +1,91 @@
+{% macro fact_uniswap_v2_fork_swap_events(
+    factory, chain, app='uniswap', version='v2'
+) %}
+    with
+        pools as (
+            select
+                decoded_log:"pair"::string as pair,
+                decoded_log:"token0"::string as token0,
+                decoded_log:"token1"::string as token1
+            from {{ chain }}_flipside.core.ez_decoded_event_logs
+            where
+                contract_address = lower('{{ factory }}')
+                and event_name = 'PairCreated'
+        ),
+        all_pool_events as (
+            select t2.*, t1.tx_hash, t1.block_number, t1.decoded_log, t1.block_timestamp, t1.event_index
+            from {{ chain }}_flipside.core.ez_decoded_event_logs t1
+            inner join
+                pools t2 on lower(t1.contract_address) = lower(t2.pair)
+            where
+                t1.event_name in ('Swap')
+                {% if is_incremental() %}
+                    and block_timestamp >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+                {% endif %}
+        )
+    select
+        block_timestamp,
+        event_index,
+        tx_hash,
+        '{{chain}}' as chain,
+        decoded_log:"sender"::string as sender,
+        decoded_log:"to"::string as recipient,
+        pair,
+        token0,
+        t0.symbol as token0_symbol,
+        abs(decoded_log:"amount0In"::float - decoded_log:"amount0Out"::float) as raw_token0_amount,
+        abs(decoded_log:"amount0In"::float - decoded_log:"amount0Out"::float) / pow(10, t0.decimals) as token0_amount,
+        token1,
+        t1.symbol as token1_symbol, 
+        abs(decoded_log:"amount1In"::float - decoded_log:"amount1Out"::float) as raw_token1_amount,
+        abs(decoded_log:"amount1In"::float - decoded_log:"amount1Out"::float) / pow(10, t1.decimals) as token1_amount
+    from all_pool_events
+    left join {{chain}}_flipside.core.dim_contracts t0 on lower(token0) = lower(t0.address) 
+    left join {{chain}}_flipside.core.dim_contracts t1 on lower(token1) = lower(t1.address) 
+{% endmacro %}
+
+
+{% macro fact_uniswap_v3_fork_swap_events(factory, chain, app, version) %}
+    with
+        pools as (
+            select
+                decoded_log:"pool"::string as pool,
+                decoded_log:"token0"::string as token0,
+                decoded_log:"token1"::string as token1,
+            from {{ chain }}_flipside.core.ez_decoded_event_logs
+            where
+                contract_address = lower('{{ factory }}')
+                and event_name = 'PoolCreated'
+        )
+        , all_pool_events as (
+            select t2.*, t1.tx_hash, t1.block_number, t1.decoded_log, t1.block_timestamp, event_index
+            from {{ chain }}_flipside.core.ez_decoded_event_logs t1
+            inner join
+                pools t2 on lower(t1.contract_address) = lower(t2.pool)
+            where
+                t1.event_name in ('Swap')
+                {% if is_incremental() %}
+                    and block_timestamp
+                    >= (select max(block_timestamp) from {{ this }})
+                {% endif %}
+        )
+    select
+        block_timestamp,
+        event_index,
+        tx_hash,
+        '{{chain}}' as chain,
+        decoded_log:"sender"::string as sender,
+        decoded_log:"recipient"::string as recipient,
+        pool,
+        token0,
+        t0.symbol as token0_symbol,
+        abs(decoded_log:"amount0"::float) as raw_token0_amount,
+        raw_token0_amount / pow(10, t0.decimals) as token0_amount,
+        token1,
+        t1.symbol as token1_symbol, 
+        abs(decoded_log:"amount1"::float) as raw_token1_amount,
+        raw_token1_amount / pow(10, t1.decimals) as token1_amount
+    from all_pool_events
+    left join {{chain}}_flipside.core.dim_contracts t0 on lower(token0) = lower(t0.address) 
+    left join {{chain}}_flipside.core.dim_contracts t1 on lower(token1) = lower(t1.address) 
+{% endmacro %}

--- a/models/projects/uniswap/raw/fact_uniswap_dex_token_prices.sql
+++ b/models/projects/uniswap/raw/fact_uniswap_dex_token_prices.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="UNISWAP_SM",
+        database="uniswap",
+        schema="raw",
+        alias="fact_dex_token_prices",
+    )
+}}
+
+with
+    dex_prices as (
+       {{
+            dbt_utils.union_relations(
+                relations=[
+                    ref("fact_uniswap_v2_ethereum_priced_tokens"),
+                    ref("fact_uniswap_v3_arbitrum_priced_tokens"),
+                    ref("fact_uniswap_v3_avalanche_priced_tokens"),
+                    ref("fact_uniswap_v3_base_priced_tokens"),
+                    ref("fact_uniswap_v3_blast_priced_tokens"),
+                    ref("fact_uniswap_v3_bsc_priced_tokens"),
+                    ref("fact_uniswap_v3_ethereum_priced_tokens"),
+                    ref("fact_uniswap_v3_optimism_priced_tokens"),
+                    ref("fact_uniswap_v3_polygon_priced_tokens"),
+                ],
+            )
+        }}
+    )
+ select
+    block_timestamp
+    , 'DeFi' as category
+    , event_index
+    , tx_hash
+    , chain
+    , app
+    , version
+    , source
+    , pair
+    , token_address
+    , symbol
+    , price
+from dex_prices

--- a/models/staging/uniswap/fact_uniswap_v2_ethereum_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v2_ethereum_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v2', 'ethereum')}}

--- a/models/staging/uniswap/fact_uniswap_v2_ethereum_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v2_ethereum_swap_events.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{
+    fact_uniswap_v2_fork_swap_events(
+        "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+        "ethereum",
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_arbitrum_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_arbitrum_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'arbitrum')}}

--- a/models/staging/uniswap/fact_uniswap_v3_arbitrum_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_arbitrum_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x1F98431c8aD98523631AE4a59f267346ea31F984", "arbitrum", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_avalanche_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_avalanche_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'avalanche')}}

--- a/models/staging/uniswap/fact_uniswap_v3_avalanche_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_avalanche_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD", "avalanche", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_base_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_base_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'base')}}

--- a/models/staging/uniswap/fact_uniswap_v3_base_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_base_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x33128a8fC17869897dcE68Ed026d694621f6FDfD", "base", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_blast_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_blast_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'blast')}}

--- a/models/staging/uniswap/fact_uniswap_v3_blast_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_blast_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x792edAdE80af5fC680d96a2eD80A44247D2Cf6Fd", "blast", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_bsc_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_bsc_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'bsc')}}

--- a/models/staging/uniswap/fact_uniswap_v3_bsc_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_bsc_swap_events.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7", "bsc", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_ethereum_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_ethereum_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'ethereum')}}

--- a/models/staging/uniswap/fact_uniswap_v3_ethereum_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_ethereum_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x1F98431c8aD98523631AE4a59f267346ea31F984", "ethereum", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_optimism_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_optimism_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'optimism')}}

--- a/models/staging/uniswap/fact_uniswap_v3_optimism_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_optimism_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x1F98431c8aD98523631AE4a59f267346ea31F984", "optimism", "uniswap", "v3"
+    )
+}}

--- a/models/staging/uniswap/fact_uniswap_v3_polygon_priced_tokens.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_polygon_priced_tokens.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+
+{{fact_dex_priced_tokens('uniswap', 'v3', 'polygon')}}

--- a/models/staging/uniswap/fact_uniswap_v3_polygon_swap_events.sql
+++ b/models/staging/uniswap/fact_uniswap_v3_polygon_swap_events.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "event_index"],
+    )
+}}
+{{
+    fact_uniswap_v3_fork_swap_events(
+        "0x1F98431c8aD98523631AE4a59f267346ea31F984", "polygon", "uniswap", "v3"
+    )
+}}


### PR DESCRIPTION
1. Adding price of tokens on the uniswap DEX across all chains. The methodology here is we price the tokens in the stablecoin and assume the stablecoin. The token is prices in the stablecoin. Because we track both USD and EUR it will get us the price of tokens in both of these prices. 

<img width="1034" alt="Screenshot 2024-10-14 at 4 40 49 PM" src="https://github.com/user-attachments/assets/76b97eb0-acf0-4acb-9565-9c2d7d34d768">

To Do:
1. Get the price of ETH and BTC in USD denominated stablecoins