### PR TITLE
Wes/jitosol

### DIFF
--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -27,7 +27,7 @@ with
     , jito_tvl as (
         SELECT
             date
-            , sum(amount_usd) as tvl
+            , sum(usd_balance) as tvl
         FROM {{ ref('fact_jitosol_tvl') }}
         GROUP BY 1
     )

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -10,7 +10,7 @@
 with 
     jito_mgmt_withdraw_fees as (
         SELECT 
-            day as date
+            date
             , withdraw_management_fees
         FROM {{ ref('fact_jito_mgmt_withdraw_fees') }}
     )

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -11,18 +11,25 @@ with
     jito_mgmt_withdraw_fees as (
         SELECT 
             day as date
-            , fees
+            , withdraw_management_fees
         FROM {{ ref('fact_jito_mgmt_withdraw_fees') }}
     )
     , jito_dau_txns_fees as ( -- Tips
         SELECT 
             day as date
-            , fees
-            , revenue
-            , supply_side_fees
-            , txns
-            , dau
+            , tip_fees
+            , tip_revenue
+            , tip_supply_side_fees
+            , tip_txns
+            , tip_dau
         FROM {{ ref('fact_jito_dau_txns_fees') }}
+    )
+    , jito_tvl as (
+        SELECT
+            date
+            , sum(amount_usd) as tvl
+        FROM {{ ref('fact_jitosol_tvl') }}
+        GROUP BY 1
     )
     , date_spine as (
         SELECT
@@ -40,6 +47,8 @@ SELECT
     , tip_supply_side_fees as supply_side_fees
     , tip_txns as txns
     , tip_dau as dau
+    , tvl
 FROM date_spine ds
 LEFT JOIN jito_mgmt_withdraw_fees using (date)
 LEFT JOIN jito_dau_txns_fees using (date)
+LEFT JOIN jito_tvl using (date)

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -7,12 +7,39 @@
         alias='ez_metrics'
     )
 }}
+with 
+    jito_mgmt_withdraw_fees as (
+        SELECT 
+            day as date
+            , fees
+        FROM {{ ref('fact_jito_mgmt_withdraw_fees') }}
+    )
+    , jito_dau_txns_fees as ( -- Tips
+        SELECT 
+            day as date
+            , fees
+            , revenue
+            , supply_side_fees
+            , txns
+            , dau
+        FROM {{ ref('fact_jito_dau_txns_fees') }}
+    )
+    , date_spine as (
+        SELECT
+            date
+        FROM {{ ref('dim_date_spine') }}
+        WHERE date between (select min(date) from jito_dau_txns_fees) and (to_date(sysdate()))
+    )
 
 SELECT 
-    day as date
-    , fees
-    , revenue
-    , supply_side_fees
-    , txns
-    , dau
-FROM {{ ref('fact_jito_dau_txns_fees') }}
+    date
+    , withdraw_management_fees
+    , tip_fees
+    , withdraw_management_fees + tip_fees as fees
+    , tip_revenue + tip_fees as revenue
+    , tip_supply_side_fees as supply_side_fees
+    , tip_txns as txns
+    , tip_dau as dau
+FROM date_spine ds
+LEFT JOIN jito_mgmt_withdraw_fees using (date)
+LEFT JOIN jito_dau_txns_fees using (date)

--- a/models/projects/jito/core/ez_jito_metrics_by_chain.sql
+++ b/models/projects/jito/core/ez_jito_metrics_by_chain.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized='view',
+        snowflake_warehouse='jito',
+        database='jito',
+        schema='core',
+        alias='ez_metrics_by_chain'
+    )
+}}
+
+SELECT
+    date,
+    'solana' as chain,
+    withdraw_management_fees,
+    tip_fees,
+    fees,
+    revenue,
+    supply_side_fees,
+    txns,
+    dau,
+    tvl
+FROM {{ ref('ez_jito_metrics') }}

