### PR TITLE
Remove arbitrum filter on bam datahub v2

### DIFF
--- a/models/data_hubs/fact_daily_bam_datahub_v2.sql
+++ b/models/data_hubs/fact_daily_bam_datahub_v2.sql
@@ -78,7 +78,6 @@ with
             sybil_users,
             non_sybil_users
         from {{ ref("all_chains_gas_dau_txns_by_chain") }} as bam_by_chain
-        where chain = 'arbitrum'
     ),
     app_coingecko as (
         select


### PR DESCRIPTION
# Description

Remove 'arbitrum' filter on bam datahub v2 b/c I've integrated the rest of the chains already (except Solana but that's fine for now)

# Tests

Ran locally