### PR TITLE
gains v8 v9 volume and traders

### DIFF
--- a/models/__global__schema.yml
+++ b/models/__global__schema.yml
@@ -192,8 +192,6 @@ column_definitions:
       description: "The average cost per MiB of data stored in blobs on a chain in USD"
     - name: submitters
       description: "The number of submitters on a chain"
-    - name: chain_dex_volume
-      description: "The total volume of DEXes on a chain"
     - name: chain_avg_block_time
       description: "The average time it takes to produce a block on a chain"
     - name: chain_avg_tps

--- a/models/projects/gains_network/core/ez_gains_network_metrics.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics.sql
@@ -20,8 +20,20 @@ with date_spine as (
 )
 
     , gains_data as (
-        select date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders
-        from {{ ref("fact_gains_trading_volume_unique_traders") }}
+        with agg as (
+            select date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders
+            from {{ ref("fact_gains_trading_volume_unique_traders") }} -- V7
+            group by date
+            UNION ALL
+            SELECT date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders
+            from {{ ref("fact_gains_data_v8_v9") }} -- V8 and V9
+            group by date
+        )
+        SELECT
+            date
+            , sum(trading_volume) as trading_volume
+            , sum(unique_traders) as unique_traders
+        FROM agg
         group by date
     )
     , gains_fees as (

--- a/models/projects/gains_network/core/ez_gains_network_metrics_by_chain.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics_by_chain.sql
@@ -10,9 +10,20 @@
 
 with 
     gains_data as (
-        select date, trading_volume, unique_traders, chain
-        from {{ ref("fact_gains_trading_volume_unique_traders") }}
-        where chain is not null
+        with agg as (
+            select date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders, chain
+            from {{ ref("fact_gains_trading_volume_unique_traders") }}
+            where chain is not null
+            group by date, chain
+            UNION ALL
+            SELECT date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders, chain
+            from {{ ref("fact_gains_data_v8_v9") }}
+            where chain is not null
+            group by date, chain
+        )
+        select date, sum(trading_volume) as trading_volume, sum(unique_traders) as unique_traders, chain
+        from agg
+        group by date, chain
     )
 
 select

--- a/models/staging/gains/__gains__sources.yml
+++ b/models/staging/gains/__gains__sources.yml
@@ -4,3 +4,4 @@ sources:
     database: LANDING_DATABASE
     tables:
       - name: raw_gains_fees
+      - name: raw_gains_trading_volume_unique_traders_v8_v9

--- a/models/staging/gains/fact_gains_data_v8_v9.sql
+++ b/models/staging/gains/fact_gains_data_v8_v9.sql
@@ -1,0 +1,23 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="GAINS_NETWORK",
+     )
+}}
+
+
+with max_extraction as (
+    select max(extraction_date) as max_date
+    from {{ source("PROD_LANDING", "raw_gains_trading_volume_unique_traders_v8_v9") }}
+)
+select
+    value:date as date,
+    value:chain as chain,
+    'gains_network' as app,
+    'DeFi' as category,
+    value:trading_volume as trading_volume,
+    value:unique_traders as unique_traders,
+    value:count_trades as count_trades
+from {{ source("PROD_LANDING", "raw_gains_trading_volume_unique_traders_v8_v9") }}
+, lateral flatten(input => parse_json(source_json))
+where extraction_date = (select max_date from max_extraction)


### PR DESCRIPTION
Test Plan:

Dagster extract runs successfully. ✅ 
All models compile. ✅ 
Data looks good ✅ 

![CleanShot 2025-04-21 at 09 38 38@2x](https://github.com/user-attachments/assets/b5bc0a47-0a47-4409-abc3-101fdf017dd8)


Note: filtered `fact_gains_trading_volume_unique_traders` by `where chain is not null` in the ez metrics query to make sure we don't double count. 

