### PR TITLE
Wes/gain+jito lst

### DIFF
--- a/macros/get_treasury_balance.sql
+++ b/macros/get_treasury_balance.sql
@@ -27,7 +27,7 @@ WITH dates AS (
         case
             when contract_address = 'native_token' 
                 then 0
-            else b.decimals
+            else t.decimals
         end as decimals_adj,
         MAX_BY({%if chain == 'solana' %}amount{% else %}balance_token{% endif %} / pow(10, coalesce(decimals_adj,18)), block_timestamp) AS balance_daily
     FROM

--- a/models/projects/gains_network/core/ez_gains_network_metrics.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GAINS_NETWORK",
+        database="gains_network",
+        schema="core",
+        alias="ez_metrics"
+    )
+}}
+
+with date_spine as (
+    select date
+    from {{ ref("dim_date_spine") }}
+    where date between '2022-12-14' and to_date(sysdate())
+)
+
+    , gains_data as (
+        select date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders
+        from {{ ref("fact_gains_trading_volume_unique_traders") }}
+        group by date
+    )
+    , gains_fees as (
+        select date, fees, revenue
+        from {{ ref("fact_gains_fees") }}
+    )
+    , gains_tvl as (
+        select date, sum(usd_balance) as tvl
+        from {{ ref("fact_gains_tvl") }}
+        group by date
+    )
+
+select
+    ds.date,
+    'gains-network' as app,
+    'DeFi' as category,
+    gd.trading_volume,
+    gd.unique_traders,
+    gf.fees,
+    gf.revenue,
+    gt.tvl
+from date_spine ds
+left join gains_data gd using (date)
+left join gains_fees gf using (date)
+left join gains_tvl gt using (date)

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -28,6 +28,7 @@ with
         SELECT
             date
             , sum(usd_balance) as tvl
+            , tvl - lag(tvl) over (order by date) as tvl_change
         FROM {{ ref('fact_jitosol_tvl') }}
         GROUP BY 1
     )
@@ -48,6 +49,8 @@ SELECT
     , coalesce(tip_txns, 0) as txns
     , coalesce(tip_dau, 0) as dau
     , coalesce(tvl, 0) as tvl
+    , coalesce(tvl, 0) as amount_staked_usd
+    , coalesce(tvl_change, 0) as amount_staked_usd_net_change
 FROM date_spine ds
 LEFT JOIN jito_mgmt_withdraw_fees using (date)
 LEFT JOIN jito_dau_txns_fees using (date)

--- a/models/projects/jito/core/ez_jito_metrics_by_chain.sql
+++ b/models/projects/jito/core/ez_jito_metrics_by_chain.sql
@@ -18,5 +18,7 @@ SELECT
     supply_side_fees,
     txns,
     dau,
-    tvl
+    tvl,
+    amount_staked_usd,
+    amount_staked_usd_net_change
 FROM {{ ref('ez_jito_metrics') }}

--- a/models/staging/gains/__gains__sources.yml
+++ b/models/staging/gains/__gains__sources.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_gains_fees

--- a/models/staging/gains/fact_gains_fees.sql
+++ b/models/staging/gains/fact_gains_fees.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GAINS_NETWORK"
+    )
+}}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_gains_fees") }}
+    )
+select
+    left(value:day, 10)::date as date,
+    value:all_fees::number as fees,
+    value:revenue::number as revenue
+from
+    {{ source("PROD_LANDING", "raw_gains_fees") }},
+    lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)

--- a/models/staging/gains/fact_gains_tvl.sql
+++ b/models/staging/gains/fact_gains_tvl.sql
@@ -1,0 +1,43 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GAINS_NETWORK"
+    )
+}}
+
+with arbitrum as (
+    {{get_treasury_balance(
+        chain='arbitrum',
+        addresses=['0xd85E038593d7A098614721EaE955EC2022B9B91B', 
+                  '0xd3443ee1e91aF28e5FB858Fbd0D72A63bA8046E0',
+                  '0x5977A9682D7AF81D347CFc338c61692163a2784C',
+                  '0xFF162c694eAA571f685030649814282eA457f169'],
+        earliest_date='2022-01-01'
+    )}}
+),
+
+polygon as (
+    {{get_treasury_balance(
+        chain='polygon',
+        addresses=['0x91993f2101cc758D0dEB7279d41e880F7dEFe827',
+                  '0x29019Fe2e72E8d4D2118E8D0318BeF389ffe2C81',
+                  '0x1544E1fF1a6f6Bdbfb901622C12bb352a43464Fb',
+                  '0x209A9A01980377916851af2cA075C2b170452018'],
+        earliest_date='2022-01-01'
+    )}}
+),
+
+base as (
+    {{get_treasury_balance(
+        chain='base',
+        addresses=['0xad20523A7dC37bAbc1CC74897E4977232b3D02e5',
+                  '0x6cD5aC19a07518A8092eEFfDA4f1174C72704eeb'],
+        earliest_date='2023-08-01'
+    )}}
+)
+
+select * from arbitrum
+union all
+select * from polygon
+union all
+select * from base


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [x] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [x] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [x] Added clear asset and metric documentation to CAD
- [x] Added metric definitions to Terminal (if applicable)
- [x] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below

Gains data:
![CleanShot 2025-03-12 at 00 21 09@2x](https://github.com/user-attachments/assets/8b981be2-8255-4053-b9a5-48e1d160a4cb)

Jito data:

![CleanShot 2025-03-12 at 00 47 43@2x](https://github.com/user-attachments/assets/eed36696-e549-4d12-a800-9efb4d571f13)

![CleanShot 2025-03-12 at 00 47 36@2x](https://github.com/user-attachments/assets/bf93d8ad-16ef-4716-95db-3a0211a08b33)

## Other

- [x] Any other relevant information that may be helpful
Jito data wouldn't populate in frontend - figured it must be a bug with local instance of frontend since the API works well for the added metrics and the metrics endpoint didn't return these metrics even after clearing local storage.