### PR TITLE
Add clustering on fact_arbitrum_transactions_v2

### DIFF
--- a/models/staging/arbitrum/fact_arbitrum_transactions_v2.sql
+++ b/models/staging/arbitrum/fact_arbitrum_transactions_v2.sql
@@ -3,6 +3,7 @@
         materialized="incremental",
         unique_key="tx_hash",
         snowflake_warehouse="BAM_TRANSACTION_XLG",
+        cluster_by=["TO_DATE(block_timestamp)", "app"],
     )
 }}
 


### PR DESCRIPTION
## :pushpin: References
- Enable table clustering on `(to_date(block_timestamp), app)` for `fact_arbitrum_transactions_v2`
- Ran `alter table fact_arbitrum_transactions_v2 CLUSTER BY (to_date(block_timestamp), app);`
- Executed incremental run 
<img width="688" alt="image" src="https://github.com/user-attachments/assets/1e42dd8a-90df-45fb-8636-1dc792d3d307" />


## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [ ] Any other relevant information that may be helpful