### PR TITLE
osmo fees fix

### DIFF
--- a/models/staging/osmosis/fact_osmosis_trading_fees.sql
+++ b/models/staging/osmosis/fact_osmosis_trading_fees.sql
@@ -55,6 +55,7 @@ with
         from data
         left join prices t2 on data.date = t2.date and lower(data.currency) = lower(t2.currency)
         left join coingecko_price t3 on data.date=t3.date and lower(data.currency) = lower(t3.currency)
+        where trading_fees < 1000000
     )
 select date, 'osmosis' as chain, sum(trading_fees) as trading_fees
 from by_token


### PR DESCRIPTION
Quick fix to Osmo data that was causing below DQ issue:

<img width="296" alt="Screenshot 2024-11-07 at 8 30 25 PM" src="https://github.com/user-attachments/assets/36e43808-ec24-4fd2-a48b-df47b23e9356">

Fix by filtering for any trader where the fee paid is > 1,000,000 USD.

Query compiles:
<img width="1512" alt="Screenshot 2024-11-07 at 8 32 55 PM" src="https://github.com/user-attachments/assets/aa037f3f-686c-4c3b-af23-4aba2d7605ab">

