### PR TITLE
C911 [TON]: Updating the ton stablecoin pipeline

### DIFF
--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -1,13 +1,9 @@
 {% macro p2p_stablecoin_transfers(chain) %}
 with 
     stablecoin_transfers as (
-        {% if chain in ("ton") %}
-            select * from {{ ref("ez_" ~ chain ~ "_stablecoin_transfers") }}
-        {% else %}
-            select * from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }}
-        {% endif %}
+        select * from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }}
     ),
-    {% if chain in ("tron", "solana", "near") %}
+    {% if chain in ("tron", "solana", "near", "ton") %}
          distinct_peer_address as (
             select address
             from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}

--- a/macros/stablecoins/l30d_stablecoin_transfers.sql
+++ b/macros/stablecoins/l30d_stablecoin_transfers.sql
@@ -9,11 +9,7 @@ select
     , from_address::string as from_address
     , to_address::string as to_address
     , coingecko_id
-{% if chain == 'ton' %}
-    from {{ ref("ez_" ~ chain ~ "_stablecoin_transfers") }} t1
-{% else %}
-    from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }} t1
-{% endif %}
+from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }} t1
 left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} t2 on lower(t1.contract_address) = lower(t2.contract_address)
 where date >= (select dateadd('day', -31, to_date(sysdate())))
 {% endmacro %}

--- a/macros/stablecoins/stablecoin_balances.sql
+++ b/macros/stablecoins/stablecoin_balances.sql
@@ -18,16 +18,10 @@ with
             , address
             {% if chain in ('solana') %}
                 , amount as stablecoin_supply_native
-            {% elif chain == 'ton' %}
-                , balance_token as stablecoin_supply_native
             {% else %}
                 , balance_token / pow(10, num_decimals) as stablecoin_supply_native
             {% endif %}
-        {% if chain == "ton" %}
-            from {{ ref("ez_" ~ chain ~ "_address_balances_by_token")}} t1
-        {% else %}
-            from {{ ref("fact_" ~ chain ~ "_address_balances_by_token")}} t1
-        {% endif %}
+        from {{ ref("fact_" ~ chain ~ "_address_balances_by_token")}} t1
         inner join {{ ref("fact_" ~ chain ~ "_stablecoin_contracts")}} t2
             on lower(t1.contract_address) = lower(t2.contract_address)
         where block_timestamp < to_date(sysdate())

--- a/macros/stablecoins/stablecoin_metrics.sql
+++ b/macros/stablecoins/stablecoin_metrics.sql
@@ -167,7 +167,7 @@
                     else filtered_contracts.category 
                 end as category
                 , case 
-                    {% if chain not in ('solana', 'tron', 'near') %}
+                    {% if chain not in ('solana', 'tron', 'near', 'ton') %}
                         when 
                             from_address not in (select contract_address from {{ ref("dim_" ~ chain ~ "_contract_addresses")}}) 
                             then 1

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -9,11 +9,7 @@ with
             , symbol
             , transfer_volume
             , to_address
-        {% if chain in ("ton") %}
-            from {{ ref("ez_" ~ chain ~ "_stablecoin_transfers")}} t
-        {% else %}
-            from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
-        {% endif %}
+        from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
         {% if is_incremental() %} 
             where block_timestamp >= (
                 select dateadd('day', -3, max(date))

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -3,17 +3,17 @@ with
     stablecoin_transfers as (
         select 
             block_timestamp
-            , tx_hash
+            {% if chain == 'ton' %}
+                , trace_id as tx_hash
+            {% else %}
+                , tx_hash
+            {% endif %}
             , from_address
             , contract_address
             , symbol
             , transfer_volume
             , to_address
-        {% if chain in ("ton") %}
-            from {{ ref("ez_" ~ chain ~ "_stablecoin_transfers")}} t
-        {% else %}
-            from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
-        {% endif %}
+        from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
         {% if is_incremental() %} 
             where block_timestamp >= (
                 select dateadd('day', -3, max(date))

--- a/macros/stablecoins/stablecoin_metrics_p2p.sql
+++ b/macros/stablecoins/stablecoin_metrics_p2p.sql
@@ -9,11 +9,7 @@ with
             , symbol
             , amount_usd as transfer_volume
             , to_address
-        {% if chain in ("ton") %}
-            from {{ ref("ez_" ~ chain ~ "_p2p_stablecoin_transfers")}} t
-        {% else %}
-            from {{ ref("fact_" ~ chain ~ "_p2p_stablecoin_transfers")}} t
-        {% endif %}
+        from {{ ref("fact_" ~ chain ~ "_p2p_stablecoin_transfers")}} t
         left join {{ ref( "fact_" ~ chain ~ "_stablecoin_contracts") }} c
             on lower(t.token_address) = lower(c.contract_address)
         {% if is_incremental() %} 

--- a/macros/wallets/distinct_eoa_addresses.sql
+++ b/macros/wallets/distinct_eoa_addresses.sql
@@ -1,8 +1,11 @@
 {% macro distinct_eoa_addresses(chain) %}
     {% if chain == "tron" %}
-        select 
-            distinct from_address as address, 'eoa' as address_type
-        from tron_allium.raw.transactions
+        select distinct from_address as address, 'eoa' as address_type
+        from tron_allium.raw.contracts
+    {% elif chain == "ton" %}
+        select distinct transaction_account as address, 'wallet' as address_type
+        from {{ref("fact_ton_transactions")}}
+        where transaction_account_workchain <> -1 and transaction_account_interface ilike '%wallet%'
     {% elif chain == "solana" %}
         select distinct signer as address,  'signer' as address_type
         from solana_flipside.core.ez_signers 

--- a/models/dimensions/contracts/dim_ton_contract_addresses.sql
+++ b/models/dimensions/contracts/dim_ton_contract_addresses.sql
@@ -1,9 +1,0 @@
-{{ 
-    config(
-        materialized="incremental",
-        snowflake_warehouse="TON",
-        unique_key=["contract_address"]
-    )
-}}
-
-{{distinct_contract_addresses("ton")}}

--- a/models/dimensions/wallet/dim_ton_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_ton_eoa_addresses.sql
@@ -1,2 +1,3 @@
 {{config(materialized="table") }}
+
 {{ distinct_eoa_addresses("ton") }}

--- a/models/dimensions/wallet/dim_tron_eoa_addresses.sql
+++ b/models/dimensions/wallet/dim_tron_eoa_addresses.sql
@@ -1,1 +1,3 @@
+{{config(materialized="table") }}
+
 {{ distinct_eoa_addresses("tron") }}

--- a/models/projects/ton/raw/ez_ton_p2p_stablecoin_transfers.sql
+++ b/models/projects/ton/raw/ez_ton_p2p_stablecoin_transfers.sql
@@ -1,8 +1,6 @@
---depends_on: {{ ref("ez_ton_stablecoin_transfers") }}
 {{
     config(
-        materialized="incremental",
-        unique_key="tx_hash",
+        materialized="view",
         snowflake_warehouse="TON",
         database="ton",
         schema="raw",
@@ -10,4 +8,5 @@
     )
 }}
 
-{{ p2p_stablecoin_transfers("ton") }}
+select * 
+from {{ref("fact_ton_p2p_stablecoin_transfers")}}

--- a/models/staging/ton/fact_ton_p2p_stablecoin_transfers.sql
+++ b/models/staging/ton/fact_ton_p2p_stablecoin_transfers.sql
@@ -1,0 +1,7 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key="tx_hash",
+    )
+}}
+{{ p2p_stablecoin_transfers("ton") }}

