### PR TITLE
Fix ton transactions model

### DIFF
--- a/models/staging/ton/fact_ton_transactions.sql
+++ b/models/staging/ton/fact_ton_transactions.sql
@@ -4,7 +4,7 @@
         unique_key="tx_hash",
     )
 }}
-select
+select distinct
     avro_raw:hash::string as tx_hash
     , avro_raw:trace_id::string as trace_id
     , avro_raw:now::timestamp as block_timestamp 


### PR DESCRIPTION
# Description

This should resolve https://artemis.dagster.cloud/prod/runs/9499821a-fd53-487c-9013-9581aa85a69d. There were duplicate rows of tx_hash in the incremental portion of the model. Upon inspection, the duplicate tx_hash rows were exactly the same, so I just added a "distinct" which should resolve the error.

Eg.
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/a8b7cf8d-8551-424e-b724-ecdf755b5e0c" />
