### PR TITLE
add arb/avax decoded events + use chain specific warehouse

### DIFF
--- a/models/staging/arbitrum/fact_arbitrum_decoded_events.sql
+++ b/models/staging/arbitrum/fact_arbitrum_decoded_events.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="ARBITRUM_LG", materialized="incremental") }}
+
+{{ decode_artemis_events('arbitrum') }}

--- a/models/staging/arbitrum/fact_arbitrum_events.sql
+++ b/models/staging/arbitrum/fact_arbitrum_events.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="ARBITRUM_MD", materialized="incremental") }}
+
+{{ clean_flipside_evm_events('arbitrum') }}

--- a/models/staging/avalanche/fact_avalanche_decoded_events.sql
+++ b/models/staging/avalanche/fact_avalanche_decoded_events.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="AVALANCHE_LG", materialized="incremental") }}
+
+{{ decode_artemis_events('arbitrum') }}

--- a/models/staging/avalanche/fact_avalanche_events.sql
+++ b/models/staging/avalanche/fact_avalanche_events.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="AVALANCHE_MD", materialized="incremental") }}
+
+{{ clean_flipside_evm_events('avalanche') }}

--- a/models/staging/base/fact_base_decoded_events.sql
+++ b/models/staging/base/fact_base_decoded_events.sql
@@ -1,3 +1,3 @@
-{{ config(snowflake_warehouse="ETHEREUM_LG", materialized="incremental") }}
+{{ config(snowflake_warehouse="BASE_LG", materialized="incremental") }}
 
 {{ decode_artemis_events('base') }}


### PR DESCRIPTION
Arbitrum sample:
![CleanShot 2025-03-21 at 16 24 59@2x](https://github.com/user-attachments/assets/98f84110-1497-4cbf-8bcd-e4d27b1884c2)


Avalanche sample:
![CleanShot 2025-03-21 at 16 25 48@2x](https://github.com/user-attachments/assets/809b2940-43bb-4fb5-a1bc-952096f62396)

