### PR TITLE
Wes/maple tvl temp fix

### DIFF
--- a/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
+++ b/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
@@ -18,23 +18,23 @@ with fees as (
     FROM {{ ref('fact_maple_fees') }}
     GROUP BY 1, 2
 )
--- , tvl as (
---     SELECT
---         date,
---         pool_name,
---         SUM(tvl_native) AS tvl_native,
---         SUM(tvl) AS tvl,
---         SUM(outstanding_supply) AS outstanding_supply
---     FROM {{ ref('fact_maple_agg_tvl') }}
---     GROUP BY 1, 2
--- )
+, tvl as (
+    SELECT
+        date,
+        pool_name,
+        -- SUM(tvl_native) AS tvl_native,
+        SUM(tvl) AS tvl,
+        SUM(outstanding_supply) AS outstanding_supply
+    FROM {{ ref('fact_maple_agg_tvl') }}
+    GROUP BY 1, 2
+)
 SELECT
     fees.date,
     fees.pool_name,
     fees.fees,
     fees.platform_fees,
     fees.delegate_fees,
-    -- tvl.tvl,
-    -- tvl.outstanding_supply
+    tvl.tvl,
+    tvl.outstanding_supply
 FROM fees
--- FULL OUTER JOIN tvl ON fees.date = tvl.date AND fees.pool_name = tvl.pool_name
+FULL OUTER JOIN tvl ON fees.date = tvl.date AND fees.pool_name = tvl.pool_name

--- a/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
+++ b/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
@@ -18,23 +18,23 @@ with fees as (
     FROM {{ ref('fact_maple_fees') }}
     GROUP BY 1, 2
 )
-, tvl as (
-    SELECT
-        date,
-        pool_name,
-        SUM(tvl_native) AS tvl_native,
-        SUM(tvl) AS tvl,
-        SUM(outstanding_supply) AS outstanding_supply
-    FROM {{ ref('fact_maple_agg_tvl') }}
-    GROUP BY 1, 2
-)
+-- , tvl as (
+--     SELECT
+--         date,
+--         pool_name,
+--         SUM(tvl_native) AS tvl_native,
+--         SUM(tvl) AS tvl,
+--         SUM(outstanding_supply) AS outstanding_supply
+--     FROM {{ ref('fact_maple_agg_tvl') }}
+--     GROUP BY 1, 2
+-- )
 SELECT
-    coalesce(fees.date, tvl.date) as date,
-    coalesce(fees.pool_name, tvl.pool_name) as pool_name,
+    fees.date,
+    fees.pool_name,
     fees.fees,
     fees.platform_fees,
     fees.delegate_fees,
-    tvl.tvl,
-    tvl.outstanding_supply
+    -- tvl.tvl,
+    -- tvl.outstanding_supply
 FROM fees
-FULL OUTER JOIN tvl ON fees.date = tvl.date AND fees.pool_name = tvl.pool_name
+-- FULL OUTER JOIN tvl ON fees.date = tvl.date AND fees.pool_name = tvl.pool_name

--- a/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
+++ b/models/projects/maple/prod/ez_maple_metrics_by_pool.sql
@@ -29,8 +29,8 @@ with fees as (
     GROUP BY 1, 2
 )
 SELECT
-    fees.date,
-    fees.pool_name,
+    coalesce(fees.date, tvl.date) as date,
+    coalesce(fees.pool_name, tvl.pool_name) as pool_name,
     fees.fees,
     fees.platform_fees,
     fees.delegate_fees,

--- a/models/projects/maple/prod/ez_maple_metrics_by_token.sql
+++ b/models/projects/maple/prod/ez_maple_metrics_by_token.sql
@@ -35,14 +35,14 @@ with fees as (
     FROM {{ ref('fact_maple_token_incentives') }}
     GROUP BY 1, 2
 )
