### PR TITLE
Akhil/bitcoin dex volumes

### DIFF
--- a/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
+++ b/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
@@ -50,6 +50,12 @@ with
             sum(cumulative_etf_flow) as cumulative_etf_flow
         FROM {{ ref("ez_bitcoin_etf_metrics") }}
         GROUP BY 1
+    ), 
+    bitcoin_dex_volumes as (
+        SELECT
+            date,
+            volume_usd as dex_volumes
+        FROM {{ ref("fact_bitcoin_dex_volumes") }}
     )
 select
     fundamental_data.date
@@ -65,7 +71,7 @@ select
     , issuance
     , circulating_supply
     , nft_trading_volume
-    , dex_volumes
+    , bitcoin_dex_volumes.dex_volumes
     -- Standardized Metrics
     -- Market Data Metrics
     , price
@@ -79,7 +85,7 @@ select
     , txns AS chain_txns
     , avg_txn_fee AS chain_avg_txn_fee
     , nft_trading_volume AS chain_nft_trading_volume
-    , dex_volumes AS chain_dex_volumes
+    , bitcoin_dex_volumes.dex_volumes AS chain_dex_volumes
     -- Cashflow metrics
     , fees_native AS gross_protocol_revenue_native
     , fees AS gross_protocol_revenue
@@ -104,4 +110,5 @@ left join github_data on fundamental_data.date = github_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join etf_metrics on fundamental_data.date = etf_metrics.date
+left join bitcoin_dex_volumes on fundamental_data.date = bitcoin_dex_volumes.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/bitcoin/__bitcoin__sources.yml
+++ b/models/staging/bitcoin/__bitcoin__sources.yml
@@ -15,6 +15,8 @@ sources:
       - name: raw_bitcoin_etf_metadata
       - name: raw_bitcoin_fidelity_outflows
       - name: raw_etf_update_thresholds
+      - name: raw_bisq_daily_volume 
+      - name: raw_lnexchange_daily_volume
 
   - name: BITCOIN_FLIPSIDE
     schema: core
@@ -22,3 +24,9 @@ sources:
     tables:
       - name: fact_outputs
       - name: fact_inputs
+
+  - name: BITCOIN_FLIPSIDE_PRICE
+    schema: price
+    database: bitcoin_flipside
+    tables:
+      - name: ez_prices_hourly

--- a/models/staging/bitcoin/fact_bitcoin_dex_volumes.sql
+++ b/models/staging/bitcoin/fact_bitcoin_dex_volumes.sql
@@ -1,0 +1,36 @@
+with
+    bisq as (
+        with max_extraction as (
+            select max(extraction_date) as max_date
+            from {{ source('PROD_LANDING', 'raw_bisq_daily_volume') }}
+        )
+        select
+            value:date::date as date,
+            value:volume_btc::float as bisq_volume_btc
+        from
+            {{ source('PROD_LANDING', 'raw_bisq_daily_volume') }},
+            lateral flatten(input => parse_json(source_json))
+        where extraction_date = (select max_date from max_extraction)
+    ),
+    lnexchange as (
+        with max_extraction as (
+            select max(extraction_date) as max_date
+            from {{ source('PROD_LANDING', 'raw_lnexchange_daily_volume') }}
+        )
+        select
+            value:date::date as date,
+            value:volume_usd::number as lnexchange_volume
+        from
+            {{ source('PROD_LANDING', 'raw_lnexchange_daily_volume') }},
+            lateral flatten(input => parse_json(source_json))
+        where extraction_date = (select max_date from max_extraction)
+    )
+select
+    coalesce(bisq.date, lnexchange.date) as date,
+    (coalesce(bisq.bisq_volume_btc, 0) * eph.price) + coalesce(lnexchange_volume, 0) as volume_usd
+from bisq
+full join lnexchange on bisq.date = lnexchange.date
+left join {{source('BITCOIN_FLIPSIDE_PRICE', 'ez_prices_hourly')}} eph 
+    on bisq.date = eph.hour and lower(eph.symbol) = 'btc'
+where eph.name = 'bitcoin'
+order by date desc


### PR DESCRIPTION
… and Bitcoin sources accordingly

## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [X] Add any relevant data screenshots below

<img width="784" alt="Screenshot 2025-04-12 at 5 41 32 PM" src="https://github.com/user-attachments/assets/6fd80bfd-77dc-440d-a41c-8c911d233d6a" />
<img width="784" alt="Screenshot 2025-04-12 at 5 41 43 PM" src="https://github.com/user-attachments/assets/cb92f2d5-2219-4e90-906a-cee02e1dbef5" />
<img width="784" alt="Screenshot 2025-04-12 at 5 41 57 PM" src="https://github.com/user-attachments/assets/42a72d27-b8fe-4cf8-8446-68c7fc11f119" />

We have higher volumes from the beginning of 2025, but the rest of the data matches perfectly.

## Other

- [ ] Any other relevant information that may be helpful