### PR TITLE
Eigenlayer TVR DBT Transformations

### DIFF
--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -47,6 +47,12 @@ sources:
     tables:
       - name: ez_prices_hourly
 
+# ETHEREUM BEACON CHAIN
+  - name: ETHEREUM_FLIPSIDE_BEACON
+    schema: beacon_chain
+    database: ethereum_flipside
+    tables:
+      - name: fact_validators
   
 # ARBITRUM
 

--- a/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_chain.sql
+++ b/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_chain.sql
@@ -1,0 +1,120 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="CORE",
+        alias="ez_metrics_by_chain",
+    )
+}}
+
+WITH price_data AS (
+    SELECT 
+        hourly.token_address, symbol, name, decimals, price,
+        trunc(hour, 'hour') AS truncated_hour
+    FROM {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} hourly --ethereum_flipside.price.ez_prices_hourly hourly
+    WHERE hour >= (SELECT MIN(date) FROM {{ref('fact_restaked_tokens')}}) --EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS) 
+), normal_tokens AS (
+    SELECT 
+        restaked_tokens.date,
+        restaked_tokens.token_address,
+        t2.symbol AS token_symbol,
+        t2.price,
+        SUM ( restaked_tokens.balance_token  / pow(10, t2.decimals) ) AS restaked_tokens_adjusted,
+        SUM ( restaked_tokens.balance_token  / pow(10, t2.decimals)  * t2.price ) as amount_restaked_usd,
+        'Liquid Token Restaking' AS restaking_type
+    FROM 
+        {{ref('fact_restaked_tokens')}} restaked_tokens --EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS restaked_tokens
+    LEFT JOIN
+        {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t2 --ethereum_flipside.price.ez_prices_hourly t2
+        on lower(restaked_tokens.token_address) = lower(t2.token_address) and t2.hour = trunc(restaked_tokens.date, 'hour')
+    WHERE (restaked_tokens.strategy_address != lower('0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7') AND restaked_tokens.token_address != lower('0x83E9115d334D248Ce39a6f36144aEaB5b3456e75'))
+    GROUP BY restaked_tokens.date, restaked_tokens.token_address, token_symbol, t2.price
+), special_case AS (
+    SELECT 
+        restaked_tokens.date,
+        restaked_tokens.token_address,
+        'bEIGEN' AS token_symbol,
+        t2.price,
+        SUM (restaked_tokens.balance_token / pow(10, t2.decimals)) AS restaked_tokens_adjusted,
+        SUM (restaked_tokens.balance_token / pow(10, t2.decimals) * t2.price) AS amount_restaked_usd,
+        'Liquid Token Restaking' AS restaking_type 
+    FROM 
+        {{ref('fact_restaked_tokens')}} restaked_tokens--EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS restaked_tokens
+    LEFT JOIN price_data t2
+        ON t2.symbol = 'EIGEN'
+        AND t2.truncated_hour = trunc(restaked_tokens.date, 'hour')
+    WHERE 
+        restaked_tokens.strategy_address = lower('0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7')
+        AND restaked_tokens.token_address = lower('0x83E9115d334D248Ce39a6f36144aEaB5b3456e75')
+    GROUP BY restaked_tokens.date, restaked_tokens.token_address, t2.price
+), restaked_eth_aggregated AS (
+    SELECT
+        date,
+        ' ' AS token_address,
+        'ETH' AS token_symbol,
+        t3.price,
+        SUM(restaked_native_eth) AS restaked_tokens_adjusted,
+        SUM(restaked_native_eth * t3.price) AS amount_restaked_usd,
+        'Native ETH' AS restaking_type
+    FROM 
+        {{ref('fact_restaked_native_eth')}} restaked_eth--EIGENLAYER.PROD_RAW.FACT_RESTAKED_NATIVE_ETH restaked_eth
+    LEFT JOIN
+        {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t3 --ETHEREUM_FLIPSIDE.PRICE.ez_prices_hourly t3
+        on 'ethereum' = t3.name and t3.hour = trunc(restaked_eth.date, 'hour')
+    GROUP BY restaked_eth.date, t3.price
+), all_aggregated AS (
+    SELECT * FROM normal_tokens
+    UNION ALL 
+    SELECT * FROM special_case
+    UNION ALL 
+    SELECT * FROM restaked_eth_aggregated
+), eth_price_data AS (
+    -- Fetch Ethereum price separately to use for ETH conversion
+    SELECT 
+        price AS eth_price_in_usd, 
+        trunc(hour, 'hour') AS truncated_hour
+    FROM {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} --FROM ETHEREUM_FLIPSIDE.PRICE.EZ_PRICES_HOURLY
+    WHERE name = 'ethereum'
+), all_aggregated_with_eth AS (
+    -- Convert restaked tokens into ETH equivalent
+    SELECT 
+        a.*,
+        p.eth_price_in_usd,
+        -- Convert num_restaked_tokens to ETH equivalent
+        CASE 
+            WHEN a.token_symbol != 'ETH' 
+            THEN a.restaked_tokens_adjusted * a.price / p.eth_price_in_usd 
+            ELSE a.restaked_tokens_adjusted
+        END AS num_restaked_eth 
+    FROM all_aggregated a
+    LEFT JOIN eth_price_data p 
+        ON a.date = p.truncated_hour
+), ez_output AS ( 
+    SELECT
+        date,
+        num_restaked_eth,
+        token_symbol,
+        num_restaked_eth * eth_price_in_usd AS amount_restaked_usd
+    FROM all_aggregated_with_eth
+    WHERE token_symbol is not NULL AND token_symbol != 'EIGEN'
+), sums AS (
+    SELECT 
+        date,
+        'eigenlayer' AS protocol,
+        'DeFi' AS category,
+        'ethereum' AS chain,
+        SUM(num_restaked_eth) AS num_restaked_eth,
+        SUM(amount_restaked_usd) AS amount_restaked_usd,
+        -- Calculate net daily change using LAG()
+    FROM ez_output
+    GROUP BY date
+)
+SELECT 
+    *,
+    num_restaked_eth - LAG(num_restaked_eth) 
+        OVER (ORDER BY date)  AS num_restaked_eth_net_change,
+
+    amount_restaked_usd - LAG(amount_restaked_usd) 
+        OVER (ORDER BY date)  AS amount_restaked_usd_net_change
+FROM sums

--- a/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_token.sql
+++ b/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_token.sql
@@ -1,0 +1,93 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="CORE",
+        alias="ez_metrics_by_token",
+    )
+}}
+
+WITH price_data AS (
+    SELECT 
+        hourly.token_address, symbol, name, decimals, price,
+        trunc(hour, 'hour') AS truncated_hour
+    FROM {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} hourly --ethereum_flipside.price.ez_prices_hourly hourly
+    WHERE hour >= (SELECT MIN(date) FROM {{ref('fact_restaked_tokens')}}) --EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS) 
+), normal_tokens AS (
+    SELECT 
+        restaked_tokens.date,
+        restaked_tokens.token_address,
+        t2.symbol AS token_symbol,
+        SUM ( restaked_tokens.balance_token  / pow(10, t2.decimals) ) AS restaked_tokens_adjusted,
+        SUM ( restaked_tokens.balance_token  / pow(10, t2.decimals)  * t2.price ) as amount_restaked_usd,
+        'Liquid Token Restaking' AS restaking_type
+    FROM 
+        {{ref('fact_restaked_tokens')}} restaked_tokens --EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS restaked_tokens
+    LEFT JOIN
+        {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t2 --ethereum_flipside.price.ez_prices_hourly t2
+        on lower(restaked_tokens.token_address) = lower(t2.token_address) and t2.hour = trunc(restaked_tokens.date, 'hour')
+    WHERE (restaked_tokens.strategy_address != lower('0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7') AND restaked_tokens.token_address != lower('0x83E9115d334D248Ce39a6f36144aEaB5b3456e75'))
+    GROUP BY restaked_tokens.date, restaked_tokens.token_address, token_symbol
+), special_case AS (
+    SELECT 
+        restaked_tokens.date,
+        restaked_tokens.token_address,
+        'bEIGEN' AS token_symbol,
+        SUM (restaked_tokens.balance_token / pow(10, t2.decimals)) AS restaked_tokens_adjusted,
+        SUM (restaked_tokens.balance_token / pow(10, t2.decimals) * t2.price) AS amount_restaked_usd,
+        'Liquid Token Restaking' AS restaking_type 
+    FROM 
+        {{ref('fact_restaked_tokens')}} restaked_tokens--EIGENLAYER.PROD_RAW.FACT_RESTAKED_TOKENS restaked_tokens
+    LEFT JOIN price_data t2
+        ON t2.symbol = 'EIGEN'
+        AND t2.truncated_hour = trunc(restaked_tokens.date, 'hour')
+    WHERE 
+        restaked_tokens.strategy_address = lower('0xaCB55C530Acdb2849e6d4f36992Cd8c9D50ED8F7')
+        AND restaked_tokens.token_address = lower('0x83E9115d334D248Ce39a6f36144aEaB5b3456e75')
+    GROUP BY restaked_tokens.date, restaked_tokens.token_address
+), restaked_eth_aggregated AS (
+    SELECT
+        date,
+        ' ' AS token_address,
+        'ETH' AS token_symbol,
+        SUM(restaked_native_eth) AS restaked_tokens_adjusted,
+        SUM(restaked_native_eth * t3.price) AS amount_restaked_usd,
+        'Native ETH' AS restaking_type
+    FROM 
+        {{ref('fact_restaked_native_eth')}} restaked_eth--EIGENLAYER.PROD_RAW.FACT_RESTAKED_NATIVE_ETH restaked_eth
+    LEFT JOIN
+        {{source("ETHEREUM_FLIPSIDE_PRICE", "ez_prices_hourly")}} t3
+        on 'ethereum' = t3.name and t3.hour = trunc(restaked_eth.date, 'hour')
+    GROUP BY restaked_eth.date
+), all_aggregated AS (
+    SELECT * FROM normal_tokens
+    UNION ALL 
+    SELECT * FROM special_case
+    UNION ALL 
+    SELECT * FROM restaked_eth_aggregated
+), ez_output AS ( 
+    SELECT 
+        date,
+        'eigenlayer' AS protocol,
+        'DeFi' AS category,
+        'ethereum' AS chain,
+        restaking_type,
+        token_symbol,
+        restaked_tokens_adjusted AS num_restaked_tokens,
+        amount_restaked_usd,
+        
+        -- Calculate net daily change using LAG()
+        restaked_tokens_adjusted - LAG(restaked_tokens_adjusted) 
+            OVER (PARTITION BY token_symbol ORDER BY date) AS num_restaked_tokens_net_change,
+    
+        amount_restaked_usd - LAG(amount_restaked_usd) 
+            OVER (PARTITION BY token_symbol ORDER BY date) AS amount_restaked_usd_net_change
+    
+    FROM all_aggregated
+    WHERE token_symbol is not NULL AND token_symbol != 'EIGEN'
+)
+SELECT * FROM ez_output
+
+
+

--- a/models/projects/eigenlayer/raw/fact_restaked_native_eth.sql
+++ b/models/projects/eigenlayer/raw/fact_restaked_native_eth.sql
@@ -1,0 +1,58 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="RAW",
+        alias="fact_restaked_native_eth",
+    )
+}}
+
+
+--current validators with their withdrawal address, at the most recent snapshot of the validator table (highest slot number)
+WITH ValidatorsCurrent AS ( 
+  SELECT
+      index AS validator_index,
+      '0x' || RIGHT(withdrawal_credentials, 40) AS withdrawal_address,
+      slot_number,
+      validator_status,
+      effective_balance,
+      modified_timestamp,
+      DATE_TRUNC('day', inserted_timestamp) AS day_      
+  FROM {{ source("ETHEREUM_FLIPSIDE_BEACON", "fact_validators")}} v -- flipside table 'ethereum.beacon_chain.fact_validators
+  QUALIFY ROW_NUMBER() OVER (
+      PARTITION BY index, withdrawal_credentials, day_
+      ORDER BY slot_number DESC
+  ) = 1
+), 
+
+--all eigenlayer pod addresses compiled from eigenlayer pod deployed events
+EigenPods AS ( 
+    SELECT 
+        decoded_log:eigenPod::STRING AS eigenpod_address,
+        DATE_TRUNC('day', block_timestamp) AS day_of_pod_deployed_event
+    FROM 
+        {{ source("ETHEREUM_FLIPSIDE", "fact_decoded_event_logs")}}-- flipside table 'ethereum.core.fact_decoded_event_logs'
+    WHERE 
+        contract_address = lower('0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338')
+        AND event_name = 'PodDeployed'
+), 
+
+--sum of all effective balance of validators that are restaked on eigenlayer pods
+DailyRestakedNativeETH AS (
+    SELECT 
+        v.day_ AS date,
+        v.validator_index,
+        SUM(v.effective_balance) AS restaked_native_eth,
+        'ethereum' AS chain,
+        'eigenlayer' AS protocol
+    FROM ValidatorsCurrent v
+    INNER JOIN EigenPods e 
+        ON e.eigenpod_address = v.withdrawal_address
+        AND e.day_of_pod_deployed_event <= v.day_  -- ensures we only count pods after they're deployed
+    WHERE validator_status IN ('active_ongoing') --other statuses: 'exited_unslashed', 'withdrawal_possible', 'pending_queued', 'pending_initialized', 'withdrawal_done'
+    GROUP BY v.day_, v.validator_index
+    ORDER BY v.day_, v.validator_index
+)
+
+SELECT * FROM DailyRestakedNativeETH

