### PR TITLE
Feature/balancer metrics

### DIFF
--- a/models/projects/balancer/core/ez_balancer_metrics.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics.sql
@@ -21,6 +21,13 @@ with date_spine as (
     FROM {{ ref('fact_balancer_tvl_by_chain_and_token') }}
     group by 1
 )
+, tvl_balancer_v1 as (
+    SELECT
+        date,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by 1
+)
 , treasury as (
     SELECT
         date,
@@ -53,13 +60,47 @@ with date_spine as (
 , market_data as (
     {{ get_coingecko_metrics('balancer') }}
 )
-
+ ,trading_metrics AS (
+        SELECT 
+            block_date AS date,
+            version,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders,
+            'TBD' AS gas_cost_native,
+            'TBD' AS gas_cost_usd
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000) --filter out deprecated, outlier tokens
+        GROUP BY block_date, version
+)
 select
     date_spine.date,
-    all_tvl.tvl_usd as tvl,
+    trading_metrics.version,
+    trading_metrics.swap_count,
+    trading_metrics.trading_fees,
+    trading_metrics.fees,
+    trading_metrics.primary_supply_side_revenue,
+    trading_metrics.secondary_supply_side_revenue,
+    trading_metrics.total_supply_side_revenue,
+    trading_metrics.protocol_revenue,
+    trading_metrics.operating_expenses,
+    trading_metrics.token_incentives,
+    trading_metrics.protocol_earnings,
+   -- all_tvl.tvl_usd as tvl,
+    tvl_balancer_v1.tvl_usd,
     treasury.net_treasury_usd as treasury_value,
     net_treasury.net_treasury_usd as net_treasury_value,
     treasury_native.treasury_native as treasury_native,
+    trading_metrics.trading_volume,
     market_data.price,
     market_data.market_cap,
     market_data.fdmc,
@@ -74,3 +115,5 @@ left join treasury_native using (date)
 left join net_treasury using (date)
 left join token_holders using (date)
 left join market_data using (date)
+left join tvl_balancer_v1 using (date)
+left join trading_metrics using (date)

--- a/models/projects/balancer/core/ez_balancer_metrics_by_chain.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics_by_chain.sql
@@ -7,16 +7,26 @@
         alias='ez_metrics_by_chain'
     )
 }}
