### PR TITLE
DAU over 100: Base and Tron

### DIFF
--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -52,6 +52,7 @@ select
     new_users,
     low_sleep_users,
     high_sleep_users,
+    dau_over_100,
     tvl,
     dex_volumes,
     weekly_contracts_deployed,

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -37,6 +37,7 @@ select
     median_txn_fee,
     returning_users,
     new_users,
+    dau_over_100,
     price,
     market_cap,
     fdmc,


### PR DESCRIPTION
- Supporting DAU over 100 for both base and tron
- the data existed in the backed just was not in the final ez metrics table