### PR TITLE
Obtain All Event Info

### DIFF
--- a/models/dimensions/__dimension__sources.yml
+++ b/models/dimensions/__dimension__sources.yml
@@ -39,3 +39,9 @@ sources:
       - name: dim_sub_categories
       - name: dim_categories
       - name: all_categories_seed
+  - name: DECODING
+    schema: prod
+    database: pc_dbt_db
+    tables:
+        - name: dim_all_abis
+        - name: dim_all_contracts

--- a/models/dimensions/events/dim_events_silver.sql
+++ b/models/dimensions/events/dim_events_silver.sql
@@ -1,17 +1,37 @@
-{{ config(materialized="table", unique_key="topic_zero", sort="topic_zero") }}
+{{ 
+    config(
+        materialized="table",
+        unique_key="topic_zero",
+        sort="topic_zero",
+        snowflake_warehouse='BALANCES_LG',
+    ) 
+}}
 with
 event_signatures as (
     select
         value:"name"::string as event_name,
         value as event_info,
         {{ target.schema }}.event_info_to_keccak_event_signature_v2(value) as topic_zero,
-        row_number() over (partition by topic_zero order by event_name) as event_id
+        row_number() over (partition by topic_zero order by event_name) as event_id,
+        'artemis' as source
     from {{ ref("dim_contract_abis") }}, lateral flatten(input => abi) as f
+    where value:"type" = 'event'
+
+    UNION ALL 
+
+    select
+        value:"name"::string as event_name,
+        value as event_info,
+        {{ target.schema }}.event_info_to_keccak_event_signature_v2(value) as topic_zero,
+        row_number() over (partition by topic_zero order by event_name) as event_id,
+        source
+    from {{ source("DECODING", "dim_all_abis") }}, lateral flatten(input => abi) as f
     where value:"type" = 'event'
 )
 select 
     event_name,
     event_info,
-    topic_zero
+    topic_zero,
+    source
 from event_signatures
 where event_id = 1 and event_name not in ('AuthorizationCanceled', 'ValidatorEcdsaPublicKeyUpdated', 'ValidatorBlsPublicKeyUpdated', 'AuthorizationUsed', 'TransferComment') -- These events emit types currently not supported by the decode_evm_event_log function


### PR DESCRIPTION
## :pushpin: References
- Combine all ABIs and extract event info for event log decoding
<img width="871" alt="image" src="https://github.com/user-attachments/assets/88bb3d2f-1403-4d15-b86d-e4dd137ce3e3" />


## 🎄 Asset Checklist

- [ ] Added to `databases.csv` or already exists

## 🧮 Metric Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Pulled fact table into `ez_asset_metrics.sql` table
- [ ] `Compiles` in Github
- [ ] `Show Changed Models` in Github matches expectations for what metric value should be
