### PR TITLE
veSTG top 100 holders

### DIFF
--- a/macros/bridge/stargate_veSTGholders.sql
+++ b/macros/bridge/stargate_veSTGholders.sql
@@ -1,0 +1,226 @@
+{% macro stargate_veSTGholders(chain, token_contract_address, veSTG_contract_address) %} 
+
+with stg_holders as (
+    select 
+        tx_hash, 
+        from_address as address,
+       raw_amount / 1e18 as stg_balance
+    from {{chain}}_flipside.core.fact_token_transfers
+    where 
+        lower(to_address) = lower('{{veSTG_contract_address}}') -- veSTG contract
+        and lower(contract_address) = lower('{{token_contract_address}}') -- STG token
+),
+veSTG_deposits as (
+    select
+        ezd.tx_hash,
+        ezd.block_timestamp,
+        decoded_log:"provider"::STRING as from_address,
+        try_cast(decoded_log:"locktime"::STRING as NUMBER) as locktime,
+        try_cast(decoded_log:"ts"::STRING as NUMBER) as ts,
+        try_cast(decoded_log:"value"::STRING as NUMERIC)/1e18 as value,
+        case when 
+            locktime is not null 
+            then TO_TIMESTAMP(locktime) else null 
+        end as locktime_ts,
+        case when 
+            ts is not null 
+            then TO_TIMESTAMP(ts) else null 
+        end as deposit_ts,
+        case 
+            when locktime is not null then greatest(0, datediff(day, current_timestamp(), TO_TIMESTAMP(locktime)))
+            else 0
+        end AS remaining_days,
+        case
+            when locktime is not null then
+                concat(
+                    floor(greatest(0, datediff(day, current_timestamp(), TO_TIMESTAMP(locktime))) / 365), ' years, ',
+                    floor(mod(greatest(0, datediff(day, current_timestamp(), TO_TIMESTAMP(locktime))), 365) / 30), ' months, ',
+                    mod(greatest(0, datediff(day, current_timestamp(), TO_TIMESTAMP(locktime))), 30), ' days'
+                )
+            else '0 days'
+        end as remaining_stake_readable,
+        stg.stg_balance,
+        case
+            when stg.stg_balance is null or locktime is null or ts is null then 0
+            when (locktime - ts) <= 0 then 0  
+            when (locktime - ts) > 94608000 then 0
+            else (stg.stg_balance * (locktime - ts)/24/3600/3/365)
+        end AS veSTG_balance
+    from {{chain}}_flipside.core.ez_decoded_event_logs ezd
+    inner join stg_holders stg on stg.tx_hash = ezd.tx_hash
+    where topic_0 = '0xbe9cf0e939c614fad640a623a53ba0a807c8cb503c4c4c8dacabe27b86ff2dd5'
+        and tx_succeeded = true 
+        and event_name = 'Deposit'
+        and stg.stg_balance is not null
+),
+veSTG_withdraws as (
+    select
+        ezd.tx_hash,
+        ezd.block_timestamp,
+        decoded_log:"provider"::STRING as from_address,
+        -- Safe numeric casting for withdrawal value
+        try_cast(decoded_log:"value"::STRING as NUMERIC)/1e18 as withdrawn_value
+    from {{chain}}_flipside.core.ez_decoded_event_logs ezd
+    where topic_0 = '0xf279e6a1f5e320cca91135676d9cb6e44ca8a08c0b88342bcdb1144f6511b568'
+        and tx_succeeded = true 
+        and event_name = 'Withdraw'
+        and try_cast(decoded_log:"value"::STRING as NUMERIC) > 0
+),
+stake_events as (
+    select
+        decoded_log:"provider"::STRING as from_address,
+        block_timestamp,
+        event_name
+    from {{chain}}_flipside.core.ez_decoded_event_logs
+    where event_name in ('Deposit', 'Withdraw')
+        and tx_succeeded = true
+        and topic_0 in ('0xbe9cf0e939c614fad640a623a53ba0a807c8cb503c4c4c8dacabe27b86ff2dd5', '0xf279e6a1f5e320cca91135676d9cb6e44ca8a08c0b88342bcdb1144f6511b568')
+),
+ranked_stake_changes as (
+    select
+        from_address,
+        block_timestamp,
+        event_name,
+        row_number() over (
+            partition by from_address 
+            order by block_timestamp desc
+        ) as rn
+    from stake_events
+),
+last_stake_changes as (
+    select
+        from_address,
+        block_timestamp as last_change_timestamp,
+        event_name as last_action_type
+    from ranked_stake_changes
+    where rn = 1
+),
+voting_data as (
+    select 
+        lower(ADDRESS) as from_address,
+        count(*) as number_of_votes,
+        max(TO_TIMESTAMP(TIMESTAMP)) as last_voted_timestamp
+    from landing_database.prod_landing.raw_stargate_proposals_csv
+    group by lower(ADDRESS)
+),
+circulating_supply AS (
+    select
+        block_timestamp,
+        try_cast(decoded_log:"supply"::STRING as NUMERIC)/1e18 AS current_total_supply
+    from ethereum_flipside.core.ez_decoded_event_logs
+    where lower(contract_address) = lower('0x0e42acbd23faee03249daff896b78d7e79fbd58e')
+        and tx_succeeded = true 
+        and event_name = 'Supply'
+    order by block_timestamp desc
+    limit 1
+),
+net_positions AS (
+    select 
+        d.from_address,
+        d.veSTG_balance,
+        d.remaining_days,
+        d.remaining_stake_readable,
+        coalesce(w.total_withdrawn, 0) as total_withdrawn,
+        case 
+            when d.remaining_days = 0 then 0 -- Expired positions have 0 value
+            else greatest(0, d.veSTG_balance - coalesce(w.total_withdrawn, 0))
+        end as net_veSTG_balance
+    from veSTG_deposits d
+    left join (
+        select 
+            from_address, 
+            sum(withdrawn_value) as total_withdrawn
+        from veSTG_withdraws
+        where withdrawn_value is not null
+        group by from_address
+    ) w on d.from_address = w.from_address
+    where d.veSTG_balance > 0
+        and d.remaining_days > 0
+),
+all_holders AS (
+    select 
+        from_address, 
+        sum(net_veSTG_balance) as veSTG_balance,
+        max(remaining_days) as max_remaining_days,
+        max(remaining_stake_readable) as max_remaining_stake_readable
+    from net_positions
+    group by from_address
+    having sum(net_veSTG_balance) > 0
+),
+latest_stg_balances as (
+    select 
+        address as from_address,
+        balance_token / 1e18 AS stg_balance,
+        row_number() over (
+            partition by address 
+            order by block_timestamp desc
+        ) AS rn
+    from {{ ref("fact_"~ chain ~"_address_balances_by_token")}}
+    where lower(contract_address) = lower('{{token_contract_address}}') -- STG token
+),
+current_stg_balances as (
+    select
+        from_address,
+        case 
+            when stg_balance < 0 then 0
+            else stg_balance
+        end as stg_balance
+    from latest_stg_balances
+    where rn = 1
+),
+total_veSTG AS (
+    select sum(veSTG_balance) as total_veSTG_amount
+    from all_holders
+),
+fees_received as (
+    select
+        sum(fees) as total_fees
+    from PC_DBT_DB.PROD.fact_stargate_v2_transfers
+    where src_chain = '{{chain}}'
+),
+top_holders AS (
+    select 
+        h.from_address, 
+        coalesce(s.stg_balance, 0) as stg_balance,
+        h.veSTG_balance,
+        h.max_remaining_days as remaining_days,
+        h.max_remaining_stake_readable as remaining_staking_period,
+        coalesce(v.number_of_votes, 0) as number_of_votes_cast,
+        v.last_voted_timestamp,
+        l.last_change_timestamp,
+        l.last_action_type,
+        case 
+            when c.current_total_supply > 0 then (h.veSTG_balance / nullif(c.current_total_supply, 0)) * 100
+            else 0
+        end AS percentage_of_circulating_supply,
+        case
+            when (select total_veSTG_amount from total_veSTG) > 0 then
+                (select total_fees from fees_received) * (1.0/6.0) * 
+                (h.veSTG_balance / nullif((select total_veSTG_amount from total_veSTG), 0))
+            else 0
+        end as fees_received
+    from all_holders h
+    left join current_stg_balances s on h.from_address = s.from_address
+    left join voting_data v on lower(h.from_address) = v.from_address
+    left join last_stake_changes l on h.from_address = l.from_address
+    cross join circulating_supply c
+    order by h.veSTG_balance desc
+    limit 100
+)
+select
+    from_address,
+    stg_balance,
+    veSTG_balance,
+    remaining_days,
+    remaining_staking_period,
+    percentage_of_circulating_supply,
+    number_of_votes_cast,
+    last_voted_timestamp ,
+    last_change_timestamp,
+    last_action_type,
+    fees_received,
+    '{{chain}}' as chain
+from top_holders
+order by veSTG_balance desc
+
+{% endmacro %}

