### PR TITLE
fix jito revs and meteora col name

### DIFF
--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -44,7 +44,7 @@ SELECT
     , coalesce(withdraw_management_fees, 0) as withdraw_management_fees
     , coalesce(tip_fees, 0) as tip_fees
     , coalesce(withdraw_management_fees, 0) + coalesce(tip_fees, 0) as fees
-    , coalesce(tip_revenue, 0) + coalesce(tip_fees, 0) as revenue
+    , coalesce(tip_revenue, 0) + coalesce(withdraw_management_fees, 0) as revenue
     , coalesce(tip_supply_side_fees, 0) as supply_side_fees
     , coalesce(tip_txns, 0) as txns
     , coalesce(tip_dau, 0) as dau

--- a/models/projects/meteora/core/ez_meteora_metrics.sql
+++ b/models/projects/meteora/core/ez_meteora_metrics.sql
@@ -34,7 +34,7 @@ with date_spine as (
 
 select
     date_spine.date,
-    coalesce(swap_metrics.unique_traders, 0) as unique_swappers,
+    coalesce(swap_metrics.unique_traders, 0) as unique_traders,
     coalesce(swap_metrics.number_of_swaps, 0) as number_of_swaps,
     coalesce(swap_metrics.trading_volume, 0) as trading_volume
 from date_spine


### PR DESCRIPTION
Jito
- Fix to sum tip_revenue + management/withdrawal fees as revenue

![CleanShot 2025-03-17 at 11 23 16@2x](https://github.com/user-attachments/assets/7b34871f-959d-4524-a983-126ee79c1500)

Meteora
- Rename column to what the adapter expects
- Ran reverse ETL and it works.