### PR TITLE
Upgrade Solana warehouses and fix coingecko nft issue

### DIFF
--- a/models/projects/solana/raw/ez_solana_transactions_v2.sql
+++ b/models/projects/solana/raw/ez_solana_transactions_v2.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key="tx_hash",
-        snowflake_warehouse="SOLANA",
+        snowflake_warehouse="BAM_TRANSACTION_XLG",
         database="solana",
         schema="raw",
         alias="ez_transactions_v2",

--- a/models/staging/coingecko/fact_coingecko_nft_price_mc_vol.sql
+++ b/models/staging/coingecko/fact_coingecko_nft_price_mc_vol.sql
@@ -38,7 +38,7 @@ with
         select
             coingecko_nft_id,
             date(to_timestamp(value[0]::number / 1000)) as date,
-            avg(value[1]::float) as h24_volume_usd
+            avg(CASE WHEN value[1] = '' THEN 0 ELSE value[1]::FLOAT END) AS h24_volume_usd
         from nft_data, lateral flatten(input => data:h24_volume_usd)
         group by coingecko_nft_id, date
     ),

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -2,7 +2,7 @@
     config(
         materialized="incremental",
         unique_key="tx_hash",
-        snowflake_warehouse="BAM_TRANSACTION_XLG",
+        snowflake_warehouse="BAM_TRANSACTION_2XLG",
     )
 }}
 -- Does a 30-day refresh on a normal day, and does a 90-day refresh every Saturday (for labels)


### PR DESCRIPTION
# Description

Solana jobs were taking to long which caused a Snowflake session auth token timeout. Additionally, coingecko nft job was broken due to an empty string instead of a value. This PR fixes both issues.

# Tests

Ran locally