### PR TITLE
Wes/btc etf data

### DIFF
--- a/models/dimensions/dim_date_spine.sql
+++ b/models/dimensions/dim_date_spine.sql
@@ -1,0 +1,70 @@
+{{
+    config(
+        materialized='table',
+        unique_key=["date"]
+    )
+}}
+
+with spine as (
+  select '2000-01-01'::date as date union all
+  select dateadd('day', 1, date) from spine
+   where date < '2049-12-31'
+),
+days (number, name, short_name, shorter_name) as (
+    select 1, 'Monday',    'Mon', 'M'  union
+    select 2, 'Tuesday',   'Tue', 'Tu' union
+    select 3, 'Wednesday', 'Wed', 'W'  union
+    select 4, 'Thursday',  'Thu', 'Th' union
+    select 5, 'Friday',    'Fri', 'F'  union
+    select 6, 'Saturday',  'Sat', 'Sa' union
+    select 0, 'Sunday',    'Sun', 'Su'
+),
+months (number, name, short_name) as (
+    select  1, 'January',   'Jan' union
+    select  2, 'February',  'Feb' union
+    select  3, 'March',     'Mar' union
+    select  4, 'April',     'Apr' union
+    select  5, 'May',       'May' union
+    select  6, 'June',      'Jun' union
+    select  7, 'July',      'Jul' union
+    select  8, 'August',    'Aug' union
+    select  9, 'September', 'Sep' union
+    select 10, 'October',   'Oct' union
+    select 11, 'November',  'Nov' union
+    select 12, 'December',  'Dec'
+),
+dates as (
+  select date,
+         date_part('year',  date) as year,
+         date_part('month', date) as month,
+         date_part('dow',   date) as day_of_week,
+         date_part('day',   date) as day_of_month,
+         date_part('woy',   date) as week_of_year,
+
+         day_of_week in (0, 6) as is_weekend,
+         not is_weekend        as is_weekday,
+
+         round(ceil(month / 3.0), 0) as quarter_of_year,
+         round(ceil(month / 6.0), 0) as half_of_year
+    from spine
+)
+select dates.*,
+
+       days.name         as day_of_week_name,
+       days.short_name   as day_of_week_short_name,
+       days.shorter_name as day_of_week_shorter_name,
+
+       months.name       as month_name,
+       months.short_name as month_short_name,
+
+       'Y' || dates.year            as year_text,
+       'Q' || dates.quarter_of_year as quarter_of_year_text,
+       'H' || dates.half_of_year    as half_of_year_text,
+
+       year_text || quarter_of_year_text as year_and_quarter_text,
+       year_text || half_of_year_text    as year_and_half_text
+  from dates
+  join days
+    on dates.day_of_week = days.number
+  join months
+    on dates.month = months.number

--- a/models/dimensions/dim_date_spine.sql
+++ b/models/dimensions/dim_date_spine.sql
@@ -10,28 +10,32 @@ with spine as (
   select dateadd('day', 1, date) from spine
    where date < '2049-12-31'
 ),
