### PR TITLE
Wes/icp duplicates fix

### DIFF
--- a/models/projects/internet_computer/core/ez_internet_computer_metrics.sql
+++ b/models/projects/internet_computer/core/ez_internet_computer_metrics.sql
@@ -49,11 +49,11 @@ select
     , dex_volumes
     , 5 as storage_cost
 from price_data
-full join icp_metrics on price_data.date = icp_metrics.date
-full join icp_blocks on price_data.date = icp_blocks.date
-full join icp_total_canister_state on price_data.date = icp_total_canister_state.date
-full join icp_neuron_funds on price_data.date = icp_neuron_funds.date
-full join defillama_data on price_data.date = defillama_data.date
+left join icp_metrics on price_data.date = icp_metrics.date
+left join icp_blocks on price_data.date = icp_blocks.date
+left join icp_total_canister_state on price_data.date = icp_total_canister_state.date
+left join icp_neuron_funds on price_data.date = icp_neuron_funds.date
+left join defillama_data on price_data.date = defillama_data.date
 where coalesce(price_data.date, defillama_data.date, icp_metrics.date, icp_blocks.date, icp_total_canister_state.date, icp_neuron_funds.date) < to_date(sysdate())
 {% if is_incremental() %}
     and coalesce(price_data.date, defillama_data.date, icp_metrics.date, icp_total_canister_state.date, icp_neuron_funds.date, icp_blocks.date)

--- a/models/staging/outerlands/fact_outerlands_asset_weights_for_month_start.sql
+++ b/models/staging/outerlands/fact_outerlands_asset_weights_for_month_start.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="outerlands"
+        snowflake_warehouse="outerlands",
+        unique_key=["date", "artemis_id"]
     )
 }}
 


### PR DESCRIPTION
We had some duplicate entries coming into the `icp` `ez_metrics` table.

Root cause was a `full join` that should have been a `left join`.

Also added a `unique_key` config to the outerlands asset weights per month table to make double sure there are no duplicate data points. The unique key is set to [date, artemis_id].

Did a full refresh on ICP and data looks good.
<img width="1511" alt="Screenshot 2024-11-12 at 5 35 21 PM" src="https://github.com/user-attachments/assets/afc7c3b1-b42b-49ee-8137-c3dde5ffe7cf">

Also checked `fact_outerlands_asset_weights_for_month_start` and data looks good there too.