### PR TITLE
Fix types in polygon_zk fact table

### DIFF
--- a/models/staging/polygon_zk/fact_polygon_zk_daa_txns_gas_usd.sql
+++ b/models/staging/polygon_zk/fact_polygon_zk_daa_txns_gas_usd.sql
@@ -13,8 +13,8 @@ with
     , extracted_data as (
         select
             date(left(value:"date_time"::string, 10)) as date,
-            value:unique_active_users as daa,
-            value:all_transactions as txns,
+            value:unique_active_users::number as daa,
+            value:all_transactions::number as txns,
             value:txn_fees::double as gas,
             value as source,
             'polygon_zk' as chain


### PR DESCRIPTION
## :pushpin: References

- `txns` and `dau` within Polygon ZK ez_metrics table were both VARIANT type
- Casting to `NUMBER` so we can Iceberg-ify the table
<img width="687" alt="image" src="https://github.com/user-attachments/assets/fe2a343a-8a58-4341-ba0e-a64be87a2bb0" />


## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [ ] Any other relevant information that may be helpful