### PR TITLE
C911: Updating SUI DBT to use BQ data

### DIFF
--- a/models/projects/sui/core/ez_sui_metrics_by_application.sql
+++ b/models/projects/sui/core/ez_sui_metrics_by_application.sql
@@ -1,70 +1,13 @@
 {{
     config(
         materialized="table",
-        unique_key="tx_hash",
         snowflake_warehouse="SUI",
         database="sui",
         schema="core",
         alias="ez_metrics_by_application",
     )
 }}
-with
-    min_date as (
-        select min(raw_date) as start_date, sender, app
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA') and app is not null
-        group by app, sender
-    ),
-    new_users as (
-        select count(distinct sender) as new_users, app, start_date
-        from min_date
-        group by start_date, app
-    ),
-    dau_txns as (
-        select
-            raw_date,
-            app,
-            count(*) txns,
-            count(distinct sender) dau
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA') and app is not null and status = 'success'
-        group by raw_date, app
-    ),
-    agg_data as (
-        select
-            raw_date,
-            app,
-            max(chain) as chain,
-            max(friendly_name) friendly_name,
-            max(category) category,
-            sum(tx_fee) gas,
-            sum(gas_usd) gas_usd
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA') and app is not null
-        group by raw_date, app
-    )
-select
-    agg_data.raw_date as date,
-    agg_data.app,
-    chain,
-    friendly_name,
-    category,
-    gas,
-    gas_usd,
-    txns,
-    dau,
-    (dau - new_users) as returning_users,
-    new_users,
-    null as low_sleep_users,
-    null as high_sleep_users,
-    null as sybil_users,
-    null as non_sybil_users
-from agg_data
-left join
-    dau_txns
-    on equal_null(agg_data.app, dau_txns.app)
-    and agg_data.raw_date = dau_txns.raw_date
-left join
-    new_users
-    on equal_null(agg_data.app, new_users.app)
-    and agg_data.raw_date = new_users.start_date
+SELECT
+    * EXCLUDE date,
+    TO_TIMESTAMP_NTZ(date) AS date
+FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }}

--- a/models/projects/sui/core/ez_sui_metrics_by_category.sql
+++ b/models/projects/sui/core/ez_sui_metrics_by_category.sql
@@ -1,68 +1,13 @@
 {{
     config(
         materialized="table",
-        unique_key="tx_hash",
         snowflake_warehouse="SUI",
         database="sui",
         schema="core",
         alias="ez_metrics_by_category",
     )
 }}
-with
-    min_date as (
-        select min(raw_date) as start_date, sender, category
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA')
-        group by category, sender
-    ),
-    new_users as (
-        select count(distinct sender) as new_users, category, start_date
-        from min_date
-        group by start_date, category
-    ),
-    dau_txns as (
-        select
-            raw_date,
-            category,
-            count(*) txns,
-            count(distinct sender) dau
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA') and status = 'success'
-        group by raw_date, category
-    ),
-    agg_data as (
-        select
-            raw_date,
-            category,
-            max(chain) as chain,
-            max(friendly_name) friendly_name,
-            sum(tx_fee) gas,
-            sum(gas_usd) gas_usd
-        from {{ ref("ez_sui_transactions") }}
-        where not equal_null(category, 'EOA')
-        group by raw_date, category
-    )
-select
-    agg_data.raw_date as date,
-    agg_data.category,
-    chain,
-    friendly_name,
-    gas,
-    gas_usd,
-    txns,
-    dau,
-    (dau - new_users) as returning_users,
-    new_users,
-    null as low_sleep_users,
-    null as high_sleep_users,
-    null as sybil_users,
-    null as non_sybil_users
-from agg_data
-left join
-    dau_txns
-    on equal_null(agg_data.category, dau_txns.category)
-    and agg_data.raw_date = dau_txns.raw_date
-left join
-    new_users
-    on equal_null(agg_data.category, new_users.category)
-    and agg_data.raw_date = new_users.start_date
+SELECT
+    * EXCLUDE date,
+    TO_TIMESTAMP_NTZ(date) AS date
+FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_category') }}