--- a/models/projects/eigenlayer/raw/fact_restaked_tokens.sql
+++ b/models/projects/eigenlayer/raw/fact_restaked_tokens.sql
@@ -1,0 +1,95 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="RAW",
+        alias="fact_restaked_tokens",
+    )
+}}
+
+
+WITH DepositsIntoStrategy AS (
+    SELECT
+        DATE(block_timestamp) AS day,
+        from_address,
+        decoded_input_data:strategy::STRING AS strategy_address,
+        decoded_input_data:token::STRING AS token_address,
+        SUM(CAST(decoded_input_data:amount AS BIGINT)) AS total_deposited
+    FROM {{ source("ETHEREUM_FLIPSIDE", "ez_decoded_traces")}}
+    WHERE TO_ADDRESS = LOWER('0x858646372CC42E1A627fcE94aa7A7033e7CF075A')
+    AND FUNCTION_NAME = 'depositIntoStrategy'
+    --AND decoded_input_data:strategy::STRING = LOWER('0x57ba429517c3473B6d34CA9aCd56c0e735b94c02') -- Strategy filter for testing
+    GROUP BY 1, 2, 3, 4
+), BalanceEntries AS (
+    SELECT 
+        block_timestamp,
+        DATE(block_timestamp) AS day,
+        address AS strategy_address,
+        contract_address AS token_address,
+        balance_token,
+        ROW_NUMBER() over (
+            PARTITION BY DATE(block_timestamp), address, contract_address
+            ORDER BY block_timestamp DESC
+        ) AS latest_balance_rank
+    FROM {{ ref('fact_ethereum_address_balances_by_token') }}  
+    --WHERE address = LOWER('0x57ba429517c3473B6d34CA9aCd56c0e735b94c02') -- Strategy filter for testing
+), LatestDailyBalances AS (
+    SELECT
+        day,
+        strategy_address,
+        token_address,
+        balance_token
+    FROM BalanceEntries
+    WHERE latest_balance_rank = 1
+), Dates AS (
+    SELECT
+        date,
+    FROM {{ ref('dim_date_spine') }}  --pc_dbt_db.prod.dim_date_spine
+    WHERE date BETWEEN '2023-12-01' AND TO_DATE(SYSDATE())
+), StrategyTokenCombinations AS (
+    SELECT DISTINCT
+        strategy_address,
+        token_address
+    FROM DepositsIntoStrategy
+), DateStrategyTokenCombinations AS (
+    SELECT
+        d.date,
+        stc.strategy_address,
+        stc.token_address
+    FROM Dates d
+    CROSS JOIN StrategyTokenCombinations stc
+), FinalResult AS (
+    SELECT
+        dst.date,
+        dst.strategy_address,
+        dst.token_address,
+        ldb.balance_token
+    FROM DateStrategyTokenCombinations dst
+    LEFT JOIN LatestDailyBalances ldb
+        ON dst.date = ldb.day
+        AND dst.strategy_address = ldb.strategy_address
+        AND dst.token_address = ldb.token_address
+), FrontFilledBalances AS (
+    SELECT
+        date,
+        strategy_address,
+        token_address,
+        COALESCE(
+            balance_token,
+            LAST_VALUE(balance_token) IGNORE NULLS OVER (
+                PARTITION BY strategy_address, token_address 
+                ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ),
+            0 -- If no historic record exists, set balance_token to 0
+        ) AS balance_token_filled
+    FROM FinalResult
+)
+
+SELECT 
+    date,
+    strategy_address,
+    token_address,
+    balance_token_filled AS balance_token
+FROM FrontFilledBalances
+ORDER BY date ASC