-
-with all_tvl_by_chain as (
+/*
+    with all_tvl_by_chain as (
+        SELECT
+            date,
+            chain,
+            sum(tvl_native) as tvl_native,
+            sum(tvl_usd) as tvl_usd
+        FROM {{ ref('fact_balancer_tvl_by_chain_and_token') }}
+        group by 1,2
+),
+*/
+with tvl_balancer_v1 as (
     SELECT
         date,
-        chain,
-        sum(tvl_native) as tvl_native,
-        sum(tvl_usd) as tvl_usd
-    FROM {{ ref('fact_balancer_tvl_by_chain_and_token') }}
+        'ethereum' as chain,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
     group by 1,2
 )
+
 , treasury_by_chain as (
     SELECT
         date,
@@ -51,24 +61,63 @@ with all_tvl_by_chain as (
     FROM {{ ref('dim_date_spine') }}
     CROSS JOIN (SELECT distinct chain from treasury_by_chain
         UNION
-        SELECT distinct chain from all_tvl_by_chain
-        UNION
+        --SELECT distinct chain from all_tvl_by_chain
+        --UNION
         SELECT distinct chain from treasury_native
         UNION
         SELECT distinct chain from net_treasury
     )
     where date between '2020-03-01' and to_date(sysdate())
 )
+,   trading_metrics_by_chain AS (
+        SELECT 
+            block_date AS date,
+            blockchain AS chain,
+            version,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders,
+            'TBD' AS gas_cost_native,
+            'TBD' AS gas_cost_usd
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000)
+        GROUP BY block_date, blockchain, version
+)
 
 select
     date_chain_spine.date,
     date_chain_spine.chain,
-    all_tvl_by_chain.tvl_usd as tvl,
+    trading_metrics_by_chain.version,
+    trading_metrics_by_chain.swap_count,
+    trading_metrics_by_chain.trading_fees,
+    trading_metrics_by_chain.fees,
+    trading_metrics_by_chain.primary_supply_side_revenue,
+    trading_metrics_by_chain.secondary_supply_side_revenue,
+    trading_metrics_by_chain.total_supply_side_revenue,
+    trading_metrics_by_chain.protocol_revenue,
+    trading_metrics_by_chain.operating_expenses,
+    trading_metrics_by_chain.token_incentives,
+    trading_metrics_by_chain.protocol_earnings,
+    --all_tvl_by_chain.tvl_usd as tvl,
+    tvl_balancer_v1.tvl_usd,
     treasury_by_chain.usd_balance as treasury_value,
+    treasury_native.treasury_native as treasury_native,
     net_treasury.net_treasury_usd as net_treasury_value,
-    treasury_native.treasury_native as treasury_native
+    trading_metrics_by_chain.trading_volume,
+    trading_metrics_by_chain.unique_traders
 from date_chain_spine
-left join all_tvl_by_chain using (date, chain)
+--left join all_tvl_by_chain using (date, chain)
 left join treasury_by_chain using (date, chain)
 left join treasury_native using (date, chain)
 left join net_treasury using (date, chain)
+left join trading_metrics_by_chain using (date, chain)
+left join tvl_balancer_v1 using (date, chain)

--- a/models/projects/balancer/core/ez_balancer_metrics_by_token.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics_by_token.sql
@@ -17,7 +17,17 @@ with all_tvl_by_token as (
     FROM {{ ref('fact_balancer_tvl_by_chain_and_token') }}
     where tvl_usd > 0
     group by 1,2
+),
+tvl_balancer_v1 as (
+    SELECT
+        date,
+        token_address,
+        token_symbol as token,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by 1,2,3
 )
+
 
 , treasury_by_token as (
     SELECT
@@ -48,6 +58,31 @@ with all_tvl_by_token as (
     and native_balance > 0
     group by 1,2
 )
+,   trading_metrics_by_token_sold AS (
+        SELECT 
+            block_date AS date,
+            blockchain AS chain,
+            version,
+            token_sold_address,
+            token_sold_symbol as token,
+            blockchain,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS token_incentives_native,
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders,
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000)
+        GROUP BY block_date, token_sold_address, token_sold_symbol, blockchain, version
+) 
 ,date_token_spine as (
     SELECT
         distinct
@@ -61,19 +96,29 @@ with all_tvl_by_token as (
                 SELECT distinct token from net_treasury
                 UNION
                 SELECT distinct token from treasury_native
+                UNION
+                SELECT distinct token from trading_metrics_by_token_sold
+                UNION
+                SELECT distinct token from tvl_balancer_v1
                 )
     where date between '2020-03-01' and to_date(sysdate())
 )
-
 select
     date_token_spine.date,
-    token,
-    all_tvl_by_token.tvl_usd as tvl,
+    trading_metrics_by_token_sold.token,
+    trading_metrics_by_token_sold.blockchain,
+    trading_metrics_by_token_sold.trading_fees,
+    trading_metrics_by_token_sold.token_incentives_native,
     treasury_by_token.usd_balance as treasury_value,
     net_treasury.net_treasury_usd as net_treasury_value,
-    treasury_native.treasury_native as treasury_native
+    treasury_native.treasury_native as treasury_native,
+    trading_metrics_by_token_sold.trading_volume as trading_volume,
+    tvl_balancer_v1.tvl_usd
+    --all_tvl_by_token.tvl_usd as tvl
 from date_token_spine
-full outer join all_tvl_by_token using (date, token)
+--full outer join all_tvl_by_token using (date, token)
 full outer join treasury_by_token using (date, token)
 full outer join net_treasury using (date, token)
 full outer join treasury_native using (date, token)
+left join trading_metrics_by_token_sold using (date, token)
+left join tvl_balancer_v1 using (date, token)

--- a/models/projects/balancer/raw/fact_balancer_liquidity.sql
+++ b/models/projects/balancer/raw/fact_balancer_liquidity.sql
@@ -1,0 +1,175 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH pool_balances AS (
+    SELECT 
+        block_timestamp,
+        block_timestamp::date as date,
+        address as pool_address,
+        contract_address as token_address,
+        max_by(balance_token, block_timestamp::date) as token_balance
+    FROM {{ ref('fact_ethereum_address_balances_by_token') }}  
+    WHERE address IN (SELECT pool FROM BALANCER.prod_raw.fact_balancer_v1_ethereum_bpools)
+    GROUP BY 1, 2, 3, 4
+),
+
+token_info AS (
+    SELECT 
+        hour,
+        token_address,
+        price,
+        symbol,
+        decimals
+    FROM {{ source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}}
+),
+
+tvl_calculations AS (
+    SELECT 
+        pb.block_timestamp,
+        pb.date,
+        EXTRACT(HOUR FROM pb.block_timestamp) as hour,
+        pb.pool_address,
+        pb.token_address,
+        pb.token_balance as token_balance_raw,
+        t.decimals,
+        pb.token_balance / pow(10,t.decimals) as token_balance,
+        t.symbol as token_symbol,
+        t.price as token_price,
+        (pb.token_balance / POW(10, t.decimals)) * t.price AS token_value_usd
+    FROM pool_balances pb
+    LEFT JOIN token_info t 
+        ON lower(t.token_address) = lower(pb.token_address) and t.hour = pb.date
+       -- AND t.hour = TIMESTAMPADD(HOUR, 23, pb.date)
+),
+latest_tvl_per_token AS (
+    SELECT 
+        tvl.block_timestamp,
+        tvl.date,
+        tvl.hour,
+        tvl.pool_address,
+        tvl.token_address,
+        token_balance_raw,
+        token_balance,
+        token_symbol,
+        token_price,
+        tvl.token_value_usd,
+        ROW_NUMBER() OVER (
+            PARTITION BY tvl.date, tvl.pool_address, tvl.token_address
+            ORDER BY tvl.block_timestamp DESC
+        ) AS rank -- Rank by the latest hour for each date, pool, and token
+    FROM tvl_calculations tvl
+    -- pb.block_timestamps
+),
+tvl_aggregated_by_token AS (
+    SELECT 
+        date,
+        hour,
+        pool_address,
+        token_address,
+        token_symbol,
+        token_price,
+        token_balance_raw,
+        token_balance,
+        token_value_usd AS tvl_token
+    FROM latest_tvl_per_token
+    WHERE rank = 1 -- Only keep the latest time entry for each token on each date
+),
+
+dates AS (
+    SELECT 
+        date 
+    FROM {{ ref('dim_date_spine') }}  --pc_dbt_db.prod.dim_date_spine
+    WHERE date BETWEEN '2020-02-27' AND TO_DATE(SYSDATE())
+),
+
+pool_token_combinations AS (
+    SELECT DISTINCT
+        pool_address,
+        token_address
+    FROM tvl_aggregated_by_token
+),
+
+date_pool_token_combinations AS (
+    SELECT 
+        d.date,
+        ptc.pool_address,
+        ptc.token_address
+    FROM dates d
+    CROSS JOIN pool_token_combinations ptc
+),
+
+final_result AS (
+    SELECT 
+        dpt.date,
+        dpt.pool_address,
+        dpt.token_address,
+        tat.token_symbol,
+        token_balance_raw,
+        token_balance,
+        token_price,
+        tat.tvl_token
+    FROM date_pool_token_combinations dpt
+    LEFT JOIN tvl_aggregated_by_token tat
+        ON dpt.date = tat.date
+        AND dpt.pool_address = tat.pool_address
+        AND dpt.token_address = tat.token_address
+),
+
+backfilled_tvl AS (
+    SELECT
+        date,
+        pool_address,
+        token_address,
+        token_symbol,
+        token_balance_raw,
+        token_balance,
+        token_price,
+        -- Fill in tvl_token values using the most recent non-NULL value
+        COALESCE(
+            tvl_token,
+            LAST_VALUE(tvl_token) IGNORE NULLS OVER (
+                PARTITION BY pool_address, token_address 
+                ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ),
+            0 -- If no historic record exists, set tvl_token to 0
+        ) AS tvl_token_filled
+    FROM final_result -- Use the output from the previous query
+),
+adjusted_tvl AS (
+    SELECT
+        date,
+        pool_address,
+        token_address,
+        token_symbol,
+        token_balance_raw,
+        token_balance,
+        token_price,
+        -- Override tvl_token for the specific token address after 2023-09-01
+        CASE
+            WHEN token_address = '0x6e36556b3ee5aa28def2a8ec3dae30ec2b208739' AND date > '2023-09-01'
+                THEN 0
+            ELSE tvl_token_filled
+        END AS tvl_token_adjusted
+    FROM backfilled_tvl
+)
+
+SELECT 
+    date,
+    pool_address,
+    'ethereum' as chain,
+    '1' as version,
+    token_address,
+    token_symbol,
+    token_balance_raw,
+    token_balance,
+    token_price,
+    tvl_token_adjusted
+FROM adjusted_tvl
+GROUP BY date, pool_address, token_address, tvl_token_adjusted, token_symbol, token_balance_raw, token_balance, token_price
+ORDER BY date, pool_address, token_address, tvl_token_adjusted DESC

--- a/models/projects/balancer/raw/fact_balancer_trades.sql
+++ b/models/projects/balancer/raw/fact_balancer_trades.sql
@@ -1,0 +1,111 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH SWAP_DETAILS AS (
+    SELECT
+        DATE_TRUNC('DAY', swaps.block_timestamp) AS block_date, -- Extracts the date part from the timestamp
+        swaps.block_timestamp,
+        swaps.block_number,
+        origin_from_address,
+        origin_to_address,
+        event_index,
+        tx_hash,
+        swaps.hour as hour,
+        'ethereum' AS chain,
+        pool,
+        caller,
+        tokenIn, -- Directly references extracted field
+        tokenAmountIn, -- Directly references extracted field
+        t2.price AS tokenInPrice,
+        t2.symbol AS tokenInSymbol,
+        t2.decimals AS tokenInDecimals,
+        tokenOut, -- Directly references extracted field
+        tokenAmountOut, -- Directly references extracted field
+        t3.price AS tokenOutPrice,
+        t3.symbol AS tokenOutSymbol,
+        t3.decimals AS tokenOutDecimals,
+    FROM {{ ref('fact_balancer_v1_ethereum_Bpool_swaps') }} AS swaps
+    LEFT JOIN
+        {{ source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t2 --ethereum_flipside.price.ez_prices_hourly t2
+        on (lower(swaps.tokenIn) = lower(t2.token_address) and t2.hour = swaps.hour)
+    LEFT JOIN
+        {{ source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t3 --ethereum_flipside.price.ez_prices_hourly t3
+        on (lower(swaps.tokenOut) = lower(t3.token_address) and t3.hour = swaps.hour)
+    ORDER BY block_date ASC -- Sorts the results by date in ascending order
+),
+SWAPS_USD_RAW AS (
+    SELECT
+        swap.block_date,
+        swap.block_timestamp,
+        source_fees.block_timestamp AS set_fee_block_timestamp,
+        swap.block_number,
+        source_fees.block_number,
+        swap.event_index,
+        swap.tx_hash,
+        hour AS swap_hour,
+        chain,
+        pool,
+        origin_from_address,
+        origin_to_address,
+        caller,
+        source_fees.tx_hash as set_fee_tx_hash,
+        tokenIn, 
+        tokenAmountIn, 
+        tokenInPrice,
+        tokenInSymbol,
+        tokenInDecimals,
+        tokenAmountIn  / pow(10, tokenInDecimals) * tokenInPrice as tokenAmountInUSD,
+        tokenOut, 
+        tokenAmountOut, 
+        tokenOutPrice,
+        tokenOutSymbol,
+        tokenOutDecimals,
+        tokenAmountOut  / pow(10, tokenOutDecimals) * tokenOutPrice as tokenAmountOutUSD,
+        source_fees.decoded_input_data:swapFee / 1e18 as swapFee,
+        swapFee * tokenAmountInUSD as swapFeeUSD,
+        ROW_NUMBER() OVER (PARTITION BY source_fees.to_address, swap.tx_hash, swap.event_index ORDER BY source_fees.block_number DESC NULLS FIRST) AS row_num
+    FROM SWAP_DETAILS swap
+    LEFT JOIN {{ source("ETHEREUM_FLIPSIDE", "ez_decoded_traces")}} source_fees --ethereum_flipside.core.ez_decoded_traces source_fees 
+        ON lower(source_fees.to_address) = lower(swap.pool)
+        AND source_fees.block_number < swap.block_number
+    WHERE FUNCTION_NAME = 'setSwapFee' 
+),
+
+SWAPS_USD AS (
+    SELECT * 
+    FROM SWAPS_USD_RAW
+    WHERE row_num = 1
+)
+SELECT
+    'ethereum' AS blockchain,
+    'balancer' AS project,
+    'v1' AS version,
+    block_date,
+    DATE_TRUNC('MONTH', block_timestamp) AS block_month,
+    block_timestamp AS block_time,
+    tokenOutSymbol AS token_bought_symbol,
+    tokenInSymbol AS token_sold_symbol,
+    CONCAT(tokenOutSymbol, '-', tokenInSymbol) AS token_pair,
+    tokenAmountOut AS token_bought_amount_raw,
+    tokenAmountIn AS token_sold_amount_raw,
+    tokenAmountOutUSD AS token_bount_amount_usd,
+    tokenAmountInUSD AS token_sold_amount_usd,
+    tokenOut AS token_bought_address,
+    tokenIn AS token_sold_address,
+    origin_from_address AS taker, --??
+    ' ' AS maker,                 --??
+    pool AS balancer_pool_address,
+    swapFee AS swap_fee,
+    swapFeeUSD AS swap_fee_usd,
+    'v1' AS pool_type,
+    tx_hash AS tx_hash,
+    origin_from_address AS tx_from, 
+    origin_to_address AS tx_to, 
+    event_index AS evt_index
+FROM SWAPS_USD

--- a/models/projects/balancer/raw/fact_balancer_v1_ethereum_Bpool_swaps.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_ethereum_Bpool_swaps.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+SELECT
+    t1.event_name,
+    t1.origin_from_address,
+    t1.origin_to_address,
+    t2.pool as pool,
+    t1.tx_hash,
+    t1.event_index,
+    t1.block_number,
+    t1.decoded_log:caller::STRING AS caller,              -- Extracts caller from JSON
+    TRY_CAST(t1.decoded_log:tokenAmountIn::STRING AS NUMBER) AS tokenAmountIn, -- Gracefully handle invalid values
+    TRY_CAST(t1.decoded_log:tokenAmountOut::STRING AS NUMBER) AS tokenAmountOut,
+   -- t1.decoded_log:tokenAmountIn::NUMBER AS tokenAmountIn, -- bug, number larger than 38 decimals
+   -- t1.decoded_log:tokenAmountOut::NUMBER AS tokenAmountOut, 
+    t1.decoded_log:tokenIn::STRING AS tokenIn,            -- Extracts tokenIn from JSON
+    t1.decoded_log:tokenOut::STRING AS tokenOut,           -- Extracts tokenOut from JSON
+    t1.block_timestamp,
+    trunc(t1.block_timestamp, 'hour') as hour,
+FROM {{ source("ETHEREUM_FLIPSIDE", "ez_decoded_event_logs")}} t1
+INNER JOIN {{ ref('fact_balancer_v1_ethereum_Bpools') }} t2 ON lower(t1.contract_address) = lower(t2.pool)
+WHERE t1.event_name = 'LOG_SWAP'

--- a/models/projects/balancer/raw/fact_balancer_v1_ethereum_Bpools.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_ethereum_Bpools.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+    
+SELECT 
+    block_timestamp,
+    event_name,
+    event_index,
+    decoded_log:caller::STRING AS caller,
+    decoded_log:pool::STRING AS pool 
+FROM {{ source("ETHEREUM_FLIPSIDE", "ez_decoded_event_logs")}}
+WHERE contract_address = lower('0x9424B1412450D0f8Fc2255FAf6046b98213B76Bd') -- Balancer v1 Core Pool Factory address 
+AND event_name = 'LOG_NEW_POOL'

--- a/models/projects/balancer/raw/fact_balancer_v1_metrics.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_metrics.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH trading_metrics AS (
+        SELECT 
+            block_date AS date,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000) --filter out deprecated, outlier tokens
+        GROUP BY block_date
+), tvl_balancer_v1 as (
+    SELECT
+        date,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by date
+),
+date_spine as (
+    select date
+    from {{ ref('dim_date_spine') }}
+    where date between '2020-03-01' and to_date(sysdate())
+)
+SELECT
+    date_spine.date,
+    '1' as version,
+    trading_metrics.swap_count,
+    trading_metrics.trading_fees,
+    trading_metrics.fees,
+    trading_metrics.primary_supply_side_revenue,
+    trading_metrics.secondary_supply_side_revenue,
+    trading_metrics.total_supply_side_revenue,
+    trading_metrics.protocol_revenue,
+    trading_metrics.operating_expenses,
+    trading_metrics.token_incentives,
+    trading_metrics.protocol_earnings,
+    trading_metrics.trading_volume,
+    trading_metrics.unique_traders,
+    tvl_balancer_v1.tvl_usd,
+    tvl_balancer_v1.tvl_usd as net_deposits
+FROM date_spine
+left join trading_metrics using (date)
+left join tvl_balancer_v1 using (date)

--- a/models/projects/balancer/raw/fact_balancer_v1_metrics_by_chain.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_metrics_by_chain.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH trading_metrics AS (
+        SELECT 
+            block_date AS date,
+            blockchain AS chain,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000) --filter out deprecated, outlier tokens
+        GROUP BY block_date, blockchain
+), tvl_balancer_v1 as (
+    SELECT
+        date,
+        chain,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by date, chain
+),
+date_spine as (
+    select 
+        date
+    from {{ ref('dim_date_spine') }}
+    where date between '2020-03-01' and to_date(sysdate())
+)
+SELECT
+    date_spine.date,
+    trading_metrics.chain,
+    '1' as version,
+    trading_metrics.swap_count,
+    trading_metrics.trading_fees,
+    trading_metrics.fees,
+    trading_metrics.primary_supply_side_revenue,
+    trading_metrics.secondary_supply_side_revenue,
+    trading_metrics.total_supply_side_revenue,
+    trading_metrics.protocol_revenue,
+    trading_metrics.operating_expenses,
+    trading_metrics.token_incentives,
+    trading_metrics.protocol_earnings,
+    trading_metrics.trading_volume,
+    trading_metrics.unique_traders,
+    tvl_balancer_v1.tvl_usd,
+    tvl_balancer_v1.tvl_usd as net_deposits
+FROM date_spine
+left join trading_metrics using (date)
+left join tvl_balancer_v1 using (date)

--- a/models/projects/balancer/raw/fact_balancer_v1_metrics_by_pool.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_metrics_by_pool.sql
@@ -1,0 +1,62 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH trading_metrics AS (
+        SELECT 
+            block_date AS date,
+            balancer_pool_address as pool_address,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000) --filter out deprecated, outlier tokens
+        GROUP BY block_date, pool_address
+), tvl_balancer_v1 as (
+    SELECT
+        date,
+        pool_address,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by date, pool_address
+),
+date_spine as (
+    select date
+    from {{ ref('dim_date_spine') }}
+    where date between '2020-03-01' and to_date(sysdate())
+)
+SELECT
+    date_spine.date,
+    trading_metrics.pool_address,
+    '1' as version,
+    trading_metrics.swap_count,
+    trading_metrics.trading_fees,
+    trading_metrics.fees,
+    trading_metrics.primary_supply_side_revenue,
+    trading_metrics.secondary_supply_side_revenue,
+    trading_metrics.total_supply_side_revenue,
+    trading_metrics.protocol_revenue,
+    trading_metrics.operating_expenses,
+    trading_metrics.token_incentives,
+    trading_metrics.protocol_earnings,
+    trading_metrics.trading_volume,
+    trading_metrics.unique_traders,
+    tvl_balancer_v1.tvl_usd,
+    tvl_balancer_v1.tvl_usd as net_deposits
+FROM date_spine
+left join trading_metrics using (date)
+left join tvl_balancer_v1 using (date)

--- a/models/projects/balancer/raw/fact_balancer_v1_metrics_by_token.sql
+++ b/models/projects/balancer/raw/fact_balancer_v1_metrics_by_token.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+    )
+}}
+
+WITH trading_metrics AS (
+        SELECT 
+            block_date AS date,
+            token_sold_address AS token_address,
+            COUNT(*) AS swap_count,
+            SUM(swap_fee_usd) AS trading_fees,
+            SUM(swap_fee_usd) AS fees, --total fees == trading fees 
+            SUM(swap_fee_usd) AS primary_supply_side_revenue,
+            0 AS secondary_supply_side_revenue,
+            SUM(swap_fee_usd) AS total_supply_side_revenue,
+            0 AS protocol_revenue,
+            0 AS operating_expenses,
+            0 AS token_incentives,        -- to verify
+            0 AS protocol_earnings,       -- to verify
+            SUM(token_sold_amount_usd) AS trading_volume,
+            COUNT(DISTINCT taker) AS unique_traders
+        FROM {{ ref('fact_balancer_trades') }}
+        WHERE NOT (token_sold_amount_raw > 9E25 AND token_sold_amount_usd > 10000000000) --filter out deprecated, outlier tokens
+        GROUP BY block_date, token_sold_address
+), tvl_balancer_v1 as (
+    SELECT
+        date,
+        token_address,
+        SUM(tvl_token_adjusted) as tvl_usd
+    FROM {{ ref('fact_balancer_liquidity') }}
+    group by date, token_address
+),
+date_spine as (
+    select 
+        date
+    from {{ ref('dim_date_spine') }}
+    where date between '2020-03-01' and to_date(sysdate())
+)
+SELECT
+    date_spine.date,
+    trading_metrics.token_address,
+    '1' as version,
+    trading_metrics.swap_count,
+    trading_metrics.trading_fees,
+    trading_metrics.fees,
+    trading_metrics.primary_supply_side_revenue,
+    trading_metrics.secondary_supply_side_revenue,
+    trading_metrics.total_supply_side_revenue,
+    trading_metrics.protocol_revenue,
+    trading_metrics.operating_expenses,
+    trading_metrics.token_incentives,
+    trading_metrics.protocol_earnings,
+    trading_metrics.trading_volume,
+    trading_metrics.unique_traders,
+    tvl_balancer_v1.tvl_usd,
+    tvl_balancer_v1.tvl_usd as net_deposits
+FROM date_spine
+left join trading_metrics using (date)
+left join tvl_balancer_v1 using (date)