--- a/models/projects/sui/core/ez_sui_metrics_by_contract.sql
+++ b/models/projects/sui/core/ez_sui_metrics_by_contract.sql
@@ -1,56 +1,13 @@
 {{
     config(
         materialized="table",
-        unique_key="tx_hash",
-        snowflake_warehouse="SUI_MD",
+        snowflake_warehouse="SUI",
         database="sui",
         schema="core",
         alias="ez_metrics_by_contract",
     )
 }}
-with
-    dau_txns as (
-        select
-            package as contract_address,
-            raw_date as date,
-            count(*) txns,
-            count(distinct sender) dau
-        from {{ ref("ez_sui_transactions") }}
-        where status = 'success'
-        group by raw_date, contract_address
-    ),
-    contract_data as (
-        select
-            package as contract_address,
-            raw_date as date,
-            max(name) name,
-            max(chain) as chain,
-            max(app) as app,
-            max(friendly_name) as friendly_name,
-            sum(tx_fee) gas,
-            sum(gas_usd) gas_usd,
-            max(category) category
-        from {{ ref("ez_sui_transactions") }}
-        where
-            not equal_null(category, 'EOA')
-            {% if is_incremental() %}
-                and date >= (select dateadd('day', -7, max(date)) from {{ this }})
-            {% endif %}
-        group by date, contract_address
-    )
-select
-    contract_data.date,
-    contract_data.contract_address,
-    chain,
-    contract_data.name,
-    contract_data.app,
-    contract_data.friendly_name,
-    contract_data.category,
-    gas,
-    gas_usd,
-    txns,
-    dau
-from contract_data
-join dau_txns
-    on contract_data.date = dau_txns.date
-    and contract_data.contract_address = dau_txns.contract_address
+SELECT
+    * EXCLUDE date,
+    TO_TIMESTAMP_NTZ(date) AS date
+FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_contract') }}

--- a/models/staging/sui/__sui__sources.yml
+++ b/models/staging/sui/__sui__sources.yml
@@ -9,6 +9,10 @@ sources:
     database: LANDING_DATABASE
     tables:
       - name: raw_sui_contracts
+      - name: ez_sui_metrics
+      - name: ez_sui_metrics_by_contract
+      - name: ez_sui_metrics_by_application
+      - name: ez_sui_metrics_by_category
   - name: ZETTABLOCKS_SUI
     schema: SUI_MAINNET
     database: ZETTABLOCK_DS