--- a/profiles.yml
+++ b/profiles.yml
@@ -14,6 +14,7 @@ snowflake-dagster:
       database: PC_DBT_DB
       warehouse: ARTEMIS_DBT_PUBLIC_WAREHOUSE
       schema: PROD
-      threads: 4
+      threads: 1
       client_session_keep_alive: False
       query_tag: PROD
+      introspect: False


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [X] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [X] Added new `fact` tables if necessary
- [X] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github 
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be

Eigenlayer TVR Methodology: Total Value Restaked is calculated as the sum of TVR in Native ETH and TVR in Restaked ERC20 Tokens
- TVR in Native ETH is calculated from the balances of active ethereum validators who point their "withdrawal credentials" to the Eigenlayer Protocol
- TVR in Restaked ERC20 Tokens is calculated from the balances of ERC20 Tokens held in the Eigenlayer Strategy Contracts

Limitations/Call-Outs:
- TVR of Restaked ERC20 Tokens will only be included if the specific ERC20 token is currently priced in the ETHEREUM_FLIPSIDE.PRICE data table
- Daily balance snapshots are taken on the last entry into balances table of the given Eigenlayer strategy contract each day. Prices are taken on the hour of this entry into balances
- Restaked $EIGEN tokens are in the ez_metrics_by_token table as $bEIGEN, as specified by Eigenlayer contract 