### PR TITLE
Update Sigma Snapshot

### DIFF
--- a/models/dimensions/__dimension__sources.yml
+++ b/models/dimensions/__dimension__sources.yml
@@ -38,5 +38,4 @@ sources:
       - name: dim_chains
       - name: dim_sub_categories
       - name: dim_categories
-      - name: dim_legacy_sigma_tagged_contracts
       - name: all_categories_seed

--- a/models/dimensions/labeling/dim_all_addresses_labeled_gold.sql
+++ b/models/dimensions/labeling/dim_all_addresses_labeled_gold.sql
@@ -1,13 +1,8 @@
 {{
     config(
-        materialized="incremental",
-        unique_key=["address", "chain"],
-        incremental_strategy="merge",
+        materialized="table",
         on_schema_change="append_new_columns"
     )
 }}
 
 SELECT * FROM {{ ref("dim_all_addresses_labeled_silver") }}
-{% if is_incremental() %}
-    WHERE last_updated > (SELECT MAX(last_updated) FROM {{ this }})
-{% endif %}

--- a/models/dimensions/labeling/dim_all_apps_silver.sql
+++ b/models/dimensions/labeling/dim_all_apps_silver.sql
@@ -4,14 +4,8 @@
     )
 }}
 
-WITH new_apps AS (
-    SELECT 
-        DISTINCT artemis_application_id 
-    FROM {{ source("PYTHON_LOGIC", "dim_namespace_to_application") }}
-    WHERE artemis_application_id IS NOT NULL
-)
 SELECT
-    COALESCE(na.artemis_application_id, sil.artemis_application_id) AS artemis_application_id,
+    sil.artemis_application_id,
     sil.artemis_category_id,
     sil.artemis_sub_category_id,
     sil.artemis_id,
@@ -32,10 +26,6 @@ SELECT
     sil.developer_x_handle
 FROM
     {{ this }} sil
-FULL OUTER JOIN 
-    new_apps na
-ON 
-    na.artemis_application_id = sil.artemis_application_id
 LEFT JOIN
     dim_coingecko_tokens token
 ON sil.coingecko_id = token.coingecko_token_id

--- a/models/dimensions/labeling/dim_legacy_sigma_tagged_contracts.sql
+++ b/models/dimensions/labeling/dim_legacy_sigma_tagged_contracts.sql
@@ -1,0 +1,25 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["address", "chain"],
+        incremental_strategy="merge"
+    )
+}}
+
+WITH combined_data AS (
+    SELECT address, name, namespace, chain, 
+           1 AS table_priority
+    FROM {{ ref('dim_usersubmittedcontracts') }} where chain is not null
+    UNION
+    SELECT address, name, namespace, chain, 
+           2 AS table_priority 
+    FROM {{ ref('dim_scanner_contracts') }} where chain is not null
+),
+ranked_data AS (
+    SELECT *,
+           ROW_NUMBER() OVER (PARTITION BY address, chain ORDER BY table_priority) AS row_rank
+    FROM combined_data
+)
+SELECT address, name, namespace, chain, CURRENT_TIMESTAMP() AS last_updated
+FROM ranked_data
+WHERE row_rank = 1


### PR DESCRIPTION
# Description

This keeps the sigma snapshots updated, although we will have to manually upload the new applications if they are created in Sigma. This is because dim_new_apps_post_sigma contains a hodgepodge of namespaces where some are legitimate but others need to be mapped to parent namespace to be legit.

Also made all addresses lowercase to standardize them and also modified labels table to be full refresh so that they can handle category changes when we modify application categories.

# Tests

Ran locally