### PR TITLE
Stablecoins: updating artemis stablecoin metrics

### DIFF
--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -34,7 +34,7 @@ with
         from stablecoin_transfers st
         left join filtered_contracts dl on lower(st.from_address) = lower(dl.address)
         left join filtered_contracts dlt on lower(st.to_address) = lower(dlt.address)
-        where lower(from_app) != 'mev' and lower(to_app) != 'mev'
+        where lower(from_category) != 'mev' and lower(from_category) != 'mev'
     ),
     artemis_cex_filters as (
         select distinct tx_hash

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -29,8 +29,10 @@ with
             st.*
             , coalesce(dl.app,'other') as from_app
             , coalesce(dlt.app,'other') as to_app
-            , coalesce(dl.sub_category,'other') as from_category
-            , coalesce(dlt.sub_category,'other') as to_category
+            , coalesce(dl.category,'other') as from_category
+            , coalesce(dlt.category,'other') as to_category
+            , coalesce(dl.sub_category,'other') as from_sub_category
+            , coalesce(dlt.sub_category,'other') as to_sub_category
         from stablecoin_transfers st
         left join filtered_contracts dl on lower(st.from_address) = lower(dl.address)
         left join filtered_contracts dlt on lower(st.to_address) = lower(dlt.address)
@@ -40,7 +42,7 @@ with
         select distinct tx_hash
         from artemis_mev_filtered
         where from_app = to_app
-            and lower(from_category) in ('cex', 'market maker') 
+            and lower(from_sub_category) in ('cex', 'market maker') 
     ),
     artemis_ranked_transfer_filter as (
         select 


### PR DESCRIPTION
We now support two types of MEV tags, `farming-mev` and `mev`. Because of this I want to remove transactions based on if the app is tagged to the category MEV rather than if the app is `mev`. This will scale better as our MEV tagging becomes more nuanced and we refine the types of MEV we tag.