### PR TITLE
Wes/pendle tvl fix

### DIFF
--- a/macros/pendle/get_pendle_deposit_redeem_txns.sql
+++ b/macros/pendle/get_pendle_deposit_redeem_txns.sql
@@ -20,6 +20,9 @@
         FROM {{ chain }}_flipside.core.fact_event_logs
         WHERE topics[0] in ('0x5fe47ed6d4225326d3303476197d782ded5a4e9c14f479dc9ec4992af4e85d59') -- Deposit event
         AND contract_address in (SELECT sy_address FROM sy_addresses)
+        {% if is_incremental() %}
+            AND block_timestamp > (SELECT DATEADD(day, -1, MAX(block_timestamp)) FROM {{this}})
+        {% endif %}
     ),
 
     redeems AS (
@@ -38,6 +41,9 @@
         FROM {{ chain }}_flipside.core.fact_event_logs
         WHERE topics[0] = '0xaee47cdf925cf525fdae94f9777ee5a06cac37e1c41220d0a8a89ed154f62d1c' -- Redeem event
         AND contract_address in (SELECT sy_address FROM sy_addresses)
+        {% if is_incremental() %}
+            AND block_timestamp > (SELECT DATEADD(day, -1, MAX(block_timestamp)) FROM {{this}})
+        {% endif %}
     )
 
     SELECT

--- a/macros/pendle/get_pendle_deposit_redeem_txns.sql
+++ b/macros/pendle/get_pendle_deposit_redeem_txns.sql
@@ -1,34 +1,58 @@
 {% macro get_pendle_deposit_redeem_txns(chain) %}
 
     WITH sy_addresses AS (
-        SELECT sy_address
-        FROM {{ref('dim_pendle_' ~ chain ~ '_market_metadata')}}
+        SELECT sy_address FROM {{ ref('dim_pendle_' ~ chain ~ '_market_metadata') }}
     )
-    , decoded_events as (
-        SELECT
-            *
-        FROM ethereum_flipside.core.ez_decoded_event_logs
-        WHERE contract_address IN (SELECT DISTINCT(sy_address) FROM sy_addresses)
-        AND event_name IN ('Deposit', 'Redeem')
-        {% if is_incremental() %}
-            AND block_timestamp > (SELECT DATEADD(day, -1, MAX(block_timestamp)) FROM {{this}})
-        {% endif %}
+
+    , deposits AS (
+        SELECT 
+            block_timestamp,
+            tx_hash,
+            contract_address,
+            'Deposit' as event_type,
+            -- Indexed parameters from topics
+            '0x' || RIGHT(topics[1], 40) as caller_address,
+            '0x' || RIGHT(topics[2], 40) as receiver_address,
+            '0x' || RIGHT(topics[3], 40) as token_address,  -- tokenIn for deposits
+            -- Unindexed parameters from data
+            PC_DBT_DB.PROD.HEX_TO_INT(SUBSTRING(data, 3, 64)) as amount_in,   -- amountDeposited
+            PC_DBT_DB.PROD.HEX_TO_INT(SUBSTRING(data, 67, 64)) as amount_out  -- amountSyOut
+        FROM {{ chain }}_flipside.core.fact_event_logs
+        WHERE topics[0] in ('0x5fe47ed6d4225326d3303476197d782ded5a4e9c14f479dc9ec4992af4e85d59') -- Deposit event
+        AND contract_address in (SELECT sy_address FROM sy_addresses)
+    ),
+
+    redeems AS (
+        SELECT 
+            block_timestamp,
+            tx_hash,
+            contract_address,
+            'Redeem' as event_type,
+            -- Indexed parameters from topics
+            '0x' || RIGHT(topics[1], 40) as caller_address,
+            '0x' || RIGHT(topics[2], 40) as receiver_address,
+            '0x' || RIGHT(topics[3], 40) as token_address,  -- tokenOut for redeems
+            -- Unindexed parameters from data
+            PC_DBT_DB.PROD.HEX_TO_INT(SUBSTRING(data, 3, 64)) as amount_in,   -- amountSyToRedeem
+            PC_DBT_DB.PROD.HEX_TO_INT(SUBSTRING(data, 67, 64)) as amount_out  -- amountTokenOut
+        FROM {{ chain }}_flipside.core.fact_event_logs
+        WHERE topics[0] = '0xaee47cdf925cf525fdae94f9777ee5a06cac37e1c41220d0a8a89ed154f62d1c' -- Redeem event
+        AND contract_address in (SELECT sy_address FROM sy_addresses)
     )
+
     SELECT
-        DECODED_LOG:tokenIn::STRING as token_address,
-        DECODED_LOG:amountDeposited::number as amount,
+        block_timestamp,
         contract_address as sy_address,
-        *
-    FROM decoded_events
-    WHERE event_name = 'Deposit'
+        amount_in::number as amount,
+        tx_hash
+    FROM deposits
     UNION ALL
     SELECT
-        DECODED_LOG:tokenOut::STRING as token_address,
-        - DECODED_LOG:amountTokenOut::number as amount,
+        block_timestamp,
         contract_address as sy_address,
-        *
-    FROM decoded_events
-    WHERE event_name = 'Redeem'
-
+        amount_in::number * -1 as amount,
+        tx_hash
+    FROM redeems
+    ORDER BY block_timestamp DESC
 
 {% endmacro %}

--- a/macros/pendle/get_pendle_deposit_redeem_txns.sql
+++ b/macros/pendle/get_pendle_deposit_redeem_txns.sql
@@ -59,6 +59,5 @@
         amount_in::number * -1 as amount,
         tx_hash
     FROM redeems
-    ORDER BY block_timestamp DESC
 
 {% endmacro %}

--- a/macros/pendle/get_pendle_market_metadata_for_chain.sql
+++ b/macros/pendle/get_pendle_market_metadata_for_chain.sql
@@ -31,6 +31,8 @@
                 AND pt_address IN (SELECT pt_address FROM pt_addresses)
                 {% if is_incremental() %}
                     AND block_timestamp > dateadd(day, -3, to_date(sysdate()))
+                {% else %}
+                    AND block_timestamp > '2022-11-22'
                 {% endif %}
         ),
 

