### PR TITLE
Add global workflow to labeling pipeline

### DIFF
--- a/models/dimensions/labeling/_test_dim_all_addresses_labeled_silver.yml
+++ b/models/dimensions/labeling/_test_dim_all_addresses_labeled_silver.yml
@@ -19,7 +19,7 @@ models:
       tests:
         - dbt_expectations.expect_column_to_exist
         - dbt_expectations.expect_column_values_to_be_in_set:
-            value_set: ['pool', 'treasury', 'stake_pool']
+            value_set: ['pool', 'treasury', 'stake_pool', 'perps_pool']
             quote_values: true
             where: "type is not null"
     - name: last_updated

--- a/models/dimensions/labeling/_test_dim_all_addresses_labeled_silver.yml
+++ b/models/dimensions/labeling/_test_dim_all_addresses_labeled_silver.yml
@@ -12,9 +12,16 @@ models:
       tests:
         - dbt_expectations.expect_column_to_exist
     - name: chain
-      tess:
+      tests:
         - not_null
         - dbt_expectations.expect_column_to_exist
+    - name: type
+      tests:
+        - dbt_expectations.expect_column_to_exist
+        - dbt_expectations.expect_column_values_to_be_in_set:
+            value_set: ['pool', 'treasury', 'stake_pool']
+            quote_values: true
+            where: "type is not null"
     - name: last_updated
       tests:
         - not_null

--- a/models/dimensions/labeling/_test_dim_all_addresses_silver.yml
+++ b/models/dimensions/labeling/_test_dim_all_addresses_silver.yml
@@ -9,7 +9,7 @@ models:
         - not_null
         - dbt_expectations.expect_column_to_exist
     - name: chain
-      tess:
+      tests:
         - not_null
         - dbt_expectations.expect_column_to_exist
     - name: last_updated

