### PR TITLE
Stablecoins: updating stablecoin warehouses

### DIFF
--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "application"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "application"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{ stablecoin_breakdown(["application"]) }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "application"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "application"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{stablecoin_breakdown(["chain", "application"])}}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_application_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "application"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "application"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{stablecoin_breakdown(["symbol", "application"])}}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{ stablecoin_breakdown(["category"]) }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{stablecoin_breakdown(["chain", "category"])}}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{stablecoin_breakdown(["symbol", "category"])}}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_category_symbol_chain.sql
@@ -1,2 +1,2 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category", "symbol"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category", "symbol"], snowflake_warehouse="STABLECOIN_DAILY") }}
 {{ stablecoin_breakdown(["chain", "category", "symbol"]) }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{ stablecoin_breakdown(["chain"]) }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{ stablecoin_breakdown(["symbol"]) }}

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_symbol_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_DAILY") }}
 
 {{ stablecoin_breakdown(["symbol", "chain"]) }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{ stablecoin_breakdown(["category"], 'month') }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain", "category"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{stablecoin_breakdown(["chain", "category"], "month")}}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{stablecoin_breakdown(["symbol", "category"], "month")}}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_category_symbol_chain.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain", "category"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{ stablecoin_breakdown(["chain", "category", "symbol"], "month") }}
 

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{ stablecoin_breakdown(["chain"], "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{ stablecoin_breakdown(["symbol"], "month") }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_symbol_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_WEEKLY") }}
 
 {{ stablecoin_breakdown(["symbol", "chain"], "month") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "category"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{ stablecoin_breakdown(["category"], 'week') }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "category", "chain"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "category", "chain"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{stablecoin_breakdown(["chain", "category"], "week")}}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{stablecoin_breakdown(["symbol", "category"], "week")}}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_category_symbol_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category", "chain"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "category", "chain"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{ stablecoin_breakdown(["chain", "category", "symbol"], "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_V2_LG") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "chain"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{ stablecoin_breakdown(["chain"], "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_symbol.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_symbol.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{ stablecoin_breakdown(["symbol"], "week") }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_symbol_chain.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_symbol_chain.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_V2_LG_2") }}
+{{ config(materialized="incremental", unique_key=["date_granularity", "symbol", "chain"], snowflake_warehouse="STABLECOIN_MONTHLY") }}
 
 {{ stablecoin_breakdown(["symbol", "chain"], "week") }}


### PR DESCRIPTION
Creating specific warehouses for the `daily`, `weekly` and `monthly` stablecoin models. This should help speed up the materializations of a full refresh. 