-days (number, name, short_name, shorter_name) as (
-    select 1, 'Monday',    'Mon', 'M'  union
-    select 2, 'Tuesday',   'Tue', 'Tu' union
-    select 3, 'Wednesday', 'Wed', 'W'  union
-    select 4, 'Thursday',  'Thu', 'Th' union
-    select 5, 'Friday',    'Fri', 'F'  union
-    select 6, 'Saturday',  'Sat', 'Sa' union
-    select 0, 'Sunday',    'Sun', 'Su'
+days as (
+    select * from (values 
+        (1, 'Monday',    'Mon', 'M'),
+        (2, 'Tuesday',   'Tue', 'Tu'),
+        (3, 'Wednesday', 'Wed', 'W'),
+        (4, 'Thursday',  'Thu', 'Th'),
+        (5, 'Friday',    'Fri', 'F'),
+        (6, 'Saturday',  'Sat', 'Sa'),
+        (0, 'Sunday',    'Sun', 'Su')
+    ) as t(number, name, short_name, shorter_name)
 ),
-months (number, name, short_name) as (
-    select  1, 'January',   'Jan' union
-    select  2, 'February',  'Feb' union
-    select  3, 'March',     'Mar' union
-    select  4, 'April',     'Apr' union
-    select  5, 'May',       'May' union
-    select  6, 'June',      'Jun' union
-    select  7, 'July',      'Jul' union
-    select  8, 'August',    'Aug' union
-    select  9, 'September', 'Sep' union
-    select 10, 'October',   'Oct' union
-    select 11, 'November',  'Nov' union
-    select 12, 'December',  'Dec'
+months as (
+    select * from (values
+        (1,  'January',   'Jan'),
+        (2,  'February',  'Feb'),
+        (3,  'March',     'Mar'),
+        (4,  'April',     'Apr'),
+        (5,  'May',       'May'),
+        (6,  'June',      'Jun'),
+        (7,  'July',      'Jul'),
+        (8,  'August',    'Aug'),
+        (9,  'September', 'Sep'),
+        (10, 'October',   'Oct'),
+        (11, 'November',  'Nov'),
+        (12, 'December',  'Dec')
+    ) as t(number, name, short_name)
 ),
 dates as (
   select date,

--- a/models/dimensions/dim_date_spine.sql
+++ b/models/dimensions/dim_date_spine.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized='table',
+        materialized='view',
         unique_key=["date"]
     )
 }}

--- a/models/projects/bitcoin/core/ez_bitcoin_etf_metrics.sql
+++ b/models/projects/bitcoin/core/ez_bitcoin_etf_metrics.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="view",
+        snowflake_warehouse="BITCOIN",
+        database="bitcoin",
+        schema="core",
+        alias="ez_etf_metrics",
+    )
+}}
+
+select * from {{ ref('fact_bitcoin_etf_flows') }}

--- a/models/projects/ethereum/core/ez_ethereum_etf_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_etf_metrics.sql
@@ -1,0 +1,11 @@
+{{
+    config(
+        materialized="view",
+        snowflake_warehouse="ETHEREUM",
+        database="ethereum",
+        schema="core",
+        alias="ez_etf_metrics",
+    )
+}}
+
+select * from {{ ref('fact_ethereum_etf_flows') }}

--- a/models/staging/__staging_sources.yml
+++ b/models/staging/__staging_sources.yml
@@ -1,4 +1,7 @@
 sources:
+
+# SOLANA
+
   - name: SOLANA_FLIPSIDE_NFT
     schema: NFT
     database: SOLANA_FLIPSIDE
@@ -22,3 +25,17 @@ sources:
     database: SOLANA_FLIPSIDE
     tables:
       - name: ez_prices_hourly
+
+# ETHEREUM
+
+  - name: ETHEREUM_FLIPSIDE_PRICE
+    schema: price
+    database: ethereum_flipside
+    tables:
+      - name: ez_prices_hourly
+
+  - name: ETHEREUM_FLIPSIDE
+    schema: core
+    database: ethereum_flipside
+    tables:
+      - name: ez_native_transfers

--- a/models/staging/bitcoin/__bitcoin__sources.yml
+++ b/models/staging/bitcoin/__bitcoin__sources.yml
@@ -14,3 +14,10 @@ sources:
       - name: raw_bitcoin_etf_addresses
       - name: raw_bitcoin_etf_metadata
       - name: raw_bitcoin_fidelity_outflows
+
+  - name: BITCOIN_FLIPSIDE
+    schema: core
+    database: bitcoin_flipside
+    tables:
+      - name: fact_outputs
+      - name: fact_inputs

