### PR TITLE
Stablecoins: Mantle Stablecoin Models

### DIFF
--- a/models/projects/mantle/core/ez_mantle_stablecoin_metrics_by_address.sql
+++ b/models/projects/mantle/core/ez_mantle_stablecoin_metrics_by_address.sql
@@ -1,0 +1,13 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        database="mantle",
+        schema="core",
+        alias="ez_stablecoin_metrics_by_address",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics("mantle")}}

--- a/models/staging/mantle/fact_mantle_stablecoin_balances.sql
+++ b/models/staging/mantle/fact_mantle_stablecoin_balances.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_balances("mantle")}}

--- a/models/staging/mantle/fact_mantle_stablecoin_metrics_all.sql
+++ b/models/staging/mantle/fact_mantle_stablecoin_metrics_all.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_all("mantle")}}

--- a/models/staging/mantle/fact_mantle_stablecoin_metrics_artemis.sql
+++ b/models/staging/mantle/fact_mantle_stablecoin_metrics_artemis.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_artemis("mantle")}}

--- a/models/staging/mantle/fact_mantle_stablecoin_metrics_p2p.sql
+++ b/models/staging/mantle/fact_mantle_stablecoin_metrics_p2p.sql
@@ -1,0 +1,10 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="unique_id",
+        snowflake_warehouse="STABLECOIN_V2_LG_2",
+    )
+}}
+
+
+{{stablecoin_metrics_p2p("mantle")}}


### PR DESCRIPTION
For Mantle:
1. Adding Stablecoin metric and balances models.
2. Adding Stablecoin metrics by address

To Do:
1. Dune data is not backfilled currently only data back to oct. 22nd. Working with Dune to get this fixed then I need to backfill the transfers tables