### PR TITLE
Fix eth block rewards native

### DIFF
--- a/models/staging/ethereum/fact_ethereum_amount_staked_silver.sql
+++ b/models/staging/ethereum/fact_ethereum_amount_staked_silver.sql
@@ -1,19 +1,42 @@
 {{ config(snowflake_warehouse="ETHEREUM_XS", materialized="table") }}
 with
+    min_date as (
+        select min(to_date(slot_timestamp)) as start_date
+        from ethereum_flipside.beacon_chain.fact_blocks
+    ),
+    date_spine as (
+        select
+            dateadd(
+                day,
+                row_number() over (order by seq4()) - 1,
+                (select start_date from min_date)
+            ) as date
+        from table(generator(rowcount => 10000))
+        qualify date <= dateadd(day, -1, current_date())
+    ),
     prices as ({{ get_coingecko_price_with_latest("ethereum") }}),
     staking_data as (
         select t1.slot_number, t2.slot_timestamp, sum(balance) as balance
         from ethereum_flipside.beacon_chain.fact_validator_balances t1
-        left join
-            ethereum_flipside.beacon_chain.fact_blocks t2
+        left join ethereum_flipside.beacon_chain.fact_blocks t2
             on t1.slot_number = t2.slot_number
         group by t1.slot_number, t2.slot_timestamp
     ),
-    amount_staked as (
+    raw_amount_staked as (
         select to_date(slot_timestamp) as date, avg(balance) as total_staked_native
         from staking_data
         group by date
-        order by date
+    ),
+    amount_staked as (
+        select
+            ds.date,
+            LAST_VALUE(ras.total_staked_native ignore nulls) over (
+                order by ds.date
+                rows between unbounded preceding and current row
+            ) as total_staked_native
+        from date_spine ds
+        left join raw_amount_staked ras
+            on ds.date = ras.date
     )
 select
     amount_staked.date,


### PR DESCRIPTION
Native block rewards:
BG:
We don't have every slot number in `fact_validator_balances` in `fact_blocks`.
Because we read it everyday instead of every slot number.
Hence:
To fill NULL balances, I decided to forward fill
Reasons:
1. The margin of error here is less 0.01% which I think is reasonable to forgo
2. ETH staking wouldn't change much for a day, due to how it works, where there is a limited number of amount being able to stake each day, and there is a queue. In reality there wouldn't be much changes within a 24hour period.

What changes were made:
![image](https://github.com/user-attachments/assets/62764094-79f6-4b1d-bf7c-bba74f6c1cfc)
![image](https://github.com/user-attachments/assets/530062f8-4064-4007-994a-0f0774c810bd)
![image](https://github.com/user-attachments/assets/c083fdd4-2524-46c8-b5eb-14ccca70a333)

Now we forward fill balances for each date. Created a Date spine to support this change as well.