--- a/models/staging/__staging_sources.yml
+++ b/models/staging/__staging_sources.yml
@@ -40,6 +40,12 @@ sources:
     database: ethereum_flipside
     tables:
       - name: ez_native_transfers
+      - name: ez_decoded_event_logs
+      - name: fact_event_logs
+      - name: fact_blocks
+      - name: fact_decoded_event_logs
+      - name: ez_token_transfers
+      - name: ez_decoded_traces
   
 # ARBITRUM
 

--- a/models/staging/maple/__maple__sources.yml
+++ b/models/staging/maple/__maple__sources.yml
@@ -1,14 +1,4 @@
 sources:
-  - name: ETHEREUM_FLIPSIDE
-    schema: core
-    database: ethereum_flipside
-    tables:
-      - name: ez_decoded_event_logs
-      - name: fact_event_logs
-      - name: fact_blocks
-      - name: fact_decoded_event_logs
-      - name: ez_token_transfers
-  
   - name: PROD_LANDING
     schema: prod_landing
     database: landing_database


### PR DESCRIPTION
Added balancer_v1 metrics through the Artemis dbt pipeline. The output is 4 ez tables in balancer.raw that replicate the output ez tables of the Artemis dbt. 
- fact_balancer_v1_metrics outputs the balancer metrics by day
- fact_balancer_v1_metrics_by_chain outputs the grouped metrics by blockchain
- fact_balancer_v1_metrics_by_pools outputs the grouped metrics by pool
- fact_balancer_v1_metrics_by_pools outputs the grouped metrics by token 