--- a/macros/pendle/get_pendle_market_metadata_for_chain.sql
+++ b/macros/pendle/get_pendle_market_metadata_for_chain.sql
@@ -13,6 +13,8 @@
                 event_name = 'CreateNewMarket'
                 {% if is_incremental() %}
                     AND block_timestamp > dateadd(day, -3, to_date(sysdate()))
+                {% else %}
+                    AND block_timestamp > '2022-11-22'
                 {% endif %}
         ),
 
@@ -34,21 +36,18 @@
 
         -- Identify new underlying addresses based on deposits related to new SYs
         deposits as (
-            SELECT
+            SELECT 
                 contract_address as sy_address,
-                DECODED_LOG:tokenIn::STRING as underlying_address,
-                COUNT(*) as deposit_count
-            FROM
-                {{ chain }}_flipside.core.ez_decoded_event_logs
-            WHERE
-                event_name = 'Deposit'
-                AND DECODED_LOG:tokenIn::STRING <> '0x0000000000000000000000000000000000000000'
+                '0x' || RIGHT(topics[3], 40) as underlying_address,
+                count(*) as deposit_count
+            FROM {{ chain }}_flipside.core.fact_event_logs
+            WHERE 1=1
+                AND '0x' || RIGHT(topics[3], 40) <> '0x0000000000000000000000000000000000000000' -- tokenIn cannot be 0x000...
                 AND contract_address IN (SELECT sy_address FROM sy_addresses)
-                {% if is_incremental() %}
-                    AND block_timestamp > dateadd(day, -3, to_date(sysdate()))
-                {% endif %}
+                AND topics[0] = '0x5fe47ed6d4225326d3303476197d782ded5a4e9c14f479dc9ec4992af4e85d59' -- Deposit event
+                -- AND contract_address IN (lower('0x9d6Ec7a7B051B32205F74B140A0fa6f09D7F223E')) -- this is a contact address we know exists in our 
             GROUP BY
-                contract_address, DECODED_LOG:tokenIn::STRING
+                1, 2
         ),
 
         -- Rank new underlying addresses by deposit count to get the most frequent one

--- a/macros/pendle/get_pendle_market_metadata_for_chain.sql
+++ b/macros/pendle/get_pendle_market_metadata_for_chain.sql
@@ -47,7 +47,6 @@
                 AND '0x' || RIGHT(topics[3], 40) <> '0x0000000000000000000000000000000000000000' -- tokenIn cannot be 0x000...
                 AND contract_address IN (SELECT sy_address FROM sy_addresses)
                 AND topics[0] = '0x5fe47ed6d4225326d3303476197d782ded5a4e9c14f479dc9ec4992af4e85d59' -- Deposit event
-                -- AND contract_address IN (lower('0x9d6Ec7a7B051B32205F74B140A0fa6f09D7F223E')) -- this is a contact address we know exists in our 
             GROUP BY
                 1, 2
         ),

--- a/models/staging/pendle/dim_pendle_base_market_metadata.sql
+++ b/models/staging/pendle/dim_pendle_base_market_metadata.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="PENDLE",
+        unique_key = "market_address"
+    )
+}}
+
+{{ get_pendle_markets_for_chain('base') }}

--- a/models/staging/pendle/dim_pendle_bsc_market_metadata.sql
+++ b/models/staging/pendle/dim_pendle_bsc_market_metadata.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="PENDLE",
+        unique_key = "market_address"
+    )
+}}
+
+{{ get_pendle_markets_for_chain('bsc') }}

--- a/models/staging/pendle/fact_pendle_base_deposit_redeem_txns.sql
+++ b/models/staging/pendle/fact_pendle_base_deposit_redeem_txns.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="PENDLE"
+    )
+}}
+
+{{ get_pendle_deposit_redeem_txns('base') }}

--- a/models/staging/pendle/fact_pendle_base_tvl_by_token.sql
+++ b/models/staging/pendle/fact_pendle_base_tvl_by_token.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="PENDLE"
+    )
+}}
+
+{{ get_pendle_tvl_for_chain_by_token('base') }}

--- a/models/staging/pendle/fact_pendle_bsc_deposit_redeem_txns.sql
+++ b/models/staging/pendle/fact_pendle_bsc_deposit_redeem_txns.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="PENDLE"
+    )
+}}
+
+{{ get_pendle_deposit_redeem_txns('bsc') }}

--- a/models/staging/pendle/fact_pendle_bsc_tvl_by_token.sql
+++ b/models/staging/pendle/fact_pendle_bsc_tvl_by_token.sql
@@ -1,0 +1,8 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="PENDLE"
+    )
+}}
+
+{{ get_pendle_tvl_for_chain_by_token('bsc') }}


### PR DESCRIPTION
FIxing Pendle TVL which was broken.

**Root Cause**: Flipside's ez_decoded_logs table was not fully capturing all of Pendle's Standard Yield token contracts, leading to missing data.

**Solution**: Begin using fact_event_logs and decode the raw logs by hand. 

**Additional Notes**: Added basic models for Base and BSC TVL. I did not include these chains in the downstream aggregate tables due to some data quality issues that were out of the scope of this PR. 

Wrote more about this [here](https://www.notion.so/artemisxyz/Pendle-Issue-17146f0265b4808d849febe2b48fbc15)