### PR TITLE
Standardizing column names for GMX perps pricing

### DIFF
--- a/models/projects/gmx/raw/fact_gmx_perps_token_prices.sql
+++ b/models/projects/gmx/raw/fact_gmx_perps_token_prices.sql
@@ -9,4 +9,15 @@
     )
 }}
 
-SELECT * FROM {{ ref('fact_gmx_all_versions_trades') }}
+SELECT
+    block_timestamp,
+    tx_hash,
+    t1.chain,
+    'gmx' as app,
+    tracked_metadata.symbol,
+    price,
+    token_address
+FROM {{ ref('fact_gmx_all_versions_trades') }} t1
+inner join  {{ref('wrapped_token_majors_by_chain')}} tracked_metadata
+    on lower(t1.token_address) = lower(tracked_metadata.contract_address) 
+    and t1.chain = tracked_metadata.chain


### PR DESCRIPTION
Making sure all of these tables have the same columns so end users know what to expect.