### PR TITLE
Benchmark data lag 1 day to match stablecoin data

### DIFF
--- a/models/projects/ach/core/ez_ach_metrics.sql
+++ b/models/projects/ach/core/ez_ach_metrics.sql
@@ -97,7 +97,7 @@ last_value as (
 extended_date_boundaries as (
     select 
         (select max(date) + 1 from final_result) as min_date,
-        current_date() as max_date
+        dateadd(day, -1, current_date()) as max_date
 ),
 -- Create sequence for extrapolated date range
 extrapolation_sequence as (

--- a/models/projects/fedwire/core/ez_fedwire_metrics.sql
+++ b/models/projects/fedwire/core/ez_fedwire_metrics.sql
@@ -77,7 +77,7 @@ last_value as (
 extended_date_boundaries as (
     select 
         (select max(date) + 1 from final_result) as min_date,
-        current_date() as max_date
+        dateadd(day, -1, current_date()) as max_date
 ),
 -- Create sequence for extrapolated date range
 extrapolation_sequence as (

--- a/models/projects/paypal/core/ez_paypal_metrics.sql
+++ b/models/projects/paypal/core/ez_paypal_metrics.sql
@@ -84,7 +84,7 @@ last_value as (
 extended_date_boundaries as (
     select 
         (select max(date) + 1 from final_result) as min_date,
-        current_date() as max_date
+        dateadd(day, -1, current_date()) as max_date
 ),
 -- Create sequence for extrapolated date range
 extrapolation_sequence as (

--- a/models/projects/remittance/core/ez_remittance_metrics.sql
+++ b/models/projects/remittance/core/ez_remittance_metrics.sql
@@ -84,7 +84,7 @@ last_value as (
 extended_date_boundaries as (
     select 
         (select max(date) + 1 from final_result) as min_date,
-        current_date() as max_date
+        dateadd(day, -1, current_date()) as max_date
 ),
 -- Create sequence for extrapolated date range
 extrapolation_sequence as (

--- a/models/projects/visa/core/ez_visa_metrics.sql
+++ b/models/projects/visa/core/ez_visa_metrics.sql
@@ -97,7 +97,7 @@ last_value as (
 extended_date_boundaries as (
     select 
         (select max(date) + 1 from final_result) as min_date,
-        current_date() as max_date
+        dateadd(day, -1, current_date()) as max_date
 ),
 -- Create sequence for extrapolated date range
 extrapolation_sequence as (


### PR DESCRIPTION
Context:
- FE will look abit buggy since the benchmark data returns today's value but stablecoin returns yesterday's value as max.
Solution:
- Lag the max day for the forward fill by 1, so its align to stablecoin data max date.

What I have done:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/9c5cb6cc-4e63-4e8f-bd22-93231384ce4e" />
<img width="442" alt="image" src="https://github.com/user-attachments/assets/8abd6fe1-3c7b-42b8-a63c-7346cdf73d09" />
