### PR TITLE
Son/drift update

### DIFF
--- a/models/staging/drift/fact_drift_amm_revenue.sql
+++ b/models/staging/drift/fact_drift_amm_revenue.sql
@@ -3,6 +3,7 @@
 WITH fact_drift_daily_perp_data AS (
     SELECT
         date
+        , max(latest_timestamp) as latest_timestamp
         , sum(latest_excess_pnl) as latest_excess_pnl
     FROM
         {{ref('fact_drift_daily_perp_data')}}
@@ -10,6 +11,7 @@ WITH fact_drift_daily_perp_data AS (
 )
 SELECT
     date
+    , latest_timestamp
     , latest_excess_pnl - LAG(latest_excess_pnl) OVER (ORDER BY date) as total_revenue
     , latest_excess_pnl
 FROM 

--- a/models/staging/drift/fact_drift_daily_perp_data.sql
+++ b/models/staging/drift/fact_drift_daily_perp_data.sql
@@ -11,6 +11,7 @@ SELECT
     AVG(value:oi_net::float) as daily_avg_net_open_interest,
     AVG(value:net_user_pnl::float) as daily_avg_net_user_pnl,
     MAX_BY(value:excess_pnl::float, TO_TIMESTAMP(value:timestamp::string, 'YYYY/MM/DD HH24:MI:SS')) as latest_excess_pnl,
+    MAX(TO_TIMESTAMP(value:timestamp::string, 'YYYY/MM/DD HH24:MI:SS')) as latest_timestamp,
     AVG(value:est_funding_dollars::float) as daily_avg_est_funding_dollars
 FROM {{ source("PROD_LANDING", "raw_drift_perp_market_data") }} ,
     lateral flatten(input => parse_json(source_json))


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [x] Added new `fact` tables if necessary
- [x] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
