### PR TITLE
Stablecoins: adding underlying Mantle tables to support stablecoins

### DIFF
--- a/macros/address_balances/address_credits_dune.sql
+++ b/macros/address_balances/address_credits_dune.sql
@@ -1,0 +1,21 @@
+-- This model currently does not take into account native tokens.
+-- TODO: Add support for native tokens
+{% macro address_credits_dune(chain) %}
+select
+    to_address as address,
+    contract_address,
+    block_timestamp,
+    cast(amount as float) as credit,
+    null as credit_usd,
+    tx_hash,
+    null as trace_index,
+    event_index
+from {{ ref("fact_" ~ chain ~ "_token_transfers") }}
+where
+    to_address <> lower('0x0000000000000000000000000000000000000000')
+    and to_date(block_timestamp) < to_date(sysdate())
+    {% if is_incremental() %}
+        and block_timestamp
+        >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}
+{% endmacro %}

--- a/macros/address_balances/address_debits_dune.sql
+++ b/macros/address_balances/address_debits_dune.sql
@@ -1,0 +1,21 @@
+-- This model currently does not take into account native tokens.
+-- TODO: Add support for native tokens
+{% macro address_debits_dune(chain) %}
+select
+    from_address as address,
+    contract_address,
+    block_timestamp,
+    cast(amount * -1 as float) as debit,
+    null as debit_usd,
+    tx_hash,
+    null as trace_index,
+    event_index
+from {{ ref("fact_" ~ chain ~ "_token_transfers")}}
+where
+    to_date(block_timestamp) < to_date(sysdate())
+    and from_address <> lower('0x0000000000000000000000000000000000000000')
+    {% if is_incremental() %}
+        and block_timestamp
+        >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}
+{% endmacro %}

--- a/macros/decode/token_transfer_events.sql
+++ b/macros/decode/token_transfer_events.sql
@@ -1,45 +1,67 @@
 {% macro token_transfer_events(chain) %}
-    select
-        block_timestamp,
-        block_number,
-        transaction_hash,
-        event_index,
-        origin_from_address,
-        origin_to_address,
-        contract_address,
-        decoded_log:"from"::string as from_address,
-        decoded_log:"to"::string as to_address,
-        try_to_number(decoded_log:"value"::string) as amount,
-        tx_status
-    from {{ ref("fact_" ~ chain ~ "_decoded_events") }}
-    where topic_zero = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
-        and data != '0x'
-        and amount is not null
-        and tx_status = 1
-    {% if is_incremental() %}
-        and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
-    {% endif %}
-    {% if chain in ('celo') %}
-        union all
+    {% if chain in ('mantle') %}
+        select 
+            block_time as block_timestamp
+            , block_date as raw_date
+            , block_number
+            , block_hash_hex as block_hash
+            , tx_hash_hex as tx_hash
+            , contract_address_hex as contract_address
+            , tx_from_hex as origin_from_address
+            , tx_to_hex as origin_to_address
+            , index as event_index
+            , '0x' || substr(topic1_hex, 27) as from_address
+            , '0x' || substr(topic2_hex, 27) as to_address
+            , try_to_number(pc_dbt_db.prod.hex_to_int(data_hex)) as amount
+        from zksync_dune.{{chain}}.logs 
+        where topic0_hex = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+            and data_hex != '0x'
+            {% if is_incremental() %}
+                and block_time >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+            {% endif %}
+    {% else %}
         select
-            t1.block_timestamp,
-            t1.block_number,
-            t1.transaction_hash,
-            null as event_index,
-            t1.from_address as origin_from_address,
-            t1.to_address as origin_to_address,
-            t1.fee_currency as contract_address,
-            t1.from_address,
-            t2.miner as to_address,
-            t1.gas * t1.gas_price as amount,
-            1 as tx_status -- Fees are paid whether or not the transaction is successful
-        from {{ref("fact_celo_transactions")}} t1
-        left join {{ref("fact_celo_blocks")}} t2
-            using (block_number)
-        where fee_currency is not null 
-         {% if is_incremental() %}
+            block_timestamp,
+            block_number,
+            transaction_hash,
+            event_index,
+            origin_from_address,
+            origin_to_address,
+            contract_address,
+            decoded_log:"from"::string as from_address,
+            decoded_log:"to"::string as to_address,
+            try_to_number(decoded_log:"value"::string) as amount,
+            tx_status
+        from {{ ref("fact_" ~ chain ~ "_decoded_events") }}
+        where topic_zero = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
+            and data != '0x'
+            and amount is not null
+            and tx_status = 1
+        {% if is_incremental() %}
             and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
+        {% if chain in ('celo') %}
+            union all
+            select
+                t1.block_timestamp,
+                t1.block_number,
+                t1.transaction_hash,
+                null as event_index,
+                t1.from_address as origin_from_address,
+                t1.to_address as origin_to_address,
+                t1.fee_currency as contract_address,
+                t1.from_address,
+                t2.miner as to_address,
+                t1.gas * t1.gas_price as amount,
+                1 as tx_status -- Fees are paid whether or not the transaction is successful
+            from {{ref("fact_celo_transactions")}} t1
+            left join {{ref("fact_celo_blocks")}} t2
+                using (block_number)
+            where fee_currency is not null 
+            {% if is_incremental() %}
+                and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+            {% endif %}
 
