### PR TITLE
C911: Fixing uniswap pricing by adding dust filter

### DIFF
--- a/macros/decentralized_exchanges/fact_dex_priced_tokens.sql
+++ b/macros/decentralized_exchanges/fact_dex_priced_tokens.sql
@@ -25,7 +25,8 @@
                 or 
                 lower(token1) in (select lower(contract_address) from {{ref("fact_" ~chain~"_stablecoin_contracts")}})
             )
-            and token0_amount > 0 and token1_amount > 0
+            --TODO: this is a temporary fix, we need to find a better way to filter out dust swaps
+            and token0_amount > .00001 and token1_amount > .00001
             {% if is_incremental() %}
                 and block_timestamp >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
             {% endif %}

--- a/models/projects/uniswap/raw/ez_uniswap_price_performance.sql
+++ b/models/projects/uniswap/raw/ez_uniswap_price_performance.sql
@@ -28,6 +28,8 @@ prices as (
     inner join tracked_metadata 
         on lower(t1.token_address) = lower(tracked_metadata.contract_address) 
         and t1.chain = tracked_metadata.chain
+    -- Filter out EURC pairs becuase we want to price things in USD
+    where pair not like '%EURC%'
 )
 
 select
@@ -36,6 +38,7 @@ select
     , max(price) as high
     , min(price) as low
     , avg(price) as average
+    , median(price) as median
     , nyc_operating_hours
 from prices
 group by hour, symbol, nyc_operating_hours


### PR DESCRIPTION
Fixing uniswap pricing model by removing dust trades. This is not a perfect filter because different tokens have different prices and the price of the token effects how this filter works but right now we can keep it simple