### PR TITLE
Art Share: Adding geo to art share

### DIFF
--- a/models/common/__common__sources.yml
+++ b/models/common/__common__sources.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: GEO
+    schema: PROD
+    database: PC_DBT_DB
+    tables:
+      - name: dim_geo_labels

--- a/models/common/dim_geo_location_labels.sql
+++ b/models/common/dim_geo_location_labels.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        snowflake_warehouse="COMMON",
+        database="common",
+        schema="core",
+        materialized='view'
+    )
+}}
+
+
+select
+    *
+from {{source("GEO", "dim_geo_labels")}}


### PR DESCRIPTION
1. Adding support for Geo Labels in Art Share. Request from Enterprise Customer