### PR TITLE
Add columns to across model

### DIFF
--- a/models/staging/across/fact_across_complete_transfers.sql
+++ b/models/staging/across/fact_across_complete_transfers.sql
@@ -86,7 +86,9 @@ SELECT
     , recipient
     , destination_chain_id
     , destination_token
+    , dst_message
     , dst_chain
+    , deposit_id
     , protocol_fee
     , bridge_message_app
     , version


### PR DESCRIPTION
# Description

`fact_across_complete_transfers` was missing 2 columns which caused `ez_across_transfers` to break. 

# Tests

Ran locally