--- a/models/staging/bitcoin/__bitcoin__sources.yml
+++ b/models/staging/bitcoin/__bitcoin__sources.yml
@@ -11,3 +11,5 @@ sources:
       - name: raw_bitcoin_addresses_with_balance_gte_one_hundred
       - name: raw_bitcoin_hodl_wave
       - name: raw_bitcoin_nft_trading_volume
+      - name: raw_bitcoin_etf_addresses
+      - name: raw_bitcoin_etf_metadata

--- a/models/staging/bitcoin/__bitcoin__sources.yml
+++ b/models/staging/bitcoin/__bitcoin__sources.yml
@@ -13,3 +13,4 @@ sources:
       - name: raw_bitcoin_nft_trading_volume
       - name: raw_bitcoin_etf_addresses
       - name: raw_bitcoin_etf_metadata
+      - name: raw_bitcoin_fidelity_outflows

--- a/models/staging/bitcoin/fact_bitcoin_etf_addresses.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_addresses.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BITCOIN'
+    )
+}}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_bitcoin_etf_addresses") }}
+    )
+select
+    date(to_timestamp(value:date::number / 1000)) as date,
+    value:addresses::int as addresses,
+    value as source,
+    'bitcoin' as chain
+from
+    {{ source("PROD_LANDING", "raw_bitcoin_etf_addresses") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/bitcoin/fact_bitcoin_etf_addresses.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_addresses.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_bitcoin_etf_addresses
 
 with
     max_extraction as (

--- a/models/staging/bitcoin/fact_bitcoin_etf_fidelity_outflows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_fidelity_outflows.sql
@@ -10,15 +10,12 @@
 with
     max_extraction as (
         select max(extraction_date) as max_date
-        from {{ source("PROD_LANDING", "raw_bitcoin_etf_addresses") }}
+        from {{ source("PROD_LANDING", "raw_bitcoin_fidelity_outflows") }}
     )
 select
-    value:address::string as address,
-    value:inverse_values::string as inverse_values,
-    value:issuer::string as issuer,
-    value:track_inflow::string as track_inflow,
-    value:track_outflow::string as track_outflow
+    value:date::date as date,
+    value:amount::float as amount
 from
-    {{ source("PROD_LANDING", "raw_bitcoin_etf_addresses") }},
+    {{ source("PROD_LANDING", "raw_bitcoin_fidelity_outflows") }},
     lateral flatten(input => parse_json(source_json))
 where extraction_date = (select max_date from max_extraction)

--- a/models/staging/bitcoin/fact_bitcoin_etf_fidelity_outflows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_fidelity_outflows.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_bitcoin_etf_fidelity_outflows
 
 with
     max_extraction as (

--- a/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
@@ -1,0 +1,108 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BITCOIN'
+    )
+}}
+
+-- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+
+select * from bitcoin_flipside.core.fact_outputs limit 10;
+
+WITH unaggregated AS (
+    SELECT 
+        i.block_timestamp
+        , a.issuer
+        , eat.ticker AS etf_ticker
+        , 'deposit' AS flow_type
+        , CASE WHEN inverse_values::boolean THEN -i.value ELSE i.value END AS amount
+    FROM bitcoin_flipside.core.fact_outputs i
+    INNER JOIN {{ ref('fact_bitcoin_etf_addresses') }} -- Known ETF address list
+        a ON a.address::string = i.PUBKEY_SCRIPT_ADDRESS::string
+        AND a.track_inflow
+    INNER JOIN {{ ref('fact_bitcoin_etf_metadata') }} eat ON a.issuer=eat.issuer
+    WHERE i.value > 0
+    and i.block_timestamp > '2019-07-24'::date
+    
+    UNION ALL
+    
+    SELECT
+        i.block_timestamp
+        , a.issuer
+        , eat.ticker AS etf_ticker
+        , 'withdrawal' AS flow_type
+        , CASE WHEN inverse_values::boolean THEN i.value ELSE -i.value END AS amount
+    FROM bitcoin_flipside.core.fact_inputs i
+    INNER JOIN {{ ref('fact_bitcoin_etf_addresses') }} -- Known ETF address list
+        a ON a.address= i.PUBKEY_SCRIPT_ADDRESS::string
+        AND a.track_outflow
+    INNER JOIN {{ ref('fact_bitcoin_etf_metadata') }} eat ON a.issuer=eat.issuer
+    WHERE i.value > 0
+    AND i.block_timestamp > '2019-07-24'::date
+    
+    UNION ALL
+    
+    SELECT
+        date::date AS block_time
+        , 'Fidelity' AS issuer
+        , 'FBTC' AS etf_ticker
+        , 'withdrawal' AS flow_type
+        , -amount AS amount
+    FROM {{ ref('fact_bitcoin_etf_fidelity_outflows') }}
+    
+    UNION ALL
+    
+    SELECT 
+        t.date as block_timestamp
+        , et.issuer
+        , et.ticker AS etf_ticker
+        , NULL AS flow_type
+        , NULL AS amount
+    FROM {{ ref('dim_date_spine') }} t
+    CROSS JOIN {{ ref('fact_bitcoin_etf_metadata') }} et
+    WHERE t.date between '2019-07-24' and to_date(sysdate())
+    )
+
+, daily_aggregates AS (
+    SELECT 
+        f.block_timestamp::date AS date
+        , f.issuer
+        , f.etf_ticker
+        , SUM(f.amount) AS amount
+    FROM unaggregated f
+    GROUP BY 1, 2, 3
+)
+, summed as (
+     SELECT 
+        date
+        , issuer
+        , etf_ticker
+        , SUM(amount) AS amount
+    FROM daily_aggregates
+    GROUP BY 1, 2, 3
+)
+, cumulative_native as (
+    SELECT
+        *,
+        SUM(amount) OVER (PARTITION BY issuer, etf_ticker ORDER BY date asc) as cum_amount,
+    FROM summed
+)
+, bitcoin_prices as (
+    SELECT
+        date(hour) as date,
+        avg(price) as price
+    FROM bitcoin_flipside.price.ez_prices_hourly
+    WHERE is_native = True
+    GROUP BY 1
+)
+
+SELECT
+    c.date,
+    c.issuer,
+    c.etf_ticker,
+    c.amount,
+    c.cum_amount,
+    c.amount * p.price as amount_usd,
+    c.cum_amount * p.price as cum_amount_usd
+FROM cumulative_native c
+LEFT JOIN bitcoin_prices p ON p.date = c.date

--- a/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+-- Credit to @hildobby for the original version of this model: https://dune.com/queries/3430945
 
 WITH unaggregated AS (
     SELECT 

--- a/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
@@ -7,8 +7,6 @@
 
 -- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
 
-select * from bitcoin_flipside.core.fact_outputs limit 10;
-
 WITH unaggregated AS (
     SELECT 
         i.block_timestamp
@@ -16,7 +14,7 @@ WITH unaggregated AS (
         , eat.ticker AS etf_ticker
         , 'deposit' AS flow_type
         , CASE WHEN inverse_values::boolean THEN -i.value ELSE i.value END AS amount
-    FROM bitcoin_flipside.core.fact_outputs i
+    FROM {{ source('BITCOIN_FLIPSIDE', 'fact_outputs') }} i
     INNER JOIN {{ ref('fact_bitcoin_etf_addresses') }} -- Known ETF address list
         a ON a.address::string = i.PUBKEY_SCRIPT_ADDRESS::string
         AND a.track_inflow
@@ -32,7 +30,7 @@ WITH unaggregated AS (
         , eat.ticker AS etf_ticker
         , 'withdrawal' AS flow_type
         , CASE WHEN inverse_values::boolean THEN i.value ELSE -i.value END AS amount
-    FROM bitcoin_flipside.core.fact_inputs i
+    FROM {{ source('BITCOIN_FLIPSIDE', 'fact_inputs') }} i
     INNER JOIN {{ ref('fact_bitcoin_etf_addresses') }} -- Known ETF address list
         a ON a.address= i.PUBKEY_SCRIPT_ADDRESS::string
         AND a.track_outflow

--- a/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
@@ -5,16 +5,19 @@
     )
 }}
 
+-- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+
 with
     max_extraction as (
         select max(extraction_date) as max_date
         from {{ source("PROD_LANDING", "raw_bitcoin_etf_metadata") }}
     )
 select
-    date(to_timestamp(value:date::number / 1000)) as date,
-    value:addresses::int as addresses,
-    value as source,
-    'bitcoin' as chain
+    value:custodian::string as custodian,
+    left(value:fee, 4)::float as fee,
+    value:issuer::string as issuer,
+    value:ticker::string as ticker,
+    value:website::string as website
 from
     {{ source("PROD_LANDING", "raw_bitcoin_etf_metadata") }},
     lateral flatten(input => parse_json(source_json))

--- a/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/btc-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_bitcoin_etf_metadata
 
 with
     max_extraction as (

--- a/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_metadata.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BITCOIN'
+    )
+}}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_bitcoin_etf_metadata") }}
+    )
+select
+    date(to_timestamp(value:date::number / 1000)) as date,
+    value:addresses::int as addresses,
+    value as source,
+    'bitcoin' as chain
+from
+    {{ source("PROD_LANDING", "raw_bitcoin_etf_metadata") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/ethereum/__ethereum__sources.yml
+++ b/models/staging/ethereum/__ethereum__sources.yml
@@ -1,0 +1,8 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_ethereum_etf_addresses
+      - name: raw_ethereum_etf_metadata
+      - name: raw_ethereum_fidelity_outflows

--- a/models/staging/ethereum/fact_ethereum_etf_addresses.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_addresses.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_ethereum_etf_addresses
 
 with
     max_extraction as (

--- a/models/staging/ethereum/fact_ethereum_etf_addresses.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_addresses.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='ETHEREUM'
+    )
+}}
+
+-- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_ethereum_etf_addresses") }}
+    )
+select
+    value:address::string as address,
+    value:inverse_values::string as inverse_values,
+    value:issuer::string as issuer,
+    value:track_inflow::string as track_inflow,
+    value:track_outflow::string as track_outflow
+from
+    {{ source("PROD_LANDING", "raw_ethereum_etf_addresses") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/ethereum/fact_ethereum_etf_fidelity_outflows.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_fidelity_outflows.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_ethereum_etf_fidelity_outflows
 
 with
     max_extraction as (

--- a/models/staging/ethereum/fact_ethereum_etf_fidelity_outflows.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_fidelity_outflows.sql
@@ -1,0 +1,21 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='ETHEREUM'
+    )
+}}
+
+-- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_ethereum_fidelity_outflows") }}
+    )
+select
+    value:date::date as date,
+    value:amount::float as amount
+from
+    {{ source("PROD_LANDING", "raw_ethereum_fidelity_outflows") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/ethereum/fact_ethereum_etf_flows.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_flows.sql
@@ -5,6 +5,8 @@
     )
 }}
 
