### PR TITLE
Fix fact_jupiter_perps_txs model

### DIFF
--- a/models/staging/jupiter/fact_jupiter_perps_txs.sql
+++ b/models/staging/jupiter/fact_jupiter_perps_txs.sql
@@ -53,17 +53,7 @@ with hex_cte as (
         {{ hex_to_base58("SUBSTRING(hex_data,456+1,64)") }} as owner, -- owner/trader address
         {{ hex_to_base58("SUBSTRING(hex_data,243,64)") }} as mint,
         -- Price calculation with dynamic offset
-        {{ big_endian_hex_to_decimal("SUBSTRING(hex_data,619+1,16)") }}/1e6 as price,
-            SUBSTRING(
-                hex_data,
-                619 -- Base offset to price
-                + (CASE WHEN SUBSTRING(hex_data, 618, 1) = '1'
-                        THEN 16
-                        ELSE 0
-                    END) -- Add offset if transferToken present
-                , 16
-            )
-        )/1e6 as price,        
+        {{ big_endian_hex_to_decimal("SUBSTRING(hex_data,619+1,16)") }}/1e6 as price,      
         hex_data
     FROM hex_cte
     WHERE substring(hex_data,1+16,16) = '409c2b4a6d83107f' -- DecreasePosition

--- a/models/staging/jupiter/fact_jupiter_perps_txs.sql
+++ b/models/staging/jupiter/fact_jupiter_perps_txs.sql
@@ -53,7 +53,13 @@ with hex_cte as (
         {{ hex_to_base58("SUBSTRING(hex_data,456+1,64)") }} as owner, -- owner/trader address
         {{ hex_to_base58("SUBSTRING(hex_data,243,64)") }} as mint,
         -- Price calculation with dynamic offset
-        {{ big_endian_hex_to_decimal("SUBSTRING(hex_data,619+1,16)") }}/1e6 as price,      
+        {{ big_endian_hex_to_decimal(
+            "SUBSTRING(
+                hex_data,
+                619 + (CASE WHEN SUBSTRING(hex_data, 618, 1) = '1' THEN 16 ELSE 0 END),
+                16
+            )"
+        ) }}/1e6 as price,        
         hex_data
     FROM hex_cte
     WHERE substring(hex_data,1+16,16) = '409c2b4a6d83107f' -- DecreasePosition


### PR DESCRIPTION
## :pushpin: References
- Removing extra `)`
- Use `big_endian_hex_to_decimal` UDF for computing price 
- Executed compiled SQL 👍 
<img width="864" alt="image" src="https://github.com/user-attachments/assets/686d53f9-239d-425a-8f5a-fe08daefab3c">


## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