--- a/models/staging/sui/sui_trending_daily.sql
+++ b/models/staging/sui/sui_trending_daily.sql
@@ -1,89 +1,61 @@
-{{ config(materialized="table", snowflake_warehouse="BAM_TRENDING_WAREHOUSE_MD") }}
-
-with
-    sui_contracts as (
-
-        select address, name, app as namespace, friendly_name, category
-        from {{ ref("dim_contracts_gold") }}
-        where chain = 'sui'
-    ),
-    prices as ({{ get_coingecko_price_for_trending("sui") }}),
-    sui_transactions as (
-        select 
-            transaction_block_digest as transaction_block_digest,
-            min_by(package, index) as package,
-            array_agg(type) as type_array
-        from {{ source('ZETTABLOCKS_SUI', 'transactions') }}
-        where block_time >= dateadd(day, -2, current_date)
-        group by transaction_block_digest
-    ),
-    last_2_day as (
-        select 
-            digest as tx_hash,
-            date_trunc('day', tb.block_time) as date, 
-            sender,
-            (total_gas_cost + storage_rebate - storage_cost)/10e8 as tx_fee,
-            (total_gas_cost + storage_rebate - storage_cost)/10e8 * price as gas_usd,
-            package,
-            sui_contracts.name,
-            sui_contracts.namespace,
-            sui_contracts.friendly_name,
-            case 
-                when package is null and array_size(type_array) = 2 and ARRAY_CONTAINS('TransferObjects'::variant, type_array)
-                then 'EOA'
-                else sui_contracts.category 
-            end as category,
-            'sui' as chain,
-            status
-        from {{ source('ZETTABLOCKS_SUI', 'transaction_blocks') }} as tb 
-        left join sui_transactions as t on lower(digest) = lower(transaction_block_digest)
-        left join sui_contracts on lower(package) = lower(address)
-        left join prices on date_trunc('day', tb.block_time) = prices.date
-        where tb.block_time >= dateadd(day, -2, current_date)
-    ),
-    last_day as (
-        select
-            package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd,
-            max(name) name,
-            max(namespace) namespace,
-            max(friendly_name) friendly_name,
-            max(category) category
-        from last_2_day as t
-        where package is not null and t.date >= dateadd(day, -1, current_date)
-        group by package
-    ),
-    two_days as (
-        select
-            t.package package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd
-        from last_2_day as t
-        where
-            package is not null
-            and t.date < dateadd(day, -1, current_date)
-            and t.date >= dateadd(day, -2, current_date)
-        group by t.package
-    )
+{{ config(materialized="table", snowflake_warehouse="BAM_TRENDING_WAREHOUSE") }}
+WITH contracts AS (
+    SELECT
+        *
+    FROM {{ ref('dim_contracts_gold') }}
+    WHERE
+        chain = 'sui'
+), last_day AS (
+    SELECT
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd,
+        metrics.friendly_name,
+        metrics.category
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT join contracts 
+        ON metrics.app = contracts.app
+    where 
+        contracts.address is not null 
+        AND metrics.date >= dateadd(day, -1, current_date)
+), first_day AS (
+    select
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT join contracts 
+        ON metrics.app = contracts.app
+    WHERE
+        contracts.address IS NOT NULL
+        AND metrics.date < dateadd(day, -1, current_date)
+        AND metrics.date >= dateadd(day, -2, current_date)
+)
 select
-    last_day.package as to_address,
-    last_day.txns,
-    last_day.gas,
-    last_day.gas_usd gas_usd,
-    last_day.dau,
-    two_days.txns prev_txns,
-    two_days.gas prev_gas,
-    two_days.gas_usd prev_gas_usd,
-    two_days.dau prev_dau,
-    last_day.name,
-    last_day.namespace,
-    last_day.friendly_name,
-    last_day.category,
+    -- Dedup to pick one record per app
+    MAX(last_day.address) to_address,
+    MAX(last_day.txns) txns,
+    MAX(last_day.gas) gas,
+    MAX(last_day.gas_usd) gas_usd,
+    MAX(last_day.dau) dau,
+    MAX(first_day.txns) prev_txns,
+    MAX(first_day.gas) prev_gas,
+    MAX(first_day.gas_usd) prev_gas_usd,
+    MAX(first_day.dau) prev_dau,
+    MAX(last_day.name) name,
+    last_day.app as namespace,
+    MAX(last_day.friendly_name) friendly_name,
+    MAX(last_day.category) category,
     'daily' as granularity
 from last_day
-left join two_days on lower(last_day.package) = lower(two_days.package)
+left join first_day on lower(last_day.address) = lower(first_day.address)
+group by
+    namespace

