### PR TITLE
fixing sui stablecoin pipeline

### DIFF
--- a/models/projects/sui/core/ez_sui_stablecoin_metrics_by_address.sql
+++ b/models/projects/sui/core/ez_sui_stablecoin_metrics_by_address.sql
@@ -9,5 +9,6 @@
     )
 }}
 
+{% set contract_address = var('contract_address', "") %} 
 
-{{stablecoin_metrics("sui")}}
+{{stablecoin_metrics("sui", contract_address) }}

--- a/models/staging/sui/fact_sui_stablecoin_balances.sql
+++ b/models/staging/sui/fact_sui_stablecoin_balances.sql
@@ -6,5 +6,6 @@
     )
 }}
 
+{% set contract_address = var('contract_address', "") %} 
 
-{{stablecoin_balances("sui")}}
+{{ stablecoin_balances("sui", contract_address) }}

--- a/models/staging/sui/fact_sui_stablecoin_metrics_all.sql
+++ b/models/staging/sui/fact_sui_stablecoin_metrics_all.sql
@@ -6,5 +6,6 @@
     )
 }}
 
+{% set contract_address = var('contract_address', "") %} 
 
-{{stablecoin_metrics_all("sui")}}
+{{stablecoin_metrics_all("sui", contract_address)}}

--- a/models/staging/sui/fact_sui_stablecoin_metrics_artemis.sql
+++ b/models/staging/sui/fact_sui_stablecoin_metrics_artemis.sql
@@ -6,5 +6,6 @@
     )
 }}
 
+{% set contract_address = var('contract_address', "") %} 
 
-{{stablecoin_metrics_artemis("sui")}}
+{{stablecoin_metrics_artemis("sui", contract_address)}}

--- a/models/staging/sui/fact_sui_stablecoin_metrics_p2p.sql
+++ b/models/staging/sui/fact_sui_stablecoin_metrics_p2p.sql
@@ -6,5 +6,6 @@
     )
 }}
 
+{% set contract_address = var('contract_address', "") %}  
 
-{{stablecoin_metrics_p2p("sui")}}
+{{stablecoin_metrics_p2p("sui", contract_address)}}

--- a/models/staging/sui/fact_sui_stablecoin_transfers.sql
+++ b/models/staging/sui/fact_sui_stablecoin_transfers.sql
@@ -5,6 +5,9 @@
         snowflake_warehouse="SUI",
     ) 
 }}
+
+{% set new_stablecoin_address = var('contract_address', "") %}
+
 select
     block_timestamp
     , date
@@ -34,9 +37,12 @@ select
 from {{ ref("fact_sui_token_transfers") }} t1
 inner join {{ ref("fact_sui_stablecoin_contracts") }} t2 
     on lower(t1.coin_type) = lower(t2.contract_address)
-{% if is_incremental() %} 
+{% if is_incremental() and new_stablecoin_address == '' %} 
     where block_timestamp >= (
         select dateadd('day', -3, max(block_timestamp))
         from {{ this }}
     )
+{% endif %}
+{% if new_stablecoin_address != '' %}
+    where lower(t1.contract_address) = lower('{{ new_stablecoin_address }}')
 {% endif %}


### PR DESCRIPTION
fact_sui_stablecoin_balances
fact_sui_stablecoin_metrics_all
fact_sui_stablecoin_metrics_artemis
fact_sui_stablecoin_metrics_p2p
ez_sui_stablecoin_metrics_by_address
all these uses the macro for SUI but it wasn't updated, which causes the job to fail for these 5, creating empty table.
I have updated it.

I also included the changes for
fact_sui_stablecoin_transfers
fact_sui_p2p_stablecoin_transfers
such that it does an incremental refresh for the rest, and full refresh for a new stablecoin address.