### PR TITLE
Modify chain transactions v2 tables

### DIFF
--- a/macros/create_ez_transactions.sql
+++ b/macros/create_ez_transactions.sql
@@ -45,8 +45,9 @@
     where
         raw_date < to_date(sysdate())
         {% if is_incremental() %}
-            and block_timestamp
+            and (block_timestamp
             >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+            or app is not null)
         {% endif %}
 
 {% endmacro %}

--- a/models/projects/sei/raw/ez_sei_transactions_v2.sql
+++ b/models/projects/sei/raw/ez_sei_transactions_v2.sql
@@ -39,4 +39,6 @@ where
     -- this filter will only be applied on an incremental run 
     inserted_timestamp
     >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+    or 
+    app is not null
 {% endif %}

--- a/models/projects/solana/raw/ez_solana_transactions_v2.sql
+++ b/models/projects/solana/raw/ez_solana_transactions_v2.sql
@@ -36,8 +36,9 @@ from {{ ref("fact_solana_transactions_v2") }}
 where
     raw_date < to_date(sysdate())
     {% if is_incremental() %}
-        and block_timestamp
+        and (block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+        or app is not null)
 {% else %}
     -- Making code not compile on purpose. Full refresh of entire history takes too
     -- long, doing last month will wipe out backfill

--- a/models/projects/solana/raw/ez_solana_transactions_v2.sql
+++ b/models/projects/solana/raw/ez_solana_transactions_v2.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key="tx_hash",
-        snowflake_warehouse="SOLANA_XLG",
+        snowflake_warehouse="SOLANA",
         database="solana",
         schema="raw",
         alias="ez_transactions_v2",
@@ -36,9 +36,8 @@ from {{ ref("fact_solana_transactions_v2") }}
 where
     raw_date < to_date(sysdate())
     {% if is_incremental() %}
-        and (block_timestamp
+        and block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
-        or app is not null)
 {% else %}
     -- Making code not compile on purpose. Full refresh of entire history takes too
     -- long, doing last month will wipe out backfill

--- a/models/projects/solana/raw/ez_solana_transactions_v2.sql
+++ b/models/projects/solana/raw/ez_solana_transactions_v2.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key="tx_hash",
-        snowflake_warehouse="SOLANA",
+        snowflake_warehouse="SOLANA_XLG",
         database="solana",
         schema="raw",
         alias="ez_transactions_v2",

--- a/models/staging/arbitrum/fact_arbitrum_transactions_v2.sql
+++ b/models/staging/arbitrum/fact_arbitrum_transactions_v2.sql
@@ -71,6 +71,10 @@ where
     and lower(to_address) <> lower('0x00000000000000000000000000000000000a4b05')
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and block_timestamp
+        and 
+        (block_timestamp
         >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null)
     {% endif %}

--- a/models/staging/avalanche/fact_avalanche_transactions_v2.sql
+++ b/models/staging/avalanche/fact_avalanche_transactions_v2.sql
@@ -70,6 +70,9 @@ where
     raw_date < to_date(sysdate())
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and block_timestamp
+        and (block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null)
     {% endif %}

--- a/models/staging/base/fact_base_transactions_v2.sql
+++ b/models/staging/base/fact_base_transactions_v2.sql
@@ -69,6 +69,8 @@ where
     lower(t.from_address) <> lower('0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001')
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and block_timestamp
+        and (block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+        or 
+        new_contracts.address is not null)
     {% endif %}

--- a/models/staging/bsc/fact_bsc_transactions_v2.sql
+++ b/models/staging/bsc/fact_bsc_transactions_v2.sql
@@ -79,4 +79,7 @@ left join balances as bal on t.from_address = bal.address and raw_date = bal.dat
     where
         block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null
 {% endif %}

--- a/models/staging/ethereum/fact_ethereum_transactions_v2.sql
+++ b/models/staging/ethereum/fact_ethereum_transactions_v2.sql
@@ -71,4 +71,7 @@ left join balances as bal on t.from_address = bal.address and raw_date = bal.dat
     where
         block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null
 {% endif %}

--- a/models/staging/mantle/fact_mantle_transactions_v2.sql
+++ b/models/staging/mantle/fact_mantle_transactions_v2.sql
@@ -48,6 +48,8 @@ where
     lower(t.from_hex) <> lower('0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001')
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and block_time
+        and (block_time
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+        or 
+            new_contracts.address is not null)
     {% endif %}

--- a/models/staging/optimism/fact_optimism_transactions_v2.sql
+++ b/models/staging/optimism/fact_optimism_transactions_v2.sql
@@ -71,6 +71,9 @@ where
     and lower(to_address) <> lower('0x420000000000000000000000000000000000000F')
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run 
-        and block_timestamp
+        and (block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null)
     {% endif %}

--- a/models/staging/polygon/fact_polygon_transactions_v2.sql
+++ b/models/staging/polygon/fact_polygon_transactions_v2.sql
@@ -80,4 +80,7 @@ left join balances as bal on t.from_address = bal.address and raw_date = bal.dat
     where
         block_timestamp
         >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
+
+        or 
+        new_contracts.address is not null
 {% endif %}

--- a/models/staging/sei/fact_sei_evm_transactions_v2.sql
+++ b/models/staging/sei/fact_sei_evm_transactions_v2.sql
@@ -50,6 +50,9 @@ with
             -- this filter will only be applied on an incremental run 
             inserted_timestamp
             >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+
+            or 
+            new_contracts.address is not null
         {% endif %}
     )
     select 

