### PR TITLE
add price handling for USDY in certificate form

### DIFF
--- a/macros/rwa/rwa_balances.sql
+++ b/macros/rwa/rwa_balances.sql
@@ -123,7 +123,7 @@ with
             , address
             , st.contract_address
             , st.symbol
-            , coalesce( d.price,
+            , coalesce( d.price, d2.price,
                     case 
                         when c.coingecko_id in (
                                 'blackrock-usd-institutional-digital-liquidity-fund', 
@@ -149,6 +149,12 @@ with
         ) d
             on lower(c.contract_address) = lower(d.contract_address)
             and st.date = d.date::date
+        left join (
+            {{get_multiple_coingecko_price_with_latest(chain)}}
+        ) d2
+            on lower(c.symbol) = lower(d2.symbol)
+            and lower(c.contract_address) != lower(d2.contract_address)
+            and st.date = d2.date::date
         left join {{ ref( "fact_hashnote_usyc_rate") }} h
             on st.date = h.date
             and st.symbol = 'USYC'

--- a/models/staging/arbitrum/fact_arbitrum_events.sql
+++ b/models/staging/arbitrum/fact_arbitrum_events.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="ARBITRUM_MD", materialized="incremental") }}
+
+{{ clean_flipside_evm_events('arbitrum') }}

--- a/models/staging/rwa/addresses/fact_ethereum_rwa_addresses.sql
+++ b/models/staging/rwa/addresses/fact_ethereum_rwa_addresses.sql
@@ -11,6 +11,7 @@ SELECT symbol, contract_address, num_decimals, coingecko_id, initial_supply FROM
             ('BUIDL', '0x7712c34205737192402172409a8f7ccef8aa2aec', 6, 'blackrock-usd-institutional-digital-liquidity-fund', 0),
             ('OUSG', '0x1b19c19393e2d034d8ff31ff34c81252fcbbee92', 18, 'ousg', 0),
             ('USDY', '0x96f6ef951840721adbf46ac996b59e0235cb985c', 18, 'ondo-us-dollar-yield', 0),
+            ('USDY', '0xe86845788d6e3e5c2393ade1a051ae617d974c09', 18, 'ondo-us-dollar-yield', 0),
             ('USYC', '0x136471a34f6ef19fe571effc1ca711fdb8e49f2b', 6, 'hashnote-usyc', 0),
             ('PAXG', '0x45804880de22913dafe09f4980848ece6ecbaf78', 18, 'pax-gold', 0),
             ('XAUT', '0x68749665ff8d2d112fa859aa293f07a622782f38', 6, 'tether-gold', 0),


### PR DESCRIPTION
- Quick change to the pricing data for RWA balances
- TLDR is USDY is actually 2 tokens, one that circulates and is held by users, and one that is held centrally in certificate form for a period of time before it can be received by end users. We were not tracking the certificate for of USDY. 
- Since coingecko does not support that specific contract address, I added an additional join for the case when the symbols match but the contract addresses do not. 

Notes:
- The pricing around RWAs is getting a bit unwieldy and the query is becoming complicated to read and debug, need to come up with a better solution to this pricing data
- We are still missing tracking of USDY across Sui, Aptos and Noble

Our values are now much more in line with the expected values:
![CleanShot 2025-03-19 at 23 37 24@2x](https://github.com/user-attachments/assets/0335af8a-0c88-46c6-b553-943e981d50d3)

![CleanShot 2025-03-19 at 23 38 13@2x](https://github.com/user-attachments/assets/e4ae33b9-19f8-4abd-a788-8798fdab35fe)



