### PR TITLE
Continue revising onchainexplorer table

### DIFF
--- a/models/data_hubs/fact_daily_onchainexplorer_datahub.sql
+++ b/models/data_hubs/fact_daily_onchainexplorer_datahub.sql
@@ -70,7 +70,7 @@ final_aggregated AS (
         d.type,
         d.chain,
         d.date,
-        COALESCE(ag.dau, 0) AS dau
+        COALESCE(ag.dau, NULL) AS dau
     FROM all_dates d
     LEFT JOIN aggregated ag 
         ON d.unique_id = ag.unique_id 
@@ -124,7 +124,8 @@ grouped_stats AS (
         app_or_address,
         chain,
         AVG(dau) AS dau_30d_avg,
-        ARRAY_AGG(OBJECT_CONSTRUCT('date', date, 'val', dau)) WITHIN GROUP (ORDER BY date ASC) AS dau_30d_historical
+        ARRAY_AGG(OBJECT_CONSTRUCT('date', date, 'val', COALESCE(dau, 0))) 
+            WITHIN GROUP (ORDER BY date ASC) AS dau_30d_historical
     FROM clean_datahub
     GROUP BY app_or_address, chain
 ),
@@ -142,15 +143,15 @@ individual_stats AS (
         t_minus_seven_dau,
         t_minus_thirty_dau,
         CASE
-            WHEN t_minus_one_dau = 0 THEN NULL
+            WHEN t_minus_one_dau IS NULL OR t_minus_one_dau = 0 THEN NULL
             ELSE (latest_dau - t_minus_one_dau) / t_minus_one_dau
         END AS dau_1d_change,
         CASE
-            WHEN t_minus_seven_dau = 0 THEN NULL
+            WHEN t_minus_seven_dau IS NULL OR t_minus_seven_dau = 0 THEN NULL
             ELSE (latest_dau - t_minus_seven_dau) / t_minus_seven_dau
         END AS dau_7d_change,
         CASE
-            WHEN t_minus_thirty_dau = 0 THEN NULL
+            WHEN t_minus_thirty_dau IS NULL OR t_minus_thirty_dau = 0 THEN NULL
             ELSE (latest_dau - t_minus_thirty_dau) / t_minus_thirty_dau
         END AS dau_30d_change,
         chain_rank,


### PR DESCRIPTION
# Description

This change modifies the average DAU on the onchain explorer table such that days where there were no interactions with the contract are NULL, but are still shown as 0 in the 30 day historical mini-chart per @crystaltai 's request

# Tests

<img width="558" alt="image" src="https://github.com/user-attachments/assets/6fe113bb-4492-419c-abdf-309e373a48d9" />
