### PR TITLE
Uniswap: fixing NYSE operating hours

### DIFF
--- a/models/projects/uniswap/raw/ez_uniswap_price_performance.sql
+++ b/models/projects/uniswap/raw/ez_uniswap_price_performance.sql
@@ -21,7 +21,7 @@ prices as (
         , price
         , CASE 
             when date_part('DOW', convert_timezone('UTC', 'America/New_York', block_timestamp)) IN (0, 6) then 'FALSE'
-            when convert_timezone('UTC', 'America/New_York', block_timestamp)::time between '09:00:00' and '17:00:00' then 'TRUE'
+            when convert_timezone('UTC', 'America/New_York', block_timestamp)::time between '09:00:00' and '15:59:59' then 'TRUE'
             else 'FALSE'
         END AS nyc_operating_hours
     from {{ref('fact_uniswap_dex_token_prices')}} t1


### PR DESCRIPTION
NYSE opterating hours are 9:30 to 4. Since we trunc by hour we say it is 9 to 4 exclusive of 4pm. 

This was Flagged by @alexwes: https://artemisxyz.slack.com/archives/C06GXJ5JTL6/p1729790206719149?thread_ts=1729720536.202329&cid=C06GXJ5JTL6