--- a/models/projects/stargate/core/ez_stargate_metrics_top100veSTGholders.sql
+++ b/models/projects/stargate/core/ez_stargate_metrics_top100veSTGholders.sql
@@ -1,0 +1,42 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="STARGATE",
+        database="stargate",
+        schema="core",
+        alias="ez_metrics_top100veSTGholders",
+    )
+}}
+
+with
+top100veSTGholders as (
+    select
+        from_address,
+        stg_balance,
+        veSTG_balance,
+        remaining_days,
+        remaining_staking_period,
+        percentage_of_circulating_supply,
+        number_of_votes_cast,
+        last_voted_timestamp,
+        last_change_timestamp,
+        last_action_type,
+        fees_received,
+        chain
+    from {{ref("fact_stargate_top100veSTGholders")}}
+)
+
+select
+    from_address,
+    stg_balance,
+    veSTG_balance,
+    remaining_days,
+    remaining_staking_period,
+    percentage_of_circulating_supply,
+    number_of_votes_cast,
+    last_voted_timestamp,
+    last_change_timestamp,
+    last_action_type,
+    fees_received,
+    chain
+from top100veSTGholders

--- a/models/staging/stargate/dim_stargate_arbitrum_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_arbitrum_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_veSTGholders(
+        'arbitrum'
+        , '0x6694340fc020c5E6B96567843da2df01b2CE1eb6'
+        , '0xfbd849e6007f9bc3cc2d6eb159c045b8dc660268'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_avalanche_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_avalanche_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_veSTGholders(
+        'avalanche'
+        , '0x2f6f07cdcf3588944bf4c42ac74ff24bf56e7590'
+        , '0xca0f57d295bbce554da2c07b005b7d6565a58fce'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_bsc_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_bsc_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_veSTGholders(
+        'bsc'
+        , '0xB0D502E938ed5f4df2E681fE6E419ff29631d62b'
+        , '0xD4888870C8686c748232719051b677791dBDa26D'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_ethereum_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_ethereum_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_veSTGholders(
+        'ethereum'
+        , '0xAf5191B0De278C7286d6C7CC6ab6BB8A73bA2Cd6'
+        , '0x0e42acbd23faee03249daff896b78d7e79fbd58e'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_optimism_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_optimism_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+{{
+    stargate_veSTGholders(
+        'optimism'
+        , '0x296F55F8Fb28E498B858d0BcDA06D955B2Cb3f97'
+        , '0x43d2761ed16c89a2c4342e2b16a3c61ccf88f05b'
+    )
+}}

--- a/models/staging/stargate/dim_stargate_polygon_veSTGholders.sql
+++ b/models/staging/stargate/dim_stargate_polygon_veSTGholders.sql
@@ -1,0 +1,8 @@
+{{config(materialized="table", snowflake_warehouse='MEDIUM')}}
+{{
+    stargate_veSTGholders(
+        'polygon'
+        , '0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590'
+        , '0x3ab2da31bbd886a7edf68a6b60d3cde657d3a15d'
+    )
+}}

--- a/models/staging/stargate/fact_stargate_top100veSTGholders.sql
+++ b/models/staging/stargate/fact_stargate_top100veSTGholders.sql
@@ -1,0 +1,31 @@
+{{config(materialized="table", snowflake_warehouse='STARGATE')}}
+
+with 
+combined_events as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("dim_stargate_arbitrum_veSTGholders"),
+                ref("dim_stargate_avalanche_veSTGholders"),
+                ref("dim_stargate_bsc_veSTGholders"),
+                ref("dim_stargate_ethereum_veSTGholders"),
+                ref("dim_stargate_optimism_veSTGholders"),
+                ref("dim_stargate_polygon_veSTGholders"),
+            ],
+        )
+    }}
+)
+select
+    from_address,
+    stg_balance,
+    veSTG_balance,
+    remaining_days,
+    remaining_staking_period,
+    percentage_of_circulating_supply,
+    number_of_votes_cast,
+    last_voted_timestamp,
+    last_change_timestamp,
+    last_action_type,
+    fees_received,
+    chain
+from combined_events


### PR DESCRIPTION
Added the 6 chains that have veSTG holders:
- arbitrum
- avalanche
- bsc
- ethereum
- optimism
- polygon

Created the fact table and ez_metrics table as well:
<img width="850" alt="image" src="https://github.com/user-attachments/assets/9beb8e94-fd99-45f7-b305-59f358089fbb" />

ez_metrics_top100veSTGholders materialized successfully