### PR TITLE
add etf to ez metrics table

### DIFF
--- a/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
+++ b/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
@@ -40,8 +40,17 @@ with
     defillama_data as ({{ get_defillama_metrics("bitcoin") }}),
     github_data as ({{ get_github_metrics("bitcoin") }}),
     nft_metrics as ({{ get_nft_metrics("bitcoin") }}),
-    rolling_metrics as ({{ get_rolling_active_address_metrics("bitcoin") }})
-
+    rolling_metrics as ({{ get_rolling_active_address_metrics("bitcoin") }}),
+    etf_metrics as (
+        SELECT
+            date,
+            sum(net_etf_flow_native) as net_etf_flow_native,
+            sum(net_etf_flow) as net_etf_flow,
+            sum(cumulative_etf_flow_native) as cumulative_etf_flow_native,
+            sum(cumulative_etf_flow) as cumulative_etf_flow
+        FROM {{ ref("ez_bitcoin_etf_metrics") }}
+        GROUP BY 1
+    )
 select
     fundamental_data.date,
     fundamental_data.chain,
@@ -64,7 +73,11 @@ select
     weekly_commits_sub_ecosystem,
     weekly_developers_core_ecosystem,
     weekly_developers_sub_ecosystem,
-    nft_trading_volume
+    nft_trading_volume,
+    net_etf_flow_native,
+    net_etf_flow,
+    cumulative_etf_flow_native,
+    cumulative_etf_flow
 from fundamental_data
 left join issuance_data on fundamental_data.date = issuance_data.date
 left join price_data on fundamental_data.date = price_data.date
@@ -72,4 +85,5 @@ left join defillama_data on fundamental_data.date = defillama_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
+left join etf_metrics on fundamental_data.date = etf_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -36,6 +36,16 @@ with
     da_metrics as (
         select date, blob_fees_native, blob_fees, blob_size_mib, avg_mib_per_second, avg_cost_per_mib, avg_cost_per_mib_gwei, submitters
         from {{ ref("fact_ethereum_da_metrics") }}
+    ),
+    etf_metrics as (
+        SELECT
+            date,
+            sum(net_etf_flow_native) as net_etf_flow_native,
+            sum(net_etf_flow) as net_etf_flow,
+            sum(cumulative_etf_flow_native) as cumulative_etf_flow_native,
+            sum(cumulative_etf_flow) as cumulative_etf_flow
+        FROM {{ ref("ez_ethereum_etf_metrics") }}
+        GROUP BY 1
     )
 
 select
@@ -114,7 +124,11 @@ select
     avg_mib_per_second,
     avg_cost_per_mib_gwei,
     avg_cost_per_mib,
-    submitters
+    submitters,
+    net_etf_flow_native,
+    net_etf_flow,
+    cumulative_etf_flow_native,
+    cumulative_etf_flow
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -129,4 +143,5 @@ left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join da_metrics on fundamental_data.date = da_metrics.date
+left join etf_metrics on fundamental_data.date = etf_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
+++ b/models/staging/bitcoin/fact_bitcoin_etf_flows.sql
@@ -98,9 +98,9 @@ SELECT
     c.date,
     c.issuer,
     c.etf_ticker,
-    c.amount,
-    c.cum_amount,
-    c.amount * p.price as amount_usd,
-    c.cum_amount * p.price as cum_amount_usd
+    c.amount as net_etf_flow_native,
+    c.cum_amount as cumulative_etf_flow_native,
+    c.amount * p.price as net_etf_flow,
+    c.cum_amount * p.price as cumulative_etf_flow
 FROM cumulative_native c
 LEFT JOIN bitcoin_prices p ON p.date = c.date

--- a/models/staging/ethereum/fact_ethereum_etf_flows.sql
+++ b/models/staging/ethereum/fact_ethereum_etf_flows.sql
@@ -74,9 +74,9 @@ WITH time_series AS (
 SELECT
     c.date,
     c.issuer,
-    amount,
-    cum_amount,
-    amount * p.price as amount_usd,
-    cum_amount * p.price as cum_usd
+    amount as net_etf_flow_native,
+    cum_amount as cumulative_etf_flow_native,
+    amount * p.price as net_etf_flow,
+    cum_amount * p.price as cumulative_etf_flow
 FROM cumulative c
 LEFT JOIN eth_prices p on p.date = c.date


### PR DESCRIPTION
Need to add aggregate ETF metrics to `ez_metrics` tables for both `bitcoin` and `ethereum` in order to be able to work with our current adapter functions.