### PR TITLE
Improve gold and silver agg table for stablecoins

### DIFF
--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_silver.sql
@@ -1,106 +1,64 @@
 {{ config(materialized="incremental", unique_key="unique_id", snowflake_warehouse="STABLECOIN_V2_LG") }}
+
+{% set chain_list = ['arbitrum', 'avalanche', 'base', 'bsc', 'celo', 'ethereum', 'mantle', 'optimism', 'polygon', 'solana', 'sui', 'ton', 'tron'] %}
+{% set list_stablecoin_address = var('list_stablecoin_address', ['0x085780639cc2cacd35e474e71f4d000e2405d8f6', '0x417ac0e078398c154edfadd9ef675d30be60af93']) %}
+{% set stablecoin_models = [] %}
+{% for chain in chain_list %}
+    {% do stablecoin_models.append(ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address")) %}
+    {% do stablecoin_models.append(ref("fact_" ~ chain ~ "_stablecoin_contracts")) %}
+{% endfor %}
+
 with
     daily_data as (
-        select *
-        from {{ref("ez_base_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_arbitrum_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_optimism_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_avalanche_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_polygon_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_ethereum_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_solana_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_tron_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_bsc_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_ton_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_celo_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_mantle_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-        union all
-        select *
-        from {{ref("ez_sui_stablecoin_metrics_by_address")}}
-        {% if is_incremental() %}
-            where date >= (select dateadd('day', -7, max(date)) from {{ this }})
-        {% endif %}
-    )
-select 
-    date
-    , from_address
-    , contract_name
-    , contract
-    , application
-    , icon
-    , app
-    , category
-    , is_wallet
+    {% if is_incremental() and list_stablecoin_address | length > 0 %}
+        -- If specific addresses exist, check if they exist in fact_<chain>_stablecoin_contracts before querying
+        {% for chain in chain_list %}
+            select *
+            from {{ ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address") }}
+            where lower (contract_address) IN (
+                select lower(contract_address)
+                from {{ ref("fact_" ~ chain ~ "_stablecoin_contracts") }}
+                where lower(contract_address) IN (
+                    {% for address in list_stablecoin_address %}
+                        lower('{{ address }}'){% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                )
+            )
+            {% if not loop.last %} union all {% endif %}
+        {% endfor %}
+    {% endif %}
+    {% if list_stablecoin_address | length == 0 %}
+        {% for chain in chain_list %}
+            select *
+            from {{ ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address") }}
+            {% if is_incremental() %}
+                where date >= (select dateadd('day', -7, max(date)) from {{ this }})
+            {% endif %}
+            {% if not loop.last %} union all {% endif %}
+        {% endfor %}
+    {% endif %}
+)
 
-    , contract_address
-    , symbol
-
-    , stablecoin_transfer_volume
-    , stablecoin_daily_txns
-    , artemis_stablecoin_transfer_volume
-    , artemis_stablecoin_daily_txns
-    , p2p_stablecoin_transfer_volume
-    , p2p_stablecoin_daily_txns
-    , stablecoin_supply
-    , chain
-    , unique_id
+select
+    date,
+    from_address,
+    contract_name,
+    contract,
+    application,
+    icon,
+    app,
+    category,
+    is_wallet,
+    contract_address,
+    symbol,
+    stablecoin_transfer_volume,
+    stablecoin_daily_txns,
+    artemis_stablecoin_transfer_volume,
+    artemis_stablecoin_daily_txns,
+    p2p_stablecoin_transfer_volume,
+    p2p_stablecoin_daily_txns,
+    stablecoin_supply,
+    chain,
+    unique_id
 from daily_data
 where date < to_date(sysdate())


### PR DESCRIPTION
Improve gold and silver table such that when I add new stablecoins, it doesn't need to full refresh, it just gets the full history for the specified stablecoin.
### Gold table:
<img width="1071" alt="Screenshot 2025-03-19 at 10 38 18 AM" src="https://github.com/user-attachments/assets/ef5e7903-b023-43a0-b588-5d2e9f89ae7b" />
### Silver table:
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/1fd7de58-13b5-485f-92a2-e9202b11775b" />

**note that silver table `date <= '2025-03-15'` is because the 2 tables are ran at different time, which will cause the different rows of events.**