### PR TITLE
correct column reference

### DIFF
--- a/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
+++ b/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
@@ -16,7 +16,7 @@ SELECT
     sum(trading_volume) as trading_volume,
     sum(trading_fees) as trading_fees,
     sum(unique_traders) as unique_traders,
-    sum(txns) as number_of_swaps,
+    sum(number_of_swaps) as number_of_swaps,
     sum(gas_cost_native) as gas_cost_native
 FROM {{ ref("ez_trader_joe_metrics_by_chain") }}
 GROUP BY 1, 2, 3


### PR DESCRIPTION
changed column references originally made in [this PR](https://github.com/Artemis-xyz/dbt/commit/9af37d08711c419f534de86e37dc2e19a2114d8e).

Outerlands job runs now.
<img width="1497" alt="Screenshot 2024-12-06 at 2 37 10 PM" src="https://github.com/user-attachments/assets/97d188bd-c221-4eac-ada8-bccd337fb3b8">

As does trader joe:
<img width="1503" alt="Screenshot 2024-12-06 at 2 37 36 PM" src="https://github.com/user-attachments/assets/f624ae3a-cc63-4fe7-a86d-eb81f84c83e3">