--- a/models/staging/sei/fact_sei_transactions_v2.sql
+++ b/models/staging/sei/fact_sei_transactions_v2.sql
@@ -36,6 +36,8 @@ WITH transaction_data as (
         -- this filter will only be applied on an incremental run 
         inserted_timestamp
         >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+        or 
+        app is not null
     {% endif %}
     UNION ALL
     SELECT
@@ -68,6 +70,8 @@ WITH transaction_data as (
         -- this filter will only be applied on an incremental run 
         inserted_timestamp
         >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+        or 
+        app is not null
     {% endif %}
 )
 SELECT

--- a/models/staging/sei/fact_sei_wasm_transactions_v2.sql
+++ b/models/staging/sei/fact_sei_wasm_transactions_v2.sql
@@ -88,7 +88,7 @@ with
             transaction_contract_data t1
         LEFT JOIN 
             new_contracts as t3
-            ON t1.contract_address = t3.address
+            ON LOWER(t1.contract_address) = LOWER(t3.address)
         {% if is_incremental() %}
             WHERE inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
             or 

--- a/models/staging/sei/fact_sei_wasm_transactions_v2.sql
+++ b/models/staging/sei/fact_sei_wasm_transactions_v2.sql
@@ -6,15 +6,6 @@
     )
 }}
 with
-    evm_txs AS (
-        select 
-            distinct tx_id from sei_flipside.core.fact_msg_attributes 
-        where 
-            msg_type ='message' and attribute_key = 'action' and ATTRIBUTE_VALUE = '/seiprotocol.seichain.evm.MsgEVMTransaction'
-        {% if is_incremental() %}
-            AND inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
-        {% endif %}
-    ),
     new_contracts as (
         select distinct
             address,
@@ -26,6 +17,12 @@ with
             contract.friendly_name
         from {{ ref("dim_all_addresses_labeled_gold") }} as contract
         where chain = 'sei'
+    ),
+    evm_txs AS (
+        select 
+            distinct tx_id from sei_flipside.core.fact_msg_attributes 
+        where 
+            msg_type ='message' and attribute_key = 'action' and ATTRIBUTE_VALUE = '/seiprotocol.seichain.evm.MsgEVMTransaction'
     ),
     prices as (
         select date as price_date, shifted_token_price_usd as price
@@ -66,9 +63,6 @@ with
             max(inserted_timestamp) as inserted_timestamp
         FROM
             sei_flipside.core.fact_msg_attributes
-            {% if is_incremental() %}
-            WHERE inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
-            {% endif %}
         GROUP BY tx_id
     ),
     transaction_contract_data as (
@@ -82,6 +76,25 @@ with
         FROM
             msg_atts_base
     ),
+    incremental_transaction_contract_data as (
+        SELECT 
+            t1.*
+            , t3.name
+            , t3.app
+            , t3.friendly_name
+            , t3.sub_category
+            , t3.category
+        FROM 
+            transaction_contract_data t1
+        LEFT JOIN 
+            new_contracts as t3
+            ON t1.contract_address = t3.address
+        {% if is_incremental() %}
+            WHERE inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+            or 
+            t3.address is not null
+        {% endif %}
+    ),
     sei_transactions as (
         SELECT 
             t1.tx_hash
@@ -89,23 +102,20 @@ with
             , t1.raw_date
             , t1.tx_succeeded as success
             , t1.contract_address
-            , t3.name
-            , t3.app
-            , t3.friendly_name
-            , t3.sub_category
-            , t3.category
+            , t1.name
+            , t1.app
+            , t1.friendly_name
+            , t1.sub_category
+            , t1.category
             , t2.tx_from as signer
             , (split(t2.fee, 'usei')[0] / pow(10, 6)) as tx_fee
             , (split(t2.fee, 'usei')[0] / pow(10, 6)) * t4.price as gas_usd
             , t1.inserted_timestamp
         FROM 
-            transaction_contract_data as t1
+            incremental_transaction_contract_data as t1
         LEFT JOIN 
             sei_flipside.core.fact_transactions as t2
             ON t1.tx_hash = t2.tx_id
-        LEFT JOIN 
-            new_contracts as t3
-            ON t1.contract_address = t3.address
         LEFT JOIN 
             prices as t4
             ON t1.raw_date = t4.price_date
@@ -113,7 +123,9 @@ with
             t1.block_timestamp < date(sysdate())
             {% if is_incremental() %}
             AND 
-            t2.inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+            (t2.inserted_timestamp >= (select dateadd('day', -5, max(inserted_timestamp)) from {{ this }})
+                or 
+                t1.app is not null)
             {% endif %}
             AND tx_id NOT IN (
                 SELECT tx_id

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -23,7 +23,7 @@ with
         select
             tx_id,
             min_by(value:"programId"::string, index) as program_id,
-            array_agg(value:"parsed":"info":"destination"::string) as destinations,
+            array_agg(value:"parsed":"info":"destination"::string) as destinations
         from solana_flipside.core.fact_transactions, lateral flatten(instructions)
         where
             value:"programId"::string in ('11111111111111111111111111111111', 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA') and ARRAY_SIZE(instructions) <= 3

--- a/models/staging/tron/fact_tron_transactions_v2.sql
+++ b/models/staging/tron/fact_tron_transactions_v2.sql
@@ -74,4 +74,6 @@ left join balances as bal on t.from_address = bal.address and raw_date = bal.dat
     where
         block_timestamp
         >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+        or 
+            new_contracts.address is not null
 {% endif %}


### PR DESCRIPTION
# Description

Modified chain-level transactions V2 tables such that they are able to incrementally take new historical labels as well. Basically, every single incremental run will include all rows in the transactions table where the contract address is labeled, regardless of how recent that row is. 

# Tests