### PR TITLE
Update recent values tests for contracts and solana issuance

### DIFF
--- a/models/metrics/contracts/_test_fact_arbitrum_contracts.yml
+++ b/models/metrics/contracts/_test_fact_arbitrum_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_avalanche_contracts.yml
+++ b/models/metrics/contracts/_test_fact_avalanche_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_base_contracts.yml
+++ b/models/metrics/contracts/_test_fact_base_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_blast_contracts.yml
+++ b/models/metrics/contracts/_test_fact_blast_contracts.yml
@@ -23,5 +23,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
               severity: warn

--- a/models/metrics/contracts/_test_fact_bsc_contracts.yml
+++ b/models/metrics/contracts/_test_fact_bsc_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_ethereum_contracts.yml
+++ b/models/metrics/contracts/_test_fact_ethereum_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_linea_contracts.yml
+++ b/models/metrics/contracts/_test_fact_linea_contracts.yml
@@ -23,5 +23,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
               severity: warn

--- a/models/metrics/contracts/_test_fact_optimism_contracts.yml
+++ b/models/metrics/contracts/_test_fact_optimism_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_polygon_contracts.yml
+++ b/models/metrics/contracts/_test_fact_polygon_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/metrics/contracts/_test_fact_scroll_contracts.yml
+++ b/models/metrics/contracts/_test_fact_scroll_contracts.yml
@@ -23,5 +23,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
               severity: warn

--- a/models/metrics/contracts/_test_fact_zora_contracts.yml
+++ b/models/metrics/contracts/_test_fact_zora_contracts.yml
@@ -23,5 +23,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
               severity: warn

--- a/models/staging/near/_test_fact_near_contracts.yml
+++ b/models/staging/near/_test_fact_near_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/staging/solana/_test_fact_solana_contracts.yml
+++ b/models/staging/solana/_test_fact_solana_contracts.yml
@@ -23,5 +23,5 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 7
         severity: warn

--- a/models/staging/solana/_test_fact_solana_issuance_silver.yml
+++ b/models/staging/solana/_test_fact_solana_issuance_silver.yml
@@ -15,7 +15,7 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 5
               severity: warn
       - name: issuance
         tests:


### PR DESCRIPTION
## Summary
- Data is written actually at the weekly granularity so the tests were misconfigured
- Solana epochs aren't mapped cleanly to dates so pushing back the test to fail after 5 days instead of 3