--- a/models/staging/ton/fact_ton_token_transfers.sql
+++ b/models/staging/ton/fact_ton_token_transfers.sql
@@ -1,28 +1,32 @@
 {{ config(
-    materialized="incremental",
+    materialized="table",
     unique_key="tx_hash",
     snowflake_warehouse="TON",
 ) }}
 
-select
-    avro_raw:utime::timestamp as block_timestamp
-    , avro_raw:trace_id::string as trace_id
-    , avro_raw:tx_hash::string as tx_hash
-    , avro_raw:type::string as type
-    , avro_raw:jetton_master::string as contract_address
-    , avro_raw:jetton_wallet::string as jetton_wallet
-    , avro_raw:source::string as from_address
-    , avro_raw:destination::string as to_address
-    , avro_raw:amount::float as amount
-    , avro_raw:comment::string as comment
-    , avro_raw:custom_payload::string as custom_payload
-    , avro_raw:forward_payload::string as forward_payload
-    , avro_raw:forward_ton_amount::float as forward_ton_amount
-    , avro_raw:query_id::string as query_id
-    , avro_raw:response_destination as response_destination
-    , not avro_raw:tx_aborted::boolean as tx_status
-    , avro_raw:tx_lt::bigint as event_index
-from {{source("PROD_LANDING", "raw_ton_jetton_events_avro")}}
-{% if is_incremental() %}
-    where avro_raw:utime::timestamp > (select dateadd('day', -5, max(utime)) from {{ this }})
-{% endif %}
+with
+    raw_receipt_transactions as (
+        select
+          avro_raw:utime::timestamp as block_timestamp
+          , avro_raw:trace_id::string as trace_id
+          , avro_raw:tx_hash::string as tx_hash
+          , avro_raw:type::string as type
+          , avro_raw:jetton_master::string as contract_address
+          , avro_raw:jetton_wallet::string as jetton_wallet
+          , avro_raw:source::string as from_address
+          , avro_raw:destination::string as to_address
+          , avro_raw:amount::float as amount
+          , avro_raw:comment::string as comment
+          , avro_raw:custom_payload::string as custom_payload
+          , avro_raw:forward_payload::string as forward_payload
+          , avro_raw:forward_ton_amount::float as forward_ton_amount
+          , avro_raw:query_id::string as query_id
+          , avro_raw:response_destination as response_destination
+          , not avro_raw:tx_aborted::boolean as tx_status
+          , avro_raw:tx_lt::bigint as event_index
+        from {{ source("PROD_LANDING", "raw_ton_jetton_events_avro") }}
+    )
+select *
+from raw_receipt_transactions
+where tx_status = 'TRUE'
+qualify row_number() over (partition by tx_hash order by block_timestamp desc) = 1


### PR DESCRIPTION
1. Cleaning up the TON stablecoin pipeline. TON now follows the same pipeline as the other chains where all the models are `fact` models and the final model is an `ez` model. 

<img width="1054" alt="Screenshot 2024-11-12 at 6 15 27 PM" src="https://github.com/user-attachments/assets/74acce05-f583-474e-ace8-d5856ca494f3">