--- a/models/dimensions/labeling/dim_all_addresses_labeled_silver.sql
+++ b/models/dimensions/labeling/dim_all_addresses_labeled_silver.sql
@@ -94,8 +94,7 @@ global_labaled_automatic_table AS (
         COALESCE(a.is_token, dmla.is_token) AS is_token,
         COALESCE(a.is_fungible, dmla.is_fungible) AS is_fungible,
         COALESCE(a.type, dmla.type) AS type,
-        COALESCE(dmla.last_updated_timestamp, a.last_updated) AS last_updated,
-        dmla.last_updated_by
+        COALESCE(dmla.last_updated, a.last_updated) AS last_updated
     FROM labeled_automatic_table a
     FULL OUTER JOIN {{ ref("dim_global_labeled_addresses")}} dmla
         ON LOWER(a.address) = LOWER(dmla.address) AND a.chain = dmla.chain

--- a/models/dimensions/labeling/dim_all_addresses_labeled_silver.sql
+++ b/models/dimensions/labeling/dim_all_addresses_labeled_silver.sql
@@ -84,7 +84,7 @@ deduped_deleted_manual_labeled_addresses AS (
     {% endif %}
     QUALIFY ROW_NUMBER() OVER (PARTITION BY address, chain ORDER BY last_updated_timestamp DESC) = 1
 ),
-global_labaled_automatic_table AS (
+global_labeled_automatic_table AS (
     SELECT
         COALESCE(dmla.address, a.address) AS address,
         COALESCE(dmla.name, a.name) AS name,
@@ -111,7 +111,7 @@ full_labeled_automatic_table AS (
         COALESCE(a.type, dmla.type) AS type,
         COALESCE(dmla.last_updated_timestamp, a.last_updated) AS last_updated,
         dmla.last_updated_by
-    FROM global_labaled_automatic_table a
+    FROM global_labeled_automatic_table a
     FULL OUTER JOIN deduped_added_manual_labeled_addresses dmla
         ON LOWER(a.address) = LOWER(dmla.address) AND a.chain = dmla.chain
 ), 

--- a/models/dimensions/labeling/dim_global_labeled_addresses.sql
+++ b/models/dimensions/labeling/dim_global_labeled_addresses.sql
@@ -1,0 +1,16 @@
+{{
+    config( 
+        materialized="table"
+    )
+}}
+
+SELECT 
+    address,
+    name,
+    artemis_application_id,
+    chain,
+    is_token,
+    is_fungible,
+    type,
+    last_updated
+FROM {{ ref("fact_jitosol_stake_accounts") }}

--- a/models/staging/jito/fact_jitosol_stake_accounts.sql
+++ b/models/staging/jito/fact_jitosol_stake_accounts.sql
@@ -37,7 +37,7 @@ WITH all_stake_accounts AS (
 
 SELECT 
     DISTINCT stake_account as address
-    , NULL as name,
+    , NULL as name
     , 'jito' as artemis_application_id
     , 'solana' as chain
     , NULL as is_token

--- a/models/staging/jito/fact_jitosol_stake_accounts.sql
+++ b/models/staging/jito/fact_jitosol_stake_accounts.sql
@@ -1,7 +1,8 @@
 {{
     config( 
         materialized="incremental",
-        snowflake_warehouse="JITO"
+        snowflake_warehouse="JITO",
+        unique_key="address"
     )
 }}
 
@@ -16,22 +17,31 @@ WITH all_stake_accounts AS (
             WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '09' THEN instruction:accounts[5]::STRING -- depositStake (deposited stake)
             WHEN LEFT(BASE58_TO_HEX(instruction:data), 2) = '15' THEN instruction:accounts[8]::STRING -- redelegate (destination validator stake)
         END AS stake_account,
-        tx_id,
-        sysdate() AS last_updated
+        tx_id
     FROM
         {{ source('SOLANA_FLIPSIDE', 'fact_events') }}
     WHERE 1=1
         AND contains(instruction:accounts, '6iQKfEyhr3bZMotVkW6beNZz5CPAkiwvgV2CTje9pVSS') -- Jito Stake Pool Authority
         AND program_id = 'SPoo1Ku8WFXoNDMHPsrGSTSG1Y47rzgn41SLUNakuHy'
         AND LEFT(BASE58_TO_HEX(instruction:data), 2) IN ('01', '03', '04', '09', '15') -- Filter only relevant instructions
-
+        {% if is_incremental() %}
+            AND block_timestamp >= (select dateadd('day', -1, max(last_updated)) from {{ this }})
+        {% endif %}
     UNION ALL
 
     -- Explicitly add the reserve stake account
     SELECT
         'BgKUXdS29YcHCFrPm5M8oLHiTzZaMDjsebggjoaQ6KFL' AS stake_account, -- Reserve Stake Account
-        NULL AS tx_id,
-        sysdate() AS last_updated
+        NULL AS tx_id
 )
 
-SELECT DISTINCT stake_account FROM all_stake_accounts
+SELECT 
+    DISTINCT stake_account as address
+    , NULL as name,
+    , 'jito' as artemis_application_id
+    , 'solana' as chain
+    , NULL as is_token
+    , NULL as is_fungible
+    , 'stake_pool' as type
+    , SYSDATE()::TIMESTAMP_NTZ as last_updated
+FROM all_stake_accounts

--- a/models/staging/jito/fact_jitosol_tvl.sql
+++ b/models/staging/jito/fact_jitosol_tvl.sql
@@ -5,4 +5,4 @@
     )
 }}
 
-{{get_entity_historical_balance(chain='solana', table_name='fact_jitosol_stake_accounts', address_column='stake_account', earliest_date='2022-10-24')}}
+{{get_entity_historical_balance(chain='solana', table_name='fact_jitosol_stake_accounts', address_column='address', earliest_date='2022-10-24')}}


### PR DESCRIPTION
# Description

Add workflow to integrate addresses derived from protocols into labeling system so that downstream TVL, balances, and other metric calculations can pull from the addresses within the labels table.

# Tests

Tested locally