--- a/models/staging/jito/fact_jito_dau_txns_fees.sql
+++ b/models/staging/jito/fact_jito_dau_txns_fees.sql
@@ -2,7 +2,7 @@
     config(
         materialized='incremental',
         unique_key='day',
-        snowflake_warehouse='jito'
+        snowflake_warehouse='JITO'
     )
 }}
 with prices as (
@@ -16,11 +16,11 @@ with prices as (
 
 SELECT 
     date_trunc('day', t.block_timestamp) as day
-    , sum(t.amount * p.price) as fees
-    , sum(t.amount * p.price) * 0.05 as revenue
-    , sum(t.amount * p.price) * 0.95 as supply_side_fees
-    , count(*) as txns
-    , count(distinct t.tx_from) as dau
+    , sum(t.amount * p.price) as tip_fees
+    , sum(t.amount * p.price) * 0.05 as tip_revenue
+    , sum(t.amount * p.price) * 0.95 as tip_supply_side_fees
+    , count(*) as tip_txns
+    , count(distinct t.tx_from) as tip_dau
 FROM {{ source('SOLANA_FLIPSIDE', 'fact_transfers') }} t
 LEFT JOIN prices p on p.date = date_trunc('day',t.block_timestamp)
 WHERE tx_to IN ('96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5' -- all the tip payment accounts from: https://jito-foundation.gitbook.io/mev/mev-payment-and-distribution/on-chain-addresses#mainnet

--- a/models/staging/jito/fact_jito_mgmt_withdraw_fees.sql
+++ b/models/staging/jito/fact_jito_mgmt_withdraw_fees.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="MEDIUM"
+    )
+}}
+
+SELECT
+    block_timestamp::date as date,
+    mint,
+    sum(amount * price) as withdraw_management_fees
+FROM {{ source('SOLANA_FLIPSIDE', 'fact_transfers') }} t
+LEFT JOIN solana_flipside.price.ez_prices_hourly p on p.token_address = t.mint and p.hour = t.block_timestamp::date
+WHERE 1=1
+    AND tx_to = '5eosrve6LktMZgVNszYzebgmmC7BjLK8NoWyRQtcmGTF'
+    AND mint = 'J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn'
+    {% if is_incremental() %}
+        AND block_timestamp > (select dateadd(day, -3, max(date)) from {{ this }})
+    {% endif %}
+    AND amount * price < 1e5
+GROUP BY 1, 2
+ORDER BY 1 desc

--- a/models/staging/jito/fact_jito_mgmt_withdraw_fees.sql
+++ b/models/staging/jito/fact_jito_mgmt_withdraw_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="MEDIUM"
+        snowflake_warehouse="JITO",
+        unique_key=["date", "mint"]
     )
 }}
 

--- a/models/staging/jito/fact_jitosol_stake_accounts.sql
+++ b/models/staging/jito/fact_jitosol_stake_accounts.sql
@@ -1,0 +1,37 @@
+{{
+    config( 
+        materialized="incremental",
+        snowflake_warehouse="JITO"
+    )
+}}
+
+
+WITH all_stake_accounts AS (
+    SELECT
+        -- Extract relevant stake account based on instruction type
+        CASE 
+            WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '01' THEN instruction:accounts[5]::STRING -- addValidatorToPool (validator stake)
+            WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '03' THEN instruction:accounts[5]::STRING -- decreaseValidatorStake (transient stake)
+            WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '04' THEN instruction:accounts[5]::STRING -- increaseValidatorStake (transient stake)
+            WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '09' THEN instruction:accounts[5]::STRING -- depositStake (deposited stake)
+            WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '15' THEN instruction:accounts[8]::STRING -- redelegate (destination validator stake)
+        END AS stake_account,
+        tx_id,
+        sysdate() AS last_updated
+    FROM
+        {{ source('SOLANA_FLIPSIDE', 'fact_events') }}
+    WHERE 1=1
+        AND contains(instruction:accounts, '6iQKfEyhr3bZMotVkW6beNZz5CPAkiwvgV2CTje9pVSS') -- Jito Stake Pool Authority
+        AND program_id = 'SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy'
+        AND LEFT(BASE58_TO_HEX(instruction:data), 2) IN ('01', '03', '04', '09', '15') -- Filter only relevant instructions
+
+    UNION ALL
+
+    -- Explicitly add the reserve stake account
+    SELECT
+        'BgKUXdS29YcHCFrPm5M8oLHiTzZaMDjsebggjoaQ6KFL' AS stake_account, -- Reserve Stake Account
+        NULL AS tx_id,
+        sysdate() AS last_updated
+)
+
+SELECT DISTINCT stake_account FROM all_stake_accounts

--- a/models/staging/jito/fact_jitosol_tvl.sql
+++ b/models/staging/jito/fact_jitosol_tvl.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="JITO"
+    )
+}}
+
+{% set stake_accounts_query %}
+  select distinct stake_account from {{ ref('fact_jitosol_stake_accounts') }}
+{% endset %}
+
+{% set stake_accounts_results = run_query(stake_accounts_query) %}
+
+{% if execute %}
+    {% set stake_accounts_list = stake_accounts_results.columns[0].values() %}
+{% else %}
+    {% set stake_accounts_list = [] %}
+{% endif %}
+
+{{ get_treasury_balance(chain='solana', addresses = stake_accounts_list, earliest_date='2022-10-24') }}


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [x] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [x] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [x] Added clear asset and metric documentation to CAD
- [x] Added metric definitions to Terminal (if applicable)
- [x] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below

TVL
![CleanShot 2025-03-11 at 17 02 04@2x](https://github.com/user-attachments/assets/3f850fd6-622e-41a0-8d2d-3e2000943b5a)

Revenue (including management/withdrawal fees)
![CleanShot 2025-03-11 at 17 34 27@2x](https://github.com/user-attachments/assets/7ca51542-f498-4d35-a61b-1f21d9fd468f)


## Other

- [x] Any other relevant information that may be helpful

Added `get_entity_historical_balance` macro which is an improved version of `get_treasury_balance`. `get_treasury_balance` has a few limitations, particularly that it was designed for treasuries that are comprised of a small number of addresses. This makes the macro unwieldy to debug when calculating the TVL of a protocol that has many addresses. 