+-- Credit to @hildobby for the original version of this model: https://dune.com/queries/4208557/7083511
+
 WITH time_series AS (
     SELECT 
         date

--- a/models/staging/ethereum/fact_ethereum_etf_flows.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_flows.sql
@@ -1,0 +1,80 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='ETHEREUM'
+    )
+}}
+
+WITH time_series AS (
+    SELECT 
+        date
+    FROM {{ ref('dim_date_spine') }}
+    WHERE date between '2017-12-11'::date and to_date(sysdate())
+    )
+
+, flows AS (
+    SELECT 
+        date_trunc('day', t.block_timestamp) AS date
+        , a.issuer
+        , SUM(CASE WHEN a.inverse_values = true THEN -t.amount ELSE t.amount END) AS amount
+    FROM {{ source('ETHEREUM_FLIPSIDE', 'ez_native_transfers') }} t
+    INNER JOIN {{ ref('fact_ethereum_etf_addresses') }} a ON a.address=t.to_address
+        AND a.track_inflow = true
+    WHERE t.block_timestamp >= date('2017-10-16')
+    GROUP BY 1, 2
+    
+    UNION ALL
+    
+    SELECT 
+        date_trunc('day', t.block_timestamp) AS date
+        , a.issuer
+        , -1 * SUM(CASE WHEN a.inverse_values = true THEN -t.amount ELSE t.amount END) AS amount
+    FROM {{ source('ETHEREUM_FLIPSIDE', 'ez_native_transfers') }} t
+    INNER JOIN {{ ref('fact_ethereum_etf_addresses') }} a ON a.address=t.from_address
+        AND a.track_outflow = true
+    WHERE t.block_timestamp >= date('2017-10-16')
+    GROUP BY 1, 2
+        
+    UNION ALL
+    
+    SELECT 
+        date AS time
+        , 'Fidelity' AS issuer
+        , -amount AS amount
+    FROM {{ ref('fact_ethereum_etf_fidelity_outflows') }}    
+)
+
+, expanded_flows AS (
+    SELECT 
+        ts.date
+        , i.issuer
+        , COALESCE(SUM(f.amount), 0) AS amount
+    FROM time_series ts
+    CROSS JOIN (SELECT issuer FROM {{ ref('fact_ethereum_etf_metadata') }}) i
+    LEFT JOIN flows f ON ts.date = f.date AND i.issuer = f.issuer
+    GROUP BY 1, 2
+)
+, cumulative as (
+    SELECT
+        *,
+        SUM(amount) OVER (PARTITION BY issuer ORDER BY date asc) as cum_amount
+    FROM expanded_flows
+)
+, eth_prices as (
+    SELECT
+        d.date,
+        p.price
+    FROM
+        {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} p
+    JOIN
+        {{ ref('dim_date_spine') }} d on p.hour = d.date and p.is_native
+)
+SELECT
+    c.date,
+    c.issuer,
+    amount,
+    cum_amount,
+    amount * p.price as amount_usd,
+    cum_amount * p.price as cum_usd
+FROM cumulative c
+LEFT JOIN eth_prices p on p.date = c.date

