### PR TITLE
Stablecoins: adding stablecoin freshness test

### DIFF
--- a/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_silver.yml
+++ b/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_silver.yml
@@ -1,5 +1,11 @@
 models:
   - name: agg_daily_stablecoin_breakdown_silver
+    tests:
+      - "dbt_expectations.expect_grouped_row_values_to_have_recent_data":
+          group_by: [CHAIN, SYMBOL]
+          timestamp_column: "DATE"
+          datepart: "day"
+          interval: 2
     columns:
       - name: "DATE"
         tests:


### PR DESCRIPTION
1. Adding stablecoin freshness test on the silver table that powers all the other major tables