### PR TITLE
Add distinct to near transactions and p2p token transfers

### DIFF
--- a/macros/p2p/p2p_token_transfers.sql
+++ b/macros/p2p/p2p_token_transfers.sql
@@ -137,7 +137,7 @@ with
                 {% endif %}
         )
     {% endif %}
-    select 
+    select distinct
         t1.block_timestamp,
         t1.block_number,
         t1.tx_hash,

--- a/models/staging/near/fact_near_transactions.sql
+++ b/models/staging/near/fact_near_transactions.sql
@@ -52,7 +52,7 @@ with
             >= (select dateadd('day', -7, max(block_timestamp)) from {{ this }})
         {% endif %}
     )
-select
+select distinct
     tx_hash,
     new_contracts.address as contract_address,
     block_timestamp,

--- a/models/staging/near/fact_near_transactions_v2.sql
+++ b/models/staging/near/fact_near_transactions_v2.sql
@@ -47,7 +47,7 @@ with
         left join collapsed_prices on raw_date = collapsed_prices.price_date
         where raw_date < to_date(sysdate()) and inserted_timestamp < to_date(sysdate())
     )
-select
+select distinct
     tx_hash,
     new_contracts.address as contract_address,
     block_timestamp,


### PR DESCRIPTION
# Description

Add a distinct to near transactions and p2p token transfers because flipside is providing us with duplicate rows.

# Tests

Ran locally. Full refresh has been ran on the fact_transactions and ez_transactions tables for near already.