### PR TITLE
fix aero by chain

### DIFF
--- a/models/projects/aerodrome/core/ez_aerodrome_metrics_by_chain.sql
+++ b/models/projects/aerodrome/core/ez_aerodrome_metrics_by_chain.sql
@@ -40,24 +40,23 @@ with swap_metrics as (
         and to_date(sysdate())
 )
 SELECT
-    ds.date,
-    'base' as chain,
+    ds.date
+    , 'base' as chain
 
     -- Old metrics needed for compatibility
-    sm.unique_traders,
-    sm.total_swaps,
-    sm.daily_volume_usd as trading_volume,
-    sm.daily_fees_usd as trading_fees,
-    tm.tvl_usd as tvl
+    , sm.unique_traders
+    , sm.total_swaps
+    , sm.daily_volume_usd as trading_volume
+    , sm.daily_fees_usd as trading_fees
 
     -- Standardized Metrics
-    sm.unique_traders as spot_dau,
-    sm.total_swaps as spot_txns,
-    sm.daily_volume_usd as spot_volume,
-    sm.daily_fees_usd as spot_fees,
-    sm.daily_fees_usd as gross_protocol_revenue,
-    sm.daily_fees_usd as fee_sharing_token_cash_flow,
-    tm.tvl_usd as tvl
+    , sm.unique_traders as spot_dau
+    , sm.total_swaps as spot_txns
+    , sm.daily_volume_usd as spot_volume
+    , sm.daily_fees_usd as spot_fees
+    , sm.daily_fees_usd as gross_protocol_revenue
+    , sm.daily_fees_usd as fee_sharing_token_cash_flow
+    , tm.tvl_usd as tvl
 
 FROM date_spine ds
 LEFT JOIN swap_metrics sm using (date)


### PR DESCRIPTION
Fix for Aerodrome ez metric by chain. Error was that there was a missing comma but also there was a duplicate column name. 