### PR TITLE
index monthly weights to incremental

### DIFF
--- a/models/staging/outerlands/fact_outerlands_asset_weights_for_month_start.sql
+++ b/models/staging/outerlands/fact_outerlands_asset_weights_for_month_start.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         snowflake_warehouse="outerlands",
         unique_key=["date", "artemis_id"]
     )
@@ -152,4 +152,8 @@ SELECT
         COALESCE(trailing_30d_sum_fees / NULLIF(total_trailing_30d_sum_fees, 0), 0)
     ) AS combined_score
 FROM trailing_and_totals t
+WHERE 1=1
+    {% if is_incremental() %}
+        AND t.date > (SELECT MAX(date) FROM {{ this }})
+    {% endif %}
 ORDER BY date DESC, artemis_id


### PR DESCRIPTION
- Added incremental logic to `fact_outerlands_fundamental_index_performance` in order to preserve historical data.
- This is particularly relevant in the case that the underlying data changes (eg. we add support for USDe on Solana -> causes historical daus, txns, etc to increase -> its historic weight changes in the index and thus its historical performance). These underlying changes should only affect future index performance.
- Only made this query incremental since it is the one that interfaces with the underlying data. All other tables rely on this table, so no need to make downstream tables incremental as well.

Ran the compiled dbt code for the model and, as expected, it returned no rows.
![CleanShot 2025-01-09 at 10 27 26@2x](https://github.com/user-attachments/assets/95aa04f0-4d88-447d-9217-1124b648d201)

Also ran the compiled dbt code with a dummy date value of '2024-12-01' to see its behavior if it were run on Jan 1st. As expected it returns only the new weights for the month of January:
![CleanShot 2025-01-09 at 10 29 17@2x](https://github.com/user-attachments/assets/2231bcd4-91d1-4039-a018-41032271c983)