### PR TITLE
Add fees to Onchain Explorer

### DIFF
--- a/models/data_hubs/fact_daily_onchainexplorer_datahub.sql
+++ b/models/data_hubs/fact_daily_onchainexplorer_datahub.sql
@@ -6,7 +6,8 @@ WITH last_30_days AS (
         chain,
         namespace,
         date,
-        dau
+        dau,
+        total_gas_usd
     FROM {{ ref('all_chains_gas_dau_txns_by_contract_v2') }}
     WHERE date >= DATEADD(DAY, -30, CURRENT_DATE)
 ),
@@ -28,7 +29,8 @@ aggregated AS (
         'application' AS type,
         chain,
         date,
-        SUM(dau) AS dau
+        SUM(dau) AS dau,
+        SUM(total_gas_usd) AS total_gas_usd
     FROM last_30_days_name_augmented
     WHERE namespace IS NOT NULL
     GROUP BY namespace, app_name, icon, chain, date
@@ -43,7 +45,8 @@ aggregated AS (
         'address' AS type,
         chain,
         date,
-        dau
+        dau,
+        total_gas_usd
     FROM last_30_days_name_augmented
     WHERE namespace IS NULL AND contract_address IS NOT NULL AND TRIM(contract_address) <> ''
 ),
@@ -70,7 +73,8 @@ final_aggregated AS (
         d.type,
         d.chain,
         d.date,
-        COALESCE(ag.dau, NULL) AS dau
+        COALESCE(ag.dau, NULL) AS dau,
+        COALESCE(ag.total_gas_usd, NULL) AS total_gas_usd
     FROM all_dates d
     LEFT JOIN aggregated ag 
         ON d.unique_id = ag.unique_id 
@@ -81,12 +85,13 @@ ranked_unique_ids AS (
         unique_id,
         chain,
         AVG(dau) AS avg_dau,
+        SUM(total_gas_usd) AS avg_total_gas_usd,
         ROW_NUMBER() OVER (
             PARTITION BY chain 
-            ORDER BY AVG(dau) DESC, unique_id
+            ORDER BY SUM(total_gas_usd) DESC, unique_id
         ) AS chain_rank,
         ROW_NUMBER() OVER (
-            ORDER BY AVG(dau) DESC, unique_id
+            ORDER BY SUM(total_gas_usd) DESC, unique_id
         ) AS global_rank
     FROM final_aggregated
     WHERE app_or_address IS NOT NULL AND app_or_address != 'Unlabeled'
@@ -114,6 +119,11 @@ clean_datahub AS (
         LAG(a.dau, 1) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_one_dau,
         LAG(a.dau, 7) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_seven_dau,
         LAG(a.dau, 29) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_thirty_dau,
+        a.total_gas_usd,
+        LAG(a.total_gas_usd, 0) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS latest_fees,
+        LAG(a.total_gas_usd, 1) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_one_fees,
+        LAG(a.total_gas_usd, 7) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_seven_fees,
+        LAG(a.total_gas_usd, 29) OVER (PARTITION BY a.app_or_address, a.chain ORDER BY date ASC) AS t_minus_thirty_fees,
         f.chain_rank,
         f.global_rank
     FROM final_aggregated a
@@ -124,6 +134,7 @@ grouped_stats AS (
         app_or_address,
         chain,
         AVG(dau) AS dau_30d_avg,
+        SUM(total_gas_usd) AS fees_30d_total,
         ARRAY_AGG(OBJECT_CONSTRUCT('date', date, 'val', COALESCE(dau, 0))) 
             WITHIN GROUP (ORDER BY date ASC) AS dau_30d_historical
     FROM clean_datahub
@@ -154,6 +165,23 @@ individual_stats AS (
             WHEN t_minus_thirty_dau IS NULL OR t_minus_thirty_dau = 0 THEN NULL
             ELSE (latest_dau - t_minus_thirty_dau) / t_minus_thirty_dau
         END AS dau_30d_change,
+        total_gas_usd,
+        latest_fees,
+        t_minus_one_fees,
+        t_minus_seven_fees,
+        t_minus_thirty_fees,
+        CASE
+            WHEN t_minus_one_fees IS NULL OR t_minus_one_fees = 0 THEN NULL
+            ELSE (latest_fees - t_minus_one_fees) / t_minus_one_fees
+        END AS fees_1d_change,
+        CASE
+            WHEN t_minus_seven_fees IS NULL OR t_minus_seven_fees = 0 THEN NULL
+            ELSE (latest_fees - t_minus_seven_fees) / t_minus_seven_fees
+        END AS fees_7d_change,
+        CASE
+            WHEN t_minus_thirty_fees IS NULL OR t_minus_thirty_fees = 0 THEN NULL
+            ELSE (latest_fees - t_minus_thirty_fees) / t_minus_thirty_fees
+        END AS fees_30d_change,
         chain_rank,
         global_rank
     FROM clean_datahub
@@ -161,6 +189,27 @@ individual_stats AS (
         PARTITION BY app_or_address, chain 
         ORDER BY date DESC
     ) = 1
+),
+fees_all_time AS (
+    SELECT
+        namespace AS app_or_address,
+        'application' AS type,
+        chain,
+        SUM(total_gas_usd) AS fees_total
+    FROM {{ ref('all_chains_gas_dau_txns_by_contract_v2') }}
+    WHERE namespace IS NOT NULL
+    GROUP BY namespace, chain
+
+    UNION ALL
+
+    SELECT
+        contract_address AS app_or_address,
+        'address' AS type,
+        chain,
+        SUM(total_gas_usd) AS fees_total
+    FROM {{ ref('all_chains_gas_dau_txns_by_contract_v2') }}
+    WHERE namespace IS NULL AND contract_address IS NOT NULL AND TRIM(contract_address) <> ''
+    GROUP BY contract_address, chain
 ),
 final_result AS (
     SELECT DISTINCT
@@ -176,12 +225,21 @@ final_result AS (
         s.dau_7d_change,
         s.dau_30d_change,
         gs.dau_30d_historical,
+        s.total_gas_usd AS fees,
+        gs.fees_30d_total,
+        s.fees_1d_change,
+        s.fees_7d_change,
+        s.fees_30d_change,
         s.chain_rank,
         s.global_rank
     FROM individual_stats s
     JOIN grouped_stats gs ON s.app_or_address = gs.app_or_address AND s.chain = gs.chain
 ) 
 SELECT DISTINCT 
-    CONCAT(app_or_address, '|', chain) AS unique_id,
-    *
-FROM final_result
+    CONCAT(s.app_or_address, '|', s.chain) AS unique_id,
+    s.*,
+    ft.fees_total
+FROM final_result s
+LEFT JOIN fees_all_time ft 
+    ON s.app_or_address = ft.app_or_address 
+        AND s.chain = ft.chain


### PR DESCRIPTION
# Description

Added fees to onchain explorer table. **We are now grabbing the top 10K rows sorted by most fees over the past 30 days**

Columns added:
fees -- this is fees collected today
fees_30d_total -- this is sum of fees over last 30 days
fees_1d_change -- this is fees 1 day change percentage
fees_7d_change -- this is fees 7 day change percentage
fees_30d_change -- this is fees 30 day change percentage
fees_total -- this is total fees collected all time

# Tests

Ran locally