**Balancer metrics calculations:**
- _swap_count_: calculated by counting the rows in the balancer_trades table, which I created to catalogue all trades (one row per trade) that were made on balancer v1 protocol
- _fees_: calculated by multiplying _tokenAmountInUSD_ (token sold amount) * the _swap_fee_ metric for that trade
        - _tokenAmountInUSD_: calculated by multiplying the tokenAmount (in token units, pulled from the swap event trade 
        logs) by the token's price _tokenInPrice_ at the date of the trade (pulled from ethereum_flipside pricing data)
- _trading_volume_: calculated by summing the _tokenInAmountUSD_ (token sold) values on a given date
- _unique_traders_: calculated as the count of DISTINCT origin_from_addresses, pulled from the swap event data table
- _tvl_: calculated using the source table fact_ethereum_address_balances_by_token. For a given liquidity pool address, there is a row per token held in the pool. tvl is calculated by calculating the token value in usd accross all pools & tokens, and summing the output by day.

**Notes:**
- fact_balancer_trades is a silver layer table that aggregates all balancer v1 trades, 1 trade per row
- fact_balancer_liquidity is a silver table with one row per day per pool per token, with token information and tvl data. The fact_ethereum_address_balances_by_token table that sources this data has multiple such rows per day, but only the latest timestamped row & token balance for a given day is passed through to fact_balancer_liquidity. This latest row is used to calculate the tvl of a pool / token combination on a given day
- The timestamp of such row is the hour used to join token pricing data into the fact_balancer_liquidity table
- Token pricing data is joined into the fact_balancer_trades table on the token_price captured on the hour of the swap 
- There is no protocol token for balancer v1, so circulating supply metrics do not apply.

**Testing:**
- Run SELECT * FROM fact_balancer_v1_metrics and filter charts by the desired metric
- Compare to the following dune queries created by the @balancer dune account:
         - https://dune.com/queries/4629516/7711340?5.+Version_e15077=1&1.+Start+date_d83555=2020-01- 01+00%3A00%3A00&2.+End+date_d83555=2025-05-01+00%3A00%3A00
         - https://dune.com/queries/4629015/7710222?5.+Version_e15077=1&1.+Aggregation_e15077=Daily
         - https://dune.com/queries/4630098/7712256?1.+Start+date_d83555=2020-01-01+00%3A00%3A00&5.+Version_e15077=1
         - https://dune.com/queries/2829096/4721231
         - https://dune.com/queries/4630162/7712341 (a modification of the @balancer account query, using @balancer data)