-, tvl as (
-    SELECT
-        date,
-        asset as token,
-        SUM(tvl_native) AS tvl_native
-    FROM {{ ref('fact_maple_agg_tvl') }}
-    GROUP BY 1, 2
-)
+-- , tvl as (
+--     SELECT
+--         date,
+--         asset as token,
+--         SUM(tvl_native) AS tvl_native
+--     FROM {{ ref('fact_maple_agg_tvl') }}
+--     GROUP BY 1, 2
+-- )
 , treasury as (
     SELECT
         date,
@@ -71,8 +71,8 @@ with fees as (
 )
 
 SELECT
-    coalesce(fees.date, revenues.date, token_incentives.date, tvl.date, treasury.date) as date,
-    coalesce(fees.token, revenues.token, token_incentives.token, tvl.token, treasury.token) as token,
+    coalesce(fees.date, revenues.date, token_incentives.date, treasury.date) as date,
+    coalesce(fees.token, revenues.token, token_incentives.token, treasury.token) as token,
     fees.fees_native as interest_fees_native,
     fees.platform_fees_native as platform_fees_native,
     fees.delegate_fees_native as delegate_fees_native,
@@ -82,8 +82,8 @@ SELECT
     token_incentives.token_incentives_native,
     token_incentives.token_incentives_native as expenses_native,
     revenues.revenue_native - token_incentives.token_incentives_native as protocol_earnings_native
-    , tvl.tvl_native
-    , tvl.tvl_native as net_deposits_native
+    -- , tvl.tvl_native
+    -- , tvl.tvl_native as net_deposits_native
     , treasury.treasury_value_native
     , treasury_native.treasury_native
     , net_treasury.net_treasury_value
@@ -91,8 +91,8 @@ FROM
     fees
 full join revenues using(date, token)
 full join token_incentives using(date, token)
-full join tvl using(date, token)
+-- full join tvl using(date, token)
 full join treasury using(date, token)
 full join treasury_native using(date, token)
 full join net_treasury using(date, token)
-WHERE coalesce(fees.date, revenues.date, token_incentives.date, tvl.date, treasury.date) < to_date(sysdate())
+WHERE coalesce(fees.date, revenues.date, token_incentives.date, treasury.date) < to_date(sysdate())

--- a/models/staging/maple/__maple__sources.yml
+++ b/models/staging/maple/__maple__sources.yml
@@ -16,3 +16,4 @@ sources:
       - name: raw_maple_otc_by_day
       - name: raw_maple_solana_by_day
       - name: raw_maple_dim_pools
+      - name: raw_maple_tvl_dune

--- a/models/staging/maple/fact_maple_agg_tvl.sql
+++ b/models/staging/maple/fact_maple_agg_tvl.sql
@@ -8,31 +8,38 @@ WITH agg_tvl AS (
     SELECT 
         date, 
         pool_name, 
-        asset,
+        -- asset,
         outstanding_usd as tvl,
-        outstanding_usd as tvl_native,
+        -- outstanding_usd as tvl_native,
         null as outstanding_supply
     FROM {{ ref('fact_maple_v1_tvl') }}
+    -- UNION ALL
+    -- SELECT 
+    --     date, 
+    --     pool_name, 
+    --     asset,
+    --     tvl,
+    --     tvl_native,
+    --     outstanding as outstanding_supply
+    -- FROM {{ ref('fact_maple_v2_tvl') }}
     UNION ALL
     SELECT 
         date, 
         pool_name, 
-        asset,
         tvl,
-        tvl_native,
+        -- tvl_native,
         outstanding as outstanding_supply
-    FROM {{ ref('fact_maple_v2_tvl') }}
+    FROM {{ ref('fact_maple_tvl_dune') }}
 )
 
 SELECT
     date,
     pool_name,
-    asset,
     sum(tvl) as tvl,
-    sum(tvl_native) as tvl_native,
+    -- sum(tvl_native) as tvl_native,
     sum(outstanding_supply) as outstanding_supply
 FROM agg_tvl
-GROUP BY 1, 2, 3
+GROUP BY 1, 2
 -- WHERE
 --  pool_name NOT IN ('Orthogonal Credit USDC1')
 ORDER BY date DESC, pool_name

--- a/models/staging/maple/fact_maple_tvl_dune.sql
+++ b/models/staging/maple/fact_maple_tvl_dune.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="MAPLE",
+    )
+}}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_maple_tvl_dune" ) }}
+        
+    ),
+   latest_data as (
+        select parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_maple_tvl_dune") }}
+        where extraction_date = (select max_date from max_extraction)
+    ),
+    flattened_data as (
+        select
+            f.value:date::date as date,
+            f.value:pool_name::string as pool_name,
+            f.value:tvl::number as tvl,
+            f.value:outstanding::number as outstanding
+        from latest_data, lateral flatten(input => data) as f
+    )
+select 
+    date, 
+    pool_name, 
+    tvl, 
+    outstanding
+from flattened_data
+where date < to_date(sysdate())
+order by date desc


### PR DESCRIPTION
Maple TVL Fix.

Key items:
1. Pull new TVL from Dune dataset.
2. No longer support TVL by token since this is not in the Dune dataset.
3. Kept the old pipeline for TVL in the optimistic case we find a new way to pull the data from a better source (API or onchain) 

![CleanShot 2025-02-09 at 08 05 18@2x](https://github.com/user-attachments/assets/32869944-6eec-4bcd-a61e-64072a3de55f)
