### PR TITLE
fix pricing issues in rwa pipeline

### DIFF
--- a/macros/rwa/rwa_balances.sql
+++ b/macros/rwa/rwa_balances.sql
@@ -123,7 +123,7 @@ with
             , address
             , st.contract_address
             , st.symbol
-            , coalesce( d.shifted_token_price_usd,
+            , coalesce( d.price,
                     case 
                         when c.coingecko_id in (
                                 'blackrock-usd-institutional-digital-liquidity-fund', 
@@ -135,25 +135,19 @@ with
                             then coalesce(h.rate, 1)
                         when c.coingecko_id = 'ousg'
                             then o.price
+                        when c.coingecko_id = 'openeden-tbill'
+                            then tbill.price
                     end
-            ) as price
+            ) as price_adj
             , rwa_supply_native
-            , rwa_supply_native * 
-                coalesce( d.shifted_token_price_usd,
-                    case 
-                        when c.coingecko_id in ('blackrock-usd-institutional-digital-liquidity-fund', 'franklin-onchain-u-s-government-money-fund')
-                            then 1  
-                        when c.coingecko_id = 'hashnote-usyc'
-                            then coalesce(h.rate, 1)
-                        when c.coingecko_id = 'ousg'
-                            then o.price
-                    end
-            ) as rwa_supply_usd
+            , rwa_supply_native * price_adj as rwa_supply_usd
         from historical_supply_by_address_balances st
         left join {{ ref( "fact_" ~ chain ~ "_rwa_addresses") }} c
                 on lower(st.contract_address) = lower(c.contract_address)
-        left join {{ ref( "fact_coingecko_token_date_adjusted_gold") }} d
-            on lower(c.coingecko_id) = lower(d.coingecko_id)
+        left join (
+            {{get_multiple_coingecko_price_with_latest(chain)}}
+        ) d
+            on lower(c.contract_address) = lower(d.contract_address)
             and st.date = d.date::date
         left join {{ ref( "fact_hashnote_usyc_rate") }} h
             on st.date = h.date
@@ -161,13 +155,18 @@ with
         left join {{ ref( "fact_ousg_prices") }} o
             on st.date = o.date
             and st.symbol = 'OUSG'
+        left join (
+            {{ get_coingecko_price_with_latest('openeden-tbill') }}
+        ) tbill
+            on st.date = tbill.date
+            and st.symbol = 'TBILL'
     )
 select
     date
     , address
     , contract_address
     , symbol
-    , price
+    , price_adj as price
     , rwa_supply_native
     , rwa_supply_usd
     , '{{ chain }}' as chain


### PR DESCRIPTION
Have to use a combination of `get_multiple_coingecko_price_with_latest` and add a specific left join for TBILL since `dim_coingecko_token_map` does not support the correct contract address on Ethereum.