### PR TITLE
Specify dbt-core subversion, install using uv in syncenv script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dbt-bigquery==1.7.4
-dbt-core~=1.7.0
+dbt-core==1.7.17
 dbt-extractor==0.5.1
 dbt-semantic-interfaces==0.4.3
 dbt-snowflake==1.7.1

--- a/syncenv
+++ b/syncenv
@@ -1,6 +1,8 @@
 python3 -m venv venv
 . ./venv/bin/activate
-pip install -r requirements.txt
+
+pip install uv==0.2.15
+uv pip sync requirements.txt
 
 chmod +x dbt_scripts/run_sqlfluff_on_changed_files.sh
 


### PR DESCRIPTION
## :pushpin: References
- Hardcode dbt-core sub-version to align with backend repo and enable partial parsing
<img width="957" alt="image" src="https://github.com/user-attachments/assets/518b9335-436f-4dd5-99f7-6963ae4a5371">



## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
