### PR TITLE
temp fix for null block_timestamps in source table

### DIFF
--- a/models/staging/axelar/fact_axelar_daa_txns.sql
+++ b/models/staging/axelar/fact_axelar_daa_txns.sql
@@ -5,4 +5,5 @@ select
     count(*) as txns,
     'axelar' as chain
 from axelar_flipside.core.fact_transactions
+where block_timestamp is not null
 group by date


### PR DESCRIPTION
Source table `axelar_flipside.core.fact_transactions` has some nulls in the `block_timestamp` particularly in transactions from the past day between blocks 15316105 and 15291544.

This is a temp fix until Flipside sorts out the issue in the source table.