### PR TITLE
Incase: removing token holders for stablecoin data

### DIFF
--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -30,9 +30,6 @@ with mau as (
         , p2p_stablecoin_daily_txns as p2p_stablecoin_txns
         , p2p_stablecoin_dau
 
-        , num_stablecoin_token_holders as token_holder_count
-        , num_p2p_stablecoin_token_holders as p2p_token_holder_count
-
         , p2p_stablecoin_supply as p2p_stablecoin_total_supply
         , stablecoin_supply as stablecoin_total_supply
     from {{ ref("agg_daily_stablecoin_breakdown_" ~ breakdown) }}
@@ -57,8 +54,6 @@ select
     , p2p_stablecoin_txns
     , p2p_stablecoin_dau
     , p2p_stablecoin_mau
-    , token_holder_count
-    , p2p_token_holder_count
     , p2p_stablecoin_total_supply
     , stablecoin_total_supply
 from daily_metrics

--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -29,8 +29,6 @@ select
         when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
         else 0
     end as p2p_stablecoin_avg_txn_value
-    , count(distinct case when stablecoin_supply > 0 then from_address end) as num_stablecoin_token_holders
-    , count(distinct case when stablecoin_supply > 0 and is_wallet::number = 1 then from_address end) as num_p2p_stablecoin_token_holders
     {% if granularity == 'day' %}
         , sum(stablecoin_supply) as stablecoin_supply
         , sum(case when is_wallet::number = 1 then stablecoin_supply else 0 end) as p2p_stablecoin_supply


### PR DESCRIPTION
I am currently trying to backfill token holder data but the data has been running for 4 hours with no end in sight. We are still on the first set of models. Because of this I have created a PR to easily revert the change. I will have the re-run the models that finished but that should be easy. If this is not done by 9:30 I will revert the change. 

To Fix:
1. Only run this on the daily models
2. Add more stablecoin warehouses. It has no extract cost and will reduce the queued models

https://artemis.dagster.cloud/prod/runs/235c1451-8d71-4f9a-912d-2be7c59bbdc8?logFileKey=yrfeyfqw&selection=%2A
https://artemis.dagster.cloud/prod/runs/716ba6e0-bbb4-4e47-901d-6bfd3d494234
https://artemis.dagster.cloud/prod/runs/c20bafab-a8e7-4ea4-88d2-88e962c475b7?logFileKey=duanrxnz&selection=%2A