### PR TITLE
Metaplex: add unique signers and new holders

### DIFF
--- a/models/projects/metaplex/core/ez_metaplex_metrics.sql
+++ b/models/projects/metaplex/core/ez_metaplex_metrics.sql
@@ -30,6 +30,20 @@ with revenue as (
     from {{ ref("fact_metaplex_active_wallets") }}
     group by 1
 )
+, unique_signers as (
+    select
+        date
+        , sum(unique_signers) as unique_signers
+    from {{ ref("fact_metaplex_unique_signers") }}
+    group by 1
+)
+, new_holders as (
+    select
+        date
+        , sum(daily_new_holders) as daily_new_holders
+    from {{ ref("fact_metaplex_new_holders") }}
+    group by 1
+)
 , transactions as (
     select
         date
@@ -57,6 +71,8 @@ SELECT
     , coalesce(mints.daily_mints, 0) as daily_mints
     , coalesce(active_wallets.dau, 0) as dau
     , coalesce(transactions.txns, 0) as txns
+    , coalesce(unique_signers.unique_signers, 0) as unique_signers
+    , coalesce(new_holders.daily_new_holders, 0) as daily_new_holders
     , coalesce(price.price, 0) as price
     , coalesce(price.market_cap, 0) as market_cap
     , price.fdmc
@@ -69,4 +85,6 @@ LEFT JOIN buybacks USING (date)
 LEFT JOIN mints USING (date)
 LEFT JOIN active_wallets USING (date)
 LEFT JOIN transactions USING (date)
+LEFT JOIN unique_signers USING (date)
+LEFT JOIN new_holders USING (date)
 where coalesce(price.date, revenue.date, buybacks.date, transactions.date) < to_date(sysdate())


### PR DESCRIPTION
Added unique signers and new holders metrics to `ez_metaplex_metrics`.

Added required metrics in backend PR.

Tested both metrics work locally:

**NEW_HOLDERS**
<img width="1510" alt="Screenshot 2024-11-12 at 7 56 26 PM" src="https://github.com/user-attachments/assets/fddd8d10-51e7-4fbb-b307-ef80f153c24e">

**UNIQUE_SIGNERS**
<img width="1533" alt="Screenshot 2024-11-12 at 7 56 18 PM" src="https://github.com/user-attachments/assets/55bb3e31-8ecb-48b8-bf08-c55ecbaeb866">
