### PR TITLE
Change tables to v2 in trending dbt models

### DIFF
--- a/models/staging/injective/injective_trending_daily_v2.sql
+++ b/models/staging/injective/injective_trending_daily_v2.sql
@@ -20,7 +20,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_injective_metrics_by_application') }} metrics
+    FROM {{ ref('ez_injective_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     where 
@@ -35,7 +35,7 @@ WITH contracts AS (
         metrics.dau,
         metrics.gas,
         metrics.gas_usd
-    FROM {{ ref('ez_injective_metrics_by_application') }} metrics
+    FROM {{ ref('ez_injective_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     WHERE

--- a/models/staging/injective/injective_trending_weekly_monthly_v2.sql
+++ b/models/staging/injective/injective_trending_weekly_monthly_v2.sql
@@ -20,7 +20,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -37,7 +37,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     WHERE
@@ -73,7 +73,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -90,7 +90,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_injective_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 

--- a/models/staging/stellar/stellar_trending_daily_v2.sql
+++ b/models/staging/stellar/stellar_trending_daily_v2.sql
@@ -21,7 +21,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     where 
@@ -36,7 +36,7 @@ WITH contracts AS (
         metrics.dau,
         metrics.gas,
         metrics.gas_usd
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     WHERE

--- a/models/staging/stellar/stellar_trending_weekly_monthly_v2.sql
+++ b/models/staging/stellar/stellar_trending_weekly_monthly_v2.sql
@@ -21,7 +21,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -38,7 +38,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     WHERE
@@ -74,7 +74,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -91,7 +91,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ ref('ez_stellar_metrics_by_application') }} metrics
+    FROM {{ ref('ez_stellar_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 

--- a/models/staging/sui/sui_trending_daily_v2.sql
+++ b/models/staging/sui/sui_trending_daily_v2.sql
@@ -20,7 +20,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     where 
@@ -35,7 +35,7 @@ WITH contracts AS (
         metrics.dau,
         metrics.gas,
         metrics.gas_usd
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT join contracts 
         ON metrics.app = contracts.app
     WHERE

--- a/models/staging/sui/sui_trending_weekly_monthly_v2.sql
+++ b/models/staging/sui/sui_trending_weekly_monthly_v2.sql
@@ -20,7 +20,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -37,7 +37,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     WHERE
@@ -73,7 +73,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 
@@ -90,7 +90,7 @@ WITH contracts AS (
         metrics.gas_usd,
         metrics.friendly_name,
         metrics.category
-    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application') }} metrics
+    FROM {{ source('PROD_LANDING', 'ez_sui_metrics_by_application_v2') }} metrics
     LEFT JOIN contracts
         ON metrics.app = contracts.app
     where 


### PR DESCRIPTION
# Description

Some referenced tables in BAM trending cards V2 are still referencing V1 tables. This fixes it.

# Tests

Ran locally and checked on localhost.