### PR TITLE
Update Cardano Fees to new Upstream Source

### DIFF
--- a/models/staging/cardano/fact_cardano_fees_and_revenue.sql
+++ b/models/staging/cardano/fact_cardano_fees_and_revenue.sql
@@ -6,7 +6,7 @@ with
     ),
     cardano_prices as ({{ get_coingecko_price_with_latest("cardano") }}),
     raw as (
-        select date(value:date) as date, value:"fees"::int as fees, value as source
+        select date(value:date) as date, value:"fees_usd"::int as fees_usd, value as source
         from
             {{ source("PROD_LANDING", "raw_cardano_fees") }},
             lateral flatten(input => parse_json(source_json))
@@ -15,8 +15,8 @@ with
 select
     raw.date,
     'cardano' as chain,
-    fees as gas,
-    fees * coalesce(price, 0) as gas_usd,
+    fees_usd / coalesce(price, 0) as gas,
+    fees_usd as gas_usd,
     0 as revenue
 from raw
 left join cardano_prices on raw.date = cardano_prices.date


### PR DESCRIPTION
## Summary

- Update to pull from new upstream source that returns `gas_usd`
- Convert back to native units of ADA 

## Test Plan
Executed compiled SQL query in Snowflake and data looks good

<img width="1025" alt="image" src="https://github.com/user-attachments/assets/b48dd58b-c107-46ec-81c5-9b3a6b97b52a">