+        {% endif %}
     {% endif %}
 {% endmacro %}

--- a/models/dimensions/contracts/dim_mantle_contract_addresses.sql
+++ b/models/dimensions/contracts/dim_mantle_contract_addresses.sql
@@ -1,0 +1,8 @@
+{{ 
+    config(
+        materialized="incremental",
+        snowflake_warehouse="MANTLE"
+    )
+}}
+
+{{distinct_contract_addresses("mantle")}}

--- a/models/dimensions/current_balances/dim_mantle_current_balances.sql
+++ b/models/dimensions/current_balances/dim_mantle_current_balances.sql
@@ -1,0 +1,4 @@
+-- depends_on: {{ ref("fact_mantle_address_balances_by_token") }}
+{{ config(materialized="incremental", unique_key=["address", "contract_address"]) }}
+
+{{ current_balances("mantle") }}

--- a/models/metrics/stablecoins/contracts/fact_mantle_stablecoin_contracts.sql
+++ b/models/metrics/stablecoins/contracts/fact_mantle_stablecoin_contracts.sql
@@ -1,0 +1,16 @@
+{{ config(materialized="table") }}
+select symbol, contract_address, num_decimals, coingecko_id, initial_supply
+from
+    (
+        values
+            ('USDC', '0x09Bc4E0D864854c6aFB6eB9A9cdF58aC190D0dF9', 6, 'usd-coin', 0),
+            ('USDT', '0x201EBa5CC46D216Ce6DC03F6a759e8E766e956aE', 6, 'tether', 0),
+            (
+                'USDe',
+                '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+                18,
+                'ethena-usde',
+                0
+            ),
+            ('AUSD', '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a', 6, 'agora-dollar', 0)
+    ) as results(symbol, contract_address, num_decimals, coingecko_id, initial_supply)

--- a/models/metrics/stablecoins/transfers/fact_mantle_stablecoin_transfers.sql
+++ b/models/metrics/stablecoins/transfers/fact_mantle_stablecoin_transfers.sql
@@ -1,0 +1,7 @@
+{{ config(
+        materialized="incremental", 
+        snowflake_warehouse="STABLECOIN_LG_2", 
+        unique_key=["tx_hash", "index"],
+    ) 
+}}
+{{ agg_chain_stablecoin_transfers("mantle") }}

--- a/models/staging/mantle/__mantle__sources.yml
+++ b/models/staging/mantle/__mantle__sources.yml
@@ -8,3 +8,8 @@ sources:
       - name: raw_mantle_gas
       - name: raw_mantle_expenses
       - name: raw_meth_staked_eth_count
+  - name: BALANCES
+    schema: PROD
+    database: PC_DBT_DB
+    tables:
+      - name: dim_mantle_current_balances

--- a/models/staging/mantle/fact_mantle_address_balances_by_token.sql
+++ b/models/staging/mantle/fact_mantle_address_balances_by_token.sql
@@ -1,0 +1,12 @@
+-- depends_on: {{ ref("fact_mantle_address_credit_by_token") }}
+-- depends_on: {{ ref("fact_mantle_address_debit_by_token") }}
+-- depends_on: {{ source("BALANCES", "dim_mantle_current_balances") }}
+{{
+    config(
+        materialized="incremental",
+        unique_key=["address", "contract_address", "block_timestamp"],
+        snowflake_warehouse="MANTLE",
+    )
+}}
+
+{{ address_balances("mantle") }}

--- a/models/staging/mantle/fact_mantle_address_credit_by_token.sql
+++ b/models/staging/mantle/fact_mantle_address_credit_by_token.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="table",
+        unique_key=["tx_hash", "event_index", "trace_index"],
+        snowflake_warehouse="MANTLE",
+    )
+}}
+
+{{ address_credits_dune("mantle") }}

--- a/models/staging/mantle/fact_mantle_address_debit_by_token.sql
+++ b/models/staging/mantle/fact_mantle_address_debit_by_token.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="table",
+        unique_key=["tx_hash", "event_index", "trace_index"],
+        snowflake_warehouse="MANTLE",
+    )
+}}
+
+{{ address_debits_dune("mantle") }}

--- a/models/staging/mantle/fact_mantle_p2p_stablecoin_transfers.sql
+++ b/models/staging/mantle/fact_mantle_p2p_stablecoin_transfers.sql
@@ -1,0 +1,9 @@
+--depends_on: {{ ref("fact_mantle_stablecoin_transfers") }}
+{{
+    config(
+        materialized="incremental",
+        unique_key=["tx_hash", "index"],
+    )
+}}
+
+{{ p2p_stablecoin_transfers("mantle") }}

--- a/models/staging/mantle/fact_mantle_token_transfers.sql
+++ b/models/staging/mantle/fact_mantle_token_transfers.sql
@@ -1,0 +1,3 @@
+{{ config(materialized="incremental", unique_key=["tx_hash", "event_index"]) }}
+
+{{ token_transfer_events("mantle") }}


### PR DESCRIPTION
1. Adding underlying tables to support stablecoin metrics. The data is currently being ingested from Dune where we build the token transfers table as well as dim contracts table. We can then create the stablecoin transfers and p2p stablecoin transfers table as well as the balances pipeline.

To Do:
1. Create the stablecoin v3 tables (balance, and metric tables)