### PR TITLE
osmosis strict filter

### DIFF
--- a/models/staging/osmosis/fact_osmosis_gas_gas_usd.sql
+++ b/models/staging/osmosis/fact_osmosis_gas_gas_usd.sql
@@ -46,6 +46,7 @@ with
         from data
         left join prices t2 on data.date = t2.date and data.currency = t2.currency
         left join coingecko_price t3 on data.date=t3.date and data.currency = t3.currency
+        where gas_usd < 10000
     )
 select date, 'osmosis' as chain, sum(gas_usd) as gas_usd
 from by_token

--- a/models/staging/osmosis/fact_osmosis_trading_fees.sql
+++ b/models/staging/osmosis/fact_osmosis_trading_fees.sql
@@ -26,6 +26,9 @@ with
             , 'factory/osmo19hdqma2mj0vnmgcxag6ytswjnr8a3y07q7e70p/wLIBRA'
             , 'factory/osmo1q77cw0mmlluxu0wr29fcdd0tdnh78gzhkvhe4n6ulal9qvrtu43qtd0nh8/turd'
             , 'ibc/DDF1CD4CDC14AE2D6A3060193624605FF12DEE71CF1F8C19EEF35E9447653493'
+            , 'factory/osmo10n8rv8npx870l69248hnp6djy6pll2yuzzn9x8/BADKID'
+            , 'factory/osmo1s6ht8qrm8x0eg8xag5x3ckx9mse9g4se248yss/BERNESE'
+            , 'factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO'
         )
         {% if is_incremental() %}
             and block_date::date >= (select dateadd('day', -5, max(date)) from {{ this }})
@@ -55,7 +58,7 @@ with
         from data
         left join prices t2 on data.date = t2.date and lower(data.currency) = lower(t2.currency)
         left join coingecko_price t3 on data.date=t3.date and lower(data.currency) = lower(t3.currency)
-        where trading_fees < 1000000
+        where trading_fees < 10000
     )
 select date, 'osmosis' as chain, sum(trading_fees) as trading_fees
 from by_token


### PR DESCRIPTION
Added much more strict filters for Osmosis fees since DQ issues kept popping up. 

I blacklisted specific addresses that were causing issues. 

I also lowered the maximum limit on trading fees allowed for a single trade from $1,000,000 to $10,000 in both `fact_osmosis_gas_gas_usd` and `fact_osmosis_trading_fees` since both are susceptible to the same type of data quality issue. 

This change assumes there will be no real trades generating more than $10,000 in fees. Considering the default fee for a pool is 0.1% ([docs](https://docs.osmosis.zone/overview/educate/osmo/#taker-fees), that would mean a single trade of $10,000,000 in value, which seems highly unlikely in any near future for Osmosis.

Osmosis Fees actually look normal for once:
<img width="1512" alt="Screenshot 2024-11-13 at 12 13 44 AM" src="https://github.com/user-attachments/assets/627a71c9-6e6c-4068-983a-20e59c2dfd13">
