### PR TITLE
Extend solana incremental lookback days

### DIFF
--- a/models/projects/solana/core/ez_solana_metrics_by_contract_v2.sql
+++ b/models/projects/solana/core/ez_solana_metrics_by_contract_v2.sql
@@ -26,7 +26,7 @@ with
         where
             not equal_null(category, 'EOA')
             {% if is_incremental() %}
-                and date >= (select dateadd('day', -7, max(date)) from {{ this }})
+                and date >= (select dateadd('day', CASE WHEN DAYOFWEEK(CURRENT_DATE) = 7 THEN -90 ELSE -30 END, max(date)) from {{ this }})
             {% endif %}
         group by date, contract_address
     )

--- a/models/projects/solana/raw/ez_solana_transactions_v2.sql
+++ b/models/projects/solana/raw/ez_solana_transactions_v2.sql
@@ -37,7 +37,7 @@ where
     raw_date < to_date(sysdate())
     {% if is_incremental() %}
         and block_timestamp
-        >= (select dateadd('day', -5, max(block_timestamp)) from {{ this }})
+        >= (select dateadd('day', CASE WHEN DAYOFWEEK(CURRENT_DATE) = 7 THEN -90 ELSE -30 END, max(block_timestamp)) from {{ this }})
 {% else %}
     -- Making code not compile on purpose. Full refresh of entire history takes too
     -- long, doing last month will wipe out backfill

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -5,7 +5,7 @@
         snowflake_warehouse="BAM_TRANSACTION_XLG",
     )
 }}
--- Does a 5-day refresh on a normal day, and does a 2 week refresh every Saturday (for labels)
+-- Does a 30-day refresh on a normal day, and does a 90-day refresh every Saturday (for labels)
 
 with
     app_contracts as (
@@ -25,7 +25,7 @@ with
         -- Chunking required here for backfills
         {% if is_incremental() %}
             where block_timestamp
-            >= (select dateadd('day', CASE WHEN DAYOFWEEK(CURRENT_DATE) = 7 THEN -14 ELSE -5 END, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('day', CASE WHEN DAYOFWEEK(CURRENT_DATE) = 7 THEN -90 ELSE -30 END, max(block_timestamp)) from {{ this }})
         {% else %}
         -- Making code not compile on purpose. Full refresh of entire history
         -- takes too long, doing last month will wipe out backfill


### PR DESCRIPTION
# Description

Increased the lookback days for solana transactions to 30 days on a daily incremental run and 90 days every saturday so that onchain explorer for solana will look normal (since it looks at up to T-30 on a daily basis).

# Tests

Checked locally.