### PR TITLE
Stablecoins: Add Token Holders

### DIFF
--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -29,6 +29,10 @@ select
         when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
         else 0
     end as p2p_stablecoin_avg_txn_value
+    {% if granularity == 'day' and (breakdown == ['symbol'] or breakdown == ['chain']) %}
+        , count(distinct case when stablecoin_supply > 0 then from_address end) as stablecoin_token_holder_count
+        , count(distinct case when is_wallet::number = 1 and stablecoin_supply > 0 then from_address end) as p2p_stablecoin_token_holder_count
+    {% endif %}
     {% if granularity == 'day' %}
         , sum(stablecoin_supply) as stablecoin_supply
         , sum(case when is_wallet::number = 1 then stablecoin_supply else 0 end) as p2p_stablecoin_supply


### PR DESCRIPTION
1. Adding Token Holders to the daily chain and daily symbol aggregate tables. I dont want to add these metrics to all of the models because they can be quite expensive to compute, see [this](https://artemisxyz.slack.com/archives/C05S8H76M08/p1729676854355899) slack message for more info on why and what happened.