--- a/models/staging/ethereum/fact_ethereum_etf_metadata.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_metadata.sql
@@ -1,0 +1,24 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='ETHEREUM'
+    )
+}}
+
+-- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_ethereum_etf_metadata") }}
+    )
+select
+    value:custodian::string as custodian,
+    left(value:fee, 4)::float as fee,
+    value:issuer::string as issuer,
+    value:ticker::string as ticker,
+    value:website::string as website
+from
+    {{ source("PROD_LANDING", "raw_ethereum_etf_metadata") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/ethereum/fact_ethereum_etf_metadata.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_metadata.sql
@@ -5,7 +5,7 @@
     )
 }}
 
--- Credit to @hildobby for the original version of this model: https://dune.com/hildobby/eth-etfs
+-- Credit to @hildobby for the original version of this dataset: https://dune.com/data/dune.hildobby.dataset_ethereum_etf_metadata
 
 with
     max_extraction as (

--- a/models/staging/maple/__maple__sources.yml
+++ b/models/staging/maple/__maple__sources.yml
@@ -9,12 +9,6 @@ sources:
       - name: fact_decoded_event_logs
       - name: ez_token_transfers
   
-  - name: ETHEREUM_FLIPSIDE
-    schema: price
-    database: ethereum_flipside
-    tables:
-      - name: ez_prices_hourly
-  
   - name: PROD_LANDING
     schema: prod_landing
     database: landing_database

--- a/models/staging/maple/fact_maple_interest_v1.sql
+++ b/models/staging/maple/fact_maple_interest_v1.sql
@@ -6,7 +6,7 @@
 }}
 
 with eth_prices as (
-    select * from {{ source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly') }}
+    select * from {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }}
     where is_native = True
 )
 select

--- a/models/staging/maple/fact_maple_interest_v2.sql
+++ b/models/staging/maple/fact_maple_interest_v2.sql
@@ -6,7 +6,7 @@
 }}
 
 with eth_prices as (
-    select * from {{source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly')}}
+    select * from {{source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly')}}
     where is_native = True
 )
 , ftlm_interest as (

--- a/models/staging/maple/fact_maple_offchain_data.sql
+++ b/models/staging/maple/fact_maple_offchain_data.sql
@@ -13,7 +13,7 @@ WITH prices AS (
         symbol,
         avg(price) as price
     FROM
-        {{ source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly') }}
+        {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }}
     WHERE
         symbol in ('WBTC', 'INJ', 'SOL', 'STETH')
         or is_native = true

--- a/models/staging/maple/fact_maple_onchain_revenue.sql
+++ b/models/staging/maple/fact_maple_onchain_revenue.sql
@@ -15,7 +15,7 @@ SELECT
     raw_amount_precise / pow(10, p.decimals) * p.price as revenue_usd
 FROM
     {{ source('ETHEREUM_FLIPSIDE', 'ez_token_transfers') }} t
-LEFT JOIN {{ source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly') }} p 
+LEFT JOIN {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} p 
     ON date_trunc('hour', block_timestamp) = p.hour 
     AND p.token_address = t.contract_address
 WHERE t.to_address = lower('0xa9466eabd096449d650d5aeb0dd3da6f52fd0b19')

--- a/models/staging/maple/fact_maple_token_incentives.sql
+++ b/models/staging/maple/fact_maple_token_incentives.sql
@@ -21,7 +21,7 @@ with rewards_contracts as (
         token_address,
         symbol
     FROM
-        {{ source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly') }}
+        {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }}
     WHERE token_address = lower('0x33349b282065b0284d756f0577fb39c158f935e6')
 )
 SELECT

--- a/models/staging/maple/fact_maple_v1_tvl.sql
+++ b/models/staging/maple/fact_maple_v1_tvl.sql
@@ -78,7 +78,7 @@ SELECT
     daily_repaid,
     CASE
         WHEN pool_name = 'M11 Credit WETH' OR pool_name = 'Celsius WETH Pool' 
-        THEN outstanding * (SELECT price FROM {{ source('ETHEREUM_FLIPSIDE', 'ez_prices_hourly') }} WHERE is_native = TRUE ORDER BY hour DESC LIMIT 1)
+        THEN outstanding * (SELECT price FROM {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} WHERE is_native = TRUE ORDER BY hour DESC LIMIT 1)
         ELSE outstanding
     END as outstanding_usd
 FROM final


### PR DESCRIPTION
Adding BTC and ETH ETF flows data.

Based on HIldobby's [BTC ETF](https://dune.com/hildobby/btc-etfs) and [ETH ETF](https://dune.com/hildobby/eth-etfs).

<img width="1132" alt="Screenshot 2024-11-13 at 11 36 49 PM" src="https://github.com/user-attachments/assets/d42760f0-834f-4e33-8157-f5b1f52eb5c9">

<img width="1120" alt="Screenshot 2024-11-13 at 11 36 35 PM" src="https://github.com/user-attachments/assets/87b96953-f304-4338-9842-4eba371f204f">

<img width="1134" alt="Screenshot 2024-11-13 at 11 36 15 PM" src="https://github.com/user-attachments/assets/5318c3a5-8c9e-4867-8212-bff498963854">

<img width="1134" alt="Screenshot 2024-11-13 at 11 35 58 PM" src="https://github.com/user-attachments/assets/0b753b87-d1a9-43ed-8a37-7f949526b035">
