### PR TITLE
Stablecoins: fix stablecoin token holders code

### DIFF
--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -29,7 +29,7 @@ select
         when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
         else 0
     end as p2p_stablecoin_avg_txn_value
-    {% if granularity == 'day' and breakdown | length == 1 and (breakdown[0] == 'symbol' or breakdown[0] == 'chain') %}
+    {% if granularity == 'day' and breakdowns | length == 1 and (breakdowns[0] == 'symbol' or breakdowns[0] == 'chain') %}
         , count(distinct case when stablecoin_supply > 0 then from_address end) as stablecoin_token_holder_count
         , count(distinct case when is_wallet::number = 1 and stablecoin_supply > 0 then from_address end) as p2p_stablecoin_token_holder_count
     {% endif %}

--- a/macros/stablecoins/stablecoin_breakdown.sql
+++ b/macros/stablecoins/stablecoin_breakdown.sql
@@ -29,7 +29,7 @@ select
         when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
         else 0
     end as p2p_stablecoin_avg_txn_value
-    {% if granularity == 'day' and (breakdown == ['symbol'] or breakdown == ['chain']) %}
+    {% if granularity == 'day' and breakdown | length == 1 and (breakdown[0] == 'symbol' or breakdown[0] == 'chain') %}
         , count(distinct case when stablecoin_supply > 0 then from_address end) as stablecoin_token_holder_count
         , count(distinct case when is_wallet::number = 1 and stablecoin_supply > 0 then from_address end) as p2p_stablecoin_token_holder_count
     {% endif %}


### PR DESCRIPTION
The old code did not compile properly. The two knew columns were left out. This si the compiled code form SF:

```
create or replace transient table PC_DBT_DB.PROD.agg_daily_stablecoin_breakdown_symbol
         as
        (






select
    date_trunc('day', date) as date_granularity
    
        
            , symbol
        
    
    , count(distinct case when stablecoin_daily_txns > 0 then from_address end) as stablecoin_dau
    , sum(stablecoin_transfer_volume) as stablecoin_transfer_volume
    , sum(stablecoin_daily_txns) as stablecoin_daily_txns
    , case 
        when sum(stablecoin_daily_txns) > 0 then sum(stablecoin_transfer_volume) / sum(stablecoin_daily_txns) 
        else 0
    end as stablecoin_avg_txn_value
    , count(distinct case when artemis_stablecoin_daily_txns > 0 then from_address end) as artemis_stablecoin_dau
    , sum(artemis_stablecoin_transfer_volume) as artemis_stablecoin_transfer_volume
    , sum(artemis_stablecoin_daily_txns) as artemis_stablecoin_daily_txns
    , case
        when sum(artemis_stablecoin_daily_txns) > 0 then sum(artemis_stablecoin_transfer_volume) / sum(artemis_stablecoin_daily_txns) 
        else 0
    end as artemis_stablecoin_avg_txn_value
    , count(distinct case when p2p_stablecoin_daily_txns > 0 then from_address end) as p2p_stablecoin_dau
    , sum(p2p_stablecoin_transfer_volume) as p2p_stablecoin_transfer_volume
    , sum(p2p_stablecoin_daily_txns) as p2p_stablecoin_daily_txns
    , case
        when sum(p2p_stablecoin_daily_txns) > 0 then sum(p2p_stablecoin_transfer_volume) / sum(p2p_stablecoin_daily_txns) 
        else 0
    end as p2p_stablecoin_avg_txn_value
    
        , count(distinct case when stablecoin_supply > 0 then from_address end) as stablecoin_token_holder_count
        , count(distinct case when is_wallet::number = 1 and stablecoin_supply > 0 then from_address end) as p2p_stablecoin_token_holder_count
    
    
        , sum(stablecoin_supply) as stablecoin_supply
        , sum(case when is_wallet::number = 1 then stablecoin_supply else 0 end) as p2p_stablecoin_supply
    
from PC_DBT_DB.PROD.agg_daily_stablecoin_breakdown_silver


group by date_granularity , symbol 
order by date_granularity

        );
```

This contains the token holder columns which is correct.