### PR TITLE
Top 100 STG holders across all chains

### DIFF
--- a/macros/bridge/stargate_OFTSent.sql
+++ b/macros/bridge/stargate_OFTSent.sql
@@ -119,7 +119,28 @@ with
     {% if is_incremental() %}
         and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
     {% endif %}
-)
+),
+dvn_fees as (
+    select
+        block_timestamp,
+        tx_hash,
+        contract_address,
+        decoded_log:"fees"[0]/1e18 as dvnFees
+    from ethereum_flipside.core.fact_decoded_event_logs
+    where lower(contract_address) = lower('0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1') -- ether: 0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1, 
+    and event_name = 'DVNFeePaid'
+),
+executor_fees as (
+    select
+        block_timestamp,
+        tx_hash,
+        contract_address,
+        decoded_log:"fee"/1e18 as executorFees
+    from ethereum_flipside.core.fact_decoded_event_logs
+    where lower(contract_address) = lower('0xbB2Ea70C9E858123480642Cf96acbcCE1372dCe1') and
+    event_name = 'ExecutorFeePaid'
+),
+
 {% endif %}
 select
     events.block_timestamp

--- a/macros/bridge/stargate_STGholders.sql
+++ b/macros/bridge/stargate_STGholders.sql
@@ -1,0 +1,126 @@
+{% macro stargate_stg_holders(chain, token_contract_address, stake_contract_address) %} 
+with
+stg_balances AS (
+    SELECT 
+        ADDRESS,
+        BALANCE_TOKEN / 1e18 AS STG_BALANCE,
+        BLOCK_TIMESTAMP,
+        ROW_NUMBER() OVER (
+            PARTITION BY ADDRESS 
+            ORDER BY BLOCK_TIMESTAMP DESC
+        ) AS today
+    FROM pc_dbt_db.prod.fact_{{chain}}_address_balances_by_token
+    WHERE lower(contract_address) = lower('{{token_contract_address}}')
+),
+circulating_supply AS (
+    SELECT 
+        1e9 - COALESCE(
+            (SELECT MAX(STG_BALANCE) 
+             FROM stg_balances 
+             WHERE lower(ADDRESS) = lower('0x8A27E7e98f62295018611DD681Ec47C7d9FF633A')
+            ), 0
+        ) AS circulating_supply
+),
+top_holders AS (
+    SELECT 
+        e.ADDRESS, 
+        e.STG_BALANCE,
+        CASE 
+            -- Vesting wallet that is still doing linear unlocks
+            WHEN lower(e.ADDRESS) = lower('0x8A27E7e98f62295018611DD681Ec47C7d9FF633A') 
+            THEN 'Locked' 
+            ELSE 'Unlocked' 
+        END AS status,  
+        (e.STG_BALANCE / c.circulating_supply) * 100 AS percentage_of_circulating_supply
+    FROM stg_balances e
+    CROSS JOIN circulating_supply c
+    WHERE e.today = 1
+    ORDER BY e.STG_BALANCE DESC
+    LIMIT 100
+),
+{% if chain == "avalanche" %}
+net_staked_withdrawal AS (
+    SELECT 
+        LOWER(fded.decoded_log:from::STRING) AS staker_address,  
+        SUM(fded.decoded_log:value::NUMERIC / 1e18) AS value
+    FROM {{chain}}_flipside.core.fact_decoded_event_logs fded
+    WHERE 
+        LOWER(fded.contract_address) = lower('{{token_contract_address}}')
+        AND LOWER(fded.decoded_log:to::STRING) = lower('{{stake_contract_address}}')
+    GROUP BY LOWER(fded.decoded_log:from::STRING)
+
+    UNION ALL
+
+     SELECT 
+        LOWER(fded.decoded_log:to::STRING) AS staker_address,  
+        SUM(fded.decoded_log:value::NUMERIC / 1e18) * -1 AS value
+    FROM {{chain}}_flipside.core.fact_decoded_event_logs fded
+    WHERE 
+        LOWER(fded.contract_address) = lower('{{token_contract_address}}')
+        AND LOWER(fded.decoded_log:from::STRING) = lower('{{stake_contract_address}}')
+    GROUP BY LOWER(fded.decoded_log:to::STRING)
+),
+{% else %}
+net_staked_withdrawal AS (
+    SELECT 
+        LOWER(fded.decoded_log:provider::STRING) AS staker_address,  
+        SUM(fded.decoded_log:value::NUMERIC / 1e18) AS value
+    FROM {{chain}}_flipside.core.fact_decoded_event_logs fded
+    WHERE 
+        LOWER(fded.contract_address) = LOWER('{{stake_contract_address}}') 
+        AND fded.event_name = 'Deposit'
+    GROUP BY LOWER(fded.decoded_log:provider::STRING)
+
+    UNION ALL
+
+    SELECT 
+        LOWER(fdew.decoded_log:provider::STRING) AS staker_address,  
+        SUM(fdew.decoded_log:value::NUMERIC / 1e18) * -1 AS value
+    FROM {{chain}}_flipside.core.fact_decoded_event_logs fdew
+    WHERE 
+        LOWER(fdew.contract_address) = LOWER('{{stake_contract_address}}')
+        AND fdew.event_name = 'Withdraw'
+    GROUP BY LOWER(fdew.decoded_log:provider::STRING)
+),
+{% endif %}
+net_balances AS (
+    SELECT
+        staker_address,
+        CASE 
+            WHEN SUM(value) < 0 THEN 0 
+            ELSE SUM(value) 
+        END AS net_balance
+    FROM
+        net_staked_withdrawal
+    GROUP BY
+        staker_address
+    ORDER BY
+        net_balance DESC
+),
+holder_stake_status AS (
+    SELECT 
+        th.ADDRESS, 
+        th.STG_BALANCE, 
+        th.status, 
+        th.percentage_of_circulating_supply,
+        COALESCE(nb.net_balance, 0) AS staked_balance,
+        CASE 
+            WHEN nb.net_balance IS NOT NULL THEN TRUE 
+            ELSE FALSE 
+        END AS stake_status,
+        COALESCE(nb.net_balance, 0) / NULLIF(th.STG_BALANCE, 0) * 100 AS stake_percentage
+    FROM top_holders th
+    LEFT JOIN net_balances nb ON LOWER(th.ADDRESS) = LOWER(nb.staker_address)
+)
+SELECT 
+    address,
+    stg_balance,
+    status,
+    percentage_of_circulating_supply,
+    staked_balance,
+    stake_status,
+    stake_percentage,
+    '{{chain}}' as chain
+FROM holder_stake_status
+ORDER BY stg_balance DESC
+{% endmacro %}

