### PR TITLE
Stablecoins: Update Column Name for Stablecoins

### DIFF
--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -57,8 +57,14 @@ select
     , p2p_stablecoin_txns
     , p2p_stablecoin_dau
     , p2p_stablecoin_mau
-    , stablecoin_token_holder_count
-    , p2p_stablecoin_token_holder_count
+    {% if breakdown == "chain" %}
+        , stablecoin_token_holder_count
+        , p2p_stablecoin_token_holder_count
+    {% elif breakdown == "symbol" %}
+        , stablecoin_token_holder_count as token_holder_count
+        , p2p_stablecoin_token_holder_count as p2p_token_holder_count
+    {% endif %}
+    
     , p2p_stablecoin_total_supply
     , stablecoin_total_supply
 from daily_metrics

--- a/macros/metrics/get_stablecoin_metrics.sql
+++ b/macros/metrics/get_stablecoin_metrics.sql
@@ -64,7 +64,6 @@ select
         , stablecoin_token_holder_count as token_holder_count
         , p2p_stablecoin_token_holder_count as p2p_token_holder_count
     {% endif %}
-    
     , p2p_stablecoin_total_supply
     , stablecoin_total_supply
 from daily_metrics


### PR DESCRIPTION
1. Update column name `stablecoin_token_holder_count` to `token_holder_count` for the `ez_metric` table for stablecoins and not for chains. This is because when thinking about AUSD as a stablecoin you what the token_holder_count for AUSD and for ethereum you would want the `stablecoin_token_holder_count` which would be different then `token_holder_count`. `token_holder_count` count for a chain should be the number of holders of the native token.

<img width="1127" alt="Screenshot 2024-10-25 at 10 25 51 AM" src="https://github.com/user-attachments/assets/8407ea17-d1d7-4755-b3e1-1bfa319ad898">
