### PR TITLE
C911: Celo Stablecoin Data

### DIFF
--- a/macros/decode/token_transfer_events.sql
+++ b/macros/decode/token_transfer_events.sql
@@ -41,12 +41,12 @@
             and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
         {% if chain in ('celo') %}
-            union all
-            select
+            union
+            select distinct
                 t1.block_timestamp,
                 t1.block_number,
                 t1.transaction_hash,
-                null as event_index,
+                -1 as event_index,
                 t1.from_address as origin_from_address,
                 t1.to_address as origin_to_address,
                 t1.fee_currency as contract_address,


### PR DESCRIPTION
1. Celo Stablecoin transfers are borked.
2. The issue is because SF/DBT does not know how to unify when one of the incremental unique keys are null. 
3. Switching null index for -1 index celo token transfers used as gas