### PR TITLE
fix decimals + ff pricing

### DIFF
--- a/macros/rwa/rwa_balances.sql
+++ b/macros/rwa/rwa_balances.sql
@@ -123,7 +123,7 @@ with
             , address
             , st.contract_address
             , st.symbol
-            , coalesce( d.price, d2.price,
+            , coalesce( d.price,
                     case 
                         when c.coingecko_id in (
                                 'blackrock-usd-institutional-digital-liquidity-fund', 
@@ -137,7 +137,12 @@ with
                             then o.price
                         when c.coingecko_id = 'openeden-tbill'
                             then tbill.price
-                    end
+                        when st.contract_address = '0xe86845788d6e3e5c2393ade1a051ae617d974c09'
+                            then d2.price
+                                        end,
+                    FIRST_VALUE(d.price IGNORE NULLS) OVER (PARTITION BY st.contract_address ORDER BY st.date ASC
+                    ROWS BETWEEN UNBOUNDED PRECEDING
+                    AND CURRENT ROW)
             ) as price_adj
             , rwa_supply_native
             , rwa_supply_native * price_adj as rwa_supply_usd

--- a/models/staging/rwa/addresses/fact_ethereum_rwa_addresses.sql
+++ b/models/staging/rwa/addresses/fact_ethereum_rwa_addresses.sql
@@ -18,6 +18,6 @@ SELECT symbol, contract_address, num_decimals, coingecko_id, initial_supply FROM
             ('TBILL', '0xdd50c053c096cb04a3e3362e2b622529ec5f2e8a', 6, 'openeden-tbill', 0),
             ('FOBXX', '0x3ddc84940ab509c11b20b76b466933f40b750dc9', 18, 'franklin-onchain-u-s-government-money-fund', 0),
             ('WTGXX', '0x1fecf3d9d4fee7f2c02917a66028a48c6706c179', 18, 'wisdomtree-government-money-market-digital-fund', 0),
-            ('USTB', '0x43415eb6ff9db7e26a15b704e7a3edce97d31c4e', 18, 'superstate-short-duration-us-government-securities-fund-ustb', 0),
-            ('USTBL', '0xe4880249745eac5f1ed9d8f7df844792d560e750', 18, 'spiko-us-t-bills-money-market-fund', 0)
+            ('USTB', '0x43415eb6ff9db7e26a15b704e7a3edce97d31c4e', 6, 'superstate-short-duration-us-government-securities-fund-ustb', 0),
+            ('USTBL', '0xe4880249745eac5f1ed9d8f7df844792d560e750', 5, 'spiko-us-t-bills-money-market-fund', 0)
     ) as results(symbol, contract_address, num_decimals, coingecko_id, initial_supply)


### PR DESCRIPTION
Fixed a couple issues with RWA pricing data:
1. Decimals were incorrect for USTB and USBTL.
2. Added forward fill mechanism for when coingecko realtime data does not exist for a certain ticker.