### PR TITLE
Stablecoins: removing not null test

### DIFF
--- a/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_silver.yml
+++ b/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_silver.yml
@@ -1,11 +1,5 @@
 models:
   - name: agg_daily_stablecoin_breakdown_silver
-    tests:
-      - "dbt_expectations.expect_grouped_row_values_to_have_recent_data":
-          group_by: [CHAIN, SYMBOL]
-          timestamp_column: "DATE"
-          datepart: "day"
-          interval: 2
     columns:
       - name: "DATE"
         tests:


### PR DESCRIPTION
Not null test is failing for some reason. This issue is coming from the server being in UTC time and expecting data for the 20th but the underlying models haven't materialized for yday 
<img width="1066" alt="Screenshot 2024-11-20 at 8 07 25 PM" src="https://github.com/user-attachments/assets/a90c8a62-2b06-4c78-87f8-52f2c9ce33f5">
