### PR TITLE
Stablecoins: `num_p2p_stablecoin_token_holders`, `num_stablecoin_token_holders`

### DIFF
--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -30,6 +30,10 @@ with mau as (
         , p2p_stablecoin_daily_txns as p2p_stablecoin_txns
         , p2p_stablecoin_dau
 
+        , num_stablecoin_token_holders as token_holder_count
+        , num_p2p_stablecoin_token_holders as p2p_token_holder_count
+
+        , p2p_stablecoin_supply as p2p_stablecoin_total_supply
         , stablecoin_supply as stablecoin_total_supply
     from {{ ref("agg_daily_stablecoin_breakdown_" ~ breakdown) }}
     {% if breakdown == "chain" %}
@@ -53,6 +57,9 @@ select
     , p2p_stablecoin_txns
     , p2p_stablecoin_dau
     , p2p_stablecoin_mau
+    , token_holder_count
+    , p2p_token_holder_count
+    , p2p_stablecoin_total_supply
     , stablecoin_total_supply
 from daily_metrics
 left join mau on daily_metrics.date = mau.date

--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -29,7 +29,8 @@ select
         when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
         else 0
     end as p2p_stablecoin_avg_txn_value
-
+    , count(distinct case when stablecoin_supply > 0 then from_address end) as num_stablecoin_token_holders
+    , count(distinct case when stablecoin_supply > 0 and is_wallet::number = 1 then from_address end) as num_p2p_stablecoin_token_holders
     {% if granularity == 'day' %}
         , sum(stablecoin_supply) as stablecoin_supply
         , sum(case when is_wallet::number = 1 then stablecoin_supply else 0 end) as p2p_stablecoin_supply


### PR DESCRIPTION
1. Adding support for the following metrics: `num_p2p_stablecoin_token_holders`, `num_stablecoin_token_holders`
2. These holders are >$.01. Anything less we currently don't count as a holder

To Do:
1. Re-backfill the tables tomorrow (will merge this tomorrow morning)