### PR TITLE
use a date spine and cast to number

### DIFF
--- a/models/staging/hyperliquid/fact_hyperliquid_unique_traders.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_unique_traders.sql
@@ -8,7 +8,7 @@ with
 
     extracted_unique_traders as (
         select
-            value:daily_unique_users as unique_traders,
+            value:daily_unique_users::number as unique_traders,
             'hyperliquid' as app,
             'hyperliquid' as chain,
             'DeFi' as category,


### PR DESCRIPTION
use a date spine so stale data in one part of the pipeline does not affect the rest of the pipeline.