--- a/models/staging/sui/sui_trending_weekly_monthly.sql
+++ b/models/staging/sui/sui_trending_weekly_monthly.sql
@@ -1,145 +1,139 @@
-{{ config(materialized="table", snowflake_warehouse="BAM_TRENDING_WAREHOUSE_LG") }}
-
-with
-    sui_contracts as (
-
-        select address, name, app as namespace, friendly_name, category
-        from {{ ref("dim_contracts_gold") }}
-        where chain = 'sui'
-    ),
-    prices as ({{ get_coingecko_price_for_trending("sui") }}),
-    sui_transactions as (
-        select 
-            transaction_block_digest as transaction_block_digest,
-            min_by(package, index) as package,
-            array_agg(type) as type_array
-        from {{ source('ZETTABLOCKS_SUI', 'transactions') }}
-        where block_time >= dateadd(day, -60, current_date)
-        group by transaction_block_digest
-    ),
-    last_2_month as (
-        select 
-            digest as tx_hash,
-            date_trunc('day', tb.block_time) as date, 
-            sender,
-            (total_gas_cost + storage_rebate - storage_cost)/10e8 as tx_fee,
-            (total_gas_cost + storage_rebate - storage_cost)/10e8 * price as gas_usd,
-            package,
-            sui_contracts.name,
-            sui_contracts.namespace,
-            sui_contracts.friendly_name,
-            case 
-                when package is null and array_size(type_array) = 2 and ARRAY_CONTAINS('TransferObjects'::variant, type_array)
-                then 'EOA'
-                else sui_contracts.category 
-            end as category,
-            'sui' as chain,
-            status
-        from {{ source('ZETTABLOCKS_SUI', 'transaction_blocks') }} as tb 
-        left join sui_transactions as t on lower(digest) = lower(transaction_block_digest)
-        left join sui_contracts on lower(package) = lower(address)
-        left join prices on date_trunc('day', tb.block_time) = prices.date
-        where tb.block_time >= dateadd(day, -60, current_date)
-    ),
-    last_week as (
-        select
-            package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd,
-            max(name) name,
-            max(namespace) namespace,
-            max(friendly_name) friendly_name,
-            max(category) category
-        from last_2_month as t
-        where package is not null and t.date >= dateadd(day, -7, current_date)
-        group by package
-    ),
-    two_week as (
-        select
-            t.package package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd
-        from last_2_month as t
-        where
-            package is not null
-            and t.date < dateadd(day, -7, current_date)
-            and t.date >= dateadd(day, -14, current_date)
-        group by t.package
-    ),
-    trending_week as (
-        select
-            last_week.package as to_address,
-            last_week.txns,
-            last_week.gas,
-            last_week.gas_usd,
-            last_week.dau,
-            two_week.txns prev_txns,
-            two_week.gas prev_gas,
-            two_week.gas_usd prev_gas_usd,
-            two_week.dau prev_dau,
-            last_week.name,
-            last_week.namespace,
-            last_week.friendly_name,
-            last_week.category,
-            'weekly' as granularity
-        from last_week
-        left join two_week on lower(last_week.package) = lower(two_week.package)
-    ),
-    last_month as (
-        select
-            package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd,
-            max(name) name,
-            max(namespace) namespace,
-            max(friendly_name) friendly_name,
-            max(category) category
-        from last_2_month as t
-        where package is not null and t.date >= dateadd(day, -30, current_date)
-        group by package
-    ),
-    two_month as (
-        select
-            t.package package,
-            count(*) txns,
-            count(distinct(sender)) dau,
-            sum(tx_fee) as gas,
-            sum(gas_usd) as gas_usd
-        from last_2_month as t
-        where
-            package is not null
-            and t.date < dateadd(day, -30, current_date)
-            and t.date >= dateadd(day, -60, current_date)
-        group by t.package
-    ),
-    trending_month as (
-        select
-            last_month.package as to_address,
-            last_month.txns,
-            last_month.gas,
-            last_month.gas_usd,
-            last_month.dau,
-            two_month.txns prev_txns,
-            two_month.gas prev_gas,
-            two_month.gas_usd prev_gas_usd,
-            two_month.dau prev_dau,
-            last_month.name,
-            last_month.namespace,
-            last_month.friendly_name,
-            last_month.category,
-            'monthly' as granularity
-        from last_month
-        left join
-            two_month on lower(last_month.package) = lower(two_month.package)
-    )
-select *
-from trending_week
-union
-select *
-from trending_month
+{{ config(materialized="table", snowflake_warehouse="BAM_TRENDING_WAREHOUSE") }}
+WITH contracts AS (
+    SELECT
+        *
+    FROM {{ ref('dim_contracts_gold') }}
+    WHERE
+        chain = 'sui'
+), last_week AS (
+    SELECT
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd,
+        metrics.friendly_name,
+        metrics.category
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT JOIN contracts
+        ON metrics.app = contracts.app
+    where 
+        contracts.address is not null 
+        AND metrics.date >= dateadd(month, -7, current_date)
+), first_week AS (
+    select
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd,
+        metrics.friendly_name,
+        metrics.category
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT JOIN contracts
+        ON metrics.app = contracts.app
+    WHERE
+        contracts.address is not null 
+        AND metrics.date < dateadd(day, -7, current_date)
+        AND metrics.date >= dateadd(day, -14, current_date)
+), trending_week AS (
+    select
+        last_week.address,
+        last_week.txns,
+        last_week.gas,
+        last_week.gas_usd,
+        last_week.dau,
+        first_week.txns prev_txns,
+        first_week.gas prev_gas,
+        first_week.gas_usd prev_gas_usd,
+        first_week.dau prev_dau,
+        last_week.name,
+        last_week.app namespace,
+        last_week.friendly_name,
+        last_week.category,
+        'weekly' as granularity
+    from last_week
+    left join first_week on lower(last_week.address) = lower(first_week.address)
+), last_month AS (
+    SELECT
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd,
+        metrics.friendly_name,
+        metrics.category
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT JOIN contracts
+        ON metrics.app = contracts.app
+    where 
+        contracts.address is not null 
+        AND metrics.date >= dateadd(month, -30, current_date)
+), first_month AS (
+    select
+        contracts.address,
+        contracts.name,
+        metrics.app,
+        metrics.txns,
+        metrics.dau,
+        metrics.gas,
+        metrics.gas_usd,
+        metrics.friendly_name,
+        metrics.category
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    LEFT JOIN contracts
+        ON metrics.app = contracts.app
+    where 
+        contracts.address is not null 
+        AND metrics.date < dateadd(day, -30, current_date)
+        AND metrics.date >= dateadd(day, -60, current_date)
+), trending_month as (
+    select
+        last_month.address to_address,
+        last_month.txns,
+        last_month.gas,
+        last_month.gas_usd,
+        last_month.dau,
+        first_month.txns prev_txns,
+        first_month.gas prev_gas,
+        first_month.gas_usd prev_gas_usd,
+        first_month.dau prev_dau,
+        last_month.name,
+        last_month.app as namespace,
+        last_month.friendly_name,
+        last_month.category,
+        'monthly' as granularity
+    from last_month
+    left join first_month on lower(last_month.address) = lower(first_month.address)
+), unioned AS (
+    select *
+    from trending_week
+    union
+    select *
+    from trending_month
+)
+-- Dedup to pick one record per app
+SELECT
+    MAX(address) to_address,
+    MAX(txns) txns,
+    MAX(gas) gas,
+    MAX(gas_usd) gas_usd,
+    MAX(dau) dau,
+    MAX(prev_txns) prev_txns,
+    MAX(prev_gas) prev_gas,
+    MAX(prev_gas_usd) prev_gas_usd,
+    MAX(prev_dau) prev_dau,
+    MAX(name) name,
+    namespace,
+    MAX(friendly_name) friendly_name,
+    MAX(category) category,
+    granularity
+FROM unioned
+group by
+    namespace, granularity


### PR DESCRIPTION
1. porting over BQ to rely on BQ data

NOT DONE: Still need to test the models in dbt

To Do:
1. Waiting until we can select assets for BQ with a group name
2. Need to delete old sui models and deprecate sui transactions (delete from `prod_raw`)