--- a/models/projects/stargate/core/ez_stargate_metrics_top100holders.sql
+++ b/models/projects/stargate/core/ez_stargate_metrics_top100holders.sql
@@ -1,0 +1,34 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="STARGATE",
+        database="stargate",
+        schema="core",
+        alias="ez_metrics_top100holders",
+    )
+}}
+
+with
+top100STGholders as (
+    select
+        address,
+        stg_balance,
+        status,
+        percentage_of_circulating_supply,
+        staked_balance,
+        has_staked,
+        stake_percentage,
+        chain
+    from {{ref("fact_stargate_top100STGholders")}}
+)
+
+select
+    address,
+    stg_balance,
+    status,
+    percentage_of_circulating_supply,
+    staked_balance,
+    has_staked,
+    stake_percentage,
+    chain
+from top100STGholders

--- a/models/staging/stargate/dim_stargate_arbitrum_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_arbitrum_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'arbitrum'
+        , '0x6694340fc020c5E6B96567843da2df01b2CE1eb6'
+        , '0xfbd849e6007f9bc3cc2d6eb159c045b8dc660268'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_avalanche_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_avalanche_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'avalanche'
+        , '0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590'
+        , '0xca0f57d295bbce554da2c07b005b7d6565a58fce'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_bsc_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_bsc_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'bsc'
+        , '0xB0D502E938ed5f4df2E681fE6E419ff29631d62b'
+        , '0xD4888870C8686c748232719051b677791dBDa26D'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_ethereum_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_ethereum_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'ethereum'
+        , '0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6'
+        , '0x0e42acbd23faee03249daff896b78d7e79fbd58e'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_optimism_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_optimism_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'optimism'
+        , '0x296F55F8Fb28E498B858d0BcDA06D955B2Cb3f97'
+        , '0x43d2761ed16c89a2c4342e2b16a3c61ccf88f05b'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_polygon_STGholders.sql
+++ b/models/staging/stargate/dim_stargate_polygon_STGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_stg_holders(
+        'polygon'
+        , '0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590'
+        , '0x3ab2da31bbd886a7edf68a6b60d3cde657d3a15d'
+    )
+}}

--- a/models/staging/stargate/fact_stargate_top100STGholders.sql
+++ b/models/staging/stargate/fact_stargate_top100STGholders.sql
@@ -1,0 +1,27 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+
+with 
+combined_events as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("dim_stargate_arbitrum_STGholders"),
+                ref("dim_stargate_avalanche_STGholders"),
+                ref("dim_stargate_bsc_STGholders"),
+                ref("dim_stargate_ethereum_STGholders"),
+                ref("dim_stargate_optimism_STGholders"),
+                ref("dim_stargate_polygon_STGholders"),
+            ],
+        )
+    }}
+)
+select
+    address,
+    stg_balance,
+    status,
+    percentage_of_circulating_supply,
+    staked_balance,
+    stake_status as has_staked,
+    stake_percentage,
+    chain
+from combined_events


### PR DESCRIPTION
Top 100 STG holders across all chains materialized successfully through DBT CLI
<img width="933" alt="image" src="https://github.com/user-attachments/assets/38e10617-7dc6-4f34-b14b-7fa22ef69811" />

checked in snowflake as well - 6 chains (arbitrum, avalanche, bsc, ethereum, optimism, polygon) excluding fantom
<img width="1464" alt="image" src="https://github.com/user-attachments/assets/f7e4e3a1-ec2e-4383-bff3-5c7ade964195" />
