### PR TITLE
Added debridge metadata

### DIFF
--- a/models/staging/debridge/__debridge__sources.yml
+++ b/models/staging/debridge/__debridge__sources.yml
@@ -4,4 +4,5 @@ sources:
     database: LANDING_DATABASE
     tables:
       - name: raw_debridge_orders
+      - name: raw_debridge_order_metadata
       - name: dln_orders_backfil_csv

--- a/models/staging/debridge/_test_fact_debridge_metadata.yml
+++ b/models/staging/debridge/_test_fact_debridge_metadata.yml
@@ -1,0 +1,7 @@
+models:
+  - name: fact_debridge_order_metadata
+    columns:
+      - name: order_id
+        tests:
+          - not_null
+          - unique

--- a/models/staging/debridge/fact_debridge_order_metadata.sql
+++ b/models/staging/debridge/fact_debridge_order_metadata.sql
@@ -1,16 +1,78 @@
 {{ config(snowflake_warehouse="DEBRIDGE", materialized="table") }}
 
+with debridge_order_metadata_backfil as (
+    select 
+        TRIM(order_id::string, '"') as order_id
+        , TRIM(sender_address_1, '"') as maker_src
+        , TRIM(sender_address_2::string, '"') as sender
+        , TRIM(receipient_address_1::string, '"') as receiver
+        , TRIM(source_token_address, '"') as src_chain_id
+        , TRIM(origin_chain_id::string, '"') as src_token_address
+        , source_amount_native as src_amount_native
+        , dst_chain_id
+        , to_timestamp(TRIM(fulfillment_time::string, '"')) as dst_block_timestamp
+        , TRIM(dst_token_address::string, '"') as dst_token_address
+        , dst_amount_native
+    from {{ source('PROD_LANDING', 'dln_orders_backfil_csv') }}
+),
+flatten_debridge_order_metadata as (
+    select 
+        value:"orderId":"stringValue"::string as order_id
+        , value:"makerSrc":"stringValue"::string as maker_src
+        , value:"orderAuthorityAddressDst":"stringValue"::string as sender
+        , value:"receiverDst":"stringValue"::string as receiver
+        , value:"giveOfferWithMetadata":"chainId":"bigIntegerValue"::int as src_chain_id
+        , value:"giveOfferWithMetadata":"tokenAddress":"stringValue"::string as src_token_address
+        , value:"giveOfferWithMetadata":"amount":"stringValue"::string as src_amount_native
+        , value:"takeOfferWithMetadata":"chainId":"bigIntegerValue"::int as dst_chain_id
+        , to_timestamp_ntz(value:"fulfilledDstEventMetadata":"blockTimeStamp"::string) as dst_block_timestamp
+        , value:"takeOfferWithMetadata":"tokenAddress":"stringValue"::string as dst_token_address
+        , value:"takeOfferWithMetadata":"amount":"stringValue"::string as dst_amount_native
+        , extraction_date
+    from {{ source('PROD_LANDING', 'raw_debridge_order_metadata') }},
+    lateral flatten(input => PARSE_JSON(source_json))
+),
+debridge_order_metadata as (
+    select
+        order_id
+        , max_by(maker_src, extraction_date) as maker_src
+        , max_by(sender, extraction_date) as sender
+        , max_by(receiver, extraction_date) as receiver
+        , max_by(src_chain_id, extraction_date) as src_chain_id
+        , max_by(src_token_address, extraction_date) as src_token_address
+        , max_by(src_amount_native, extraction_date) as src_amount_native
+        , max_by(dst_chain_id, extraction_date) as dst_chain_id
+        , max_by(dst_block_timestamp, extraction_date) as dst_block_timestamp
+        , max_by(dst_token_address, extraction_date) as dst_token_address
+        , max_by(dst_amount_native, extraction_date) as dst_amount_native
+    from flatten_debridge_order_metadata
+    where order_id is not null
+    group by order_id 
+)
 select 
-    TRIM(order_id::string, '"') as order_id
-    , to_timestamp(TRIM(fulfillment_time::string, '"')) as fulfillment_time
-    , TRIM(sender_address_1, '"') as maker
-    , TRIM(source_token_address, '"') as origin_chain_id
-    , TRIM(origin_chain_id::string, '"') as source_token_address
-    , source_amount_native
-    , TRIM(receipient_address_1::string, '"') as receipient_address
+    order_id
+    , maker_src
+    , sender
+    , receiver
+    , src_chain_id
+    , src_token_address
+    , src_amount_native
     , dst_chain_id
-    , TRIM(dst_token_address::string, '"') as dst_token_address
+    , dst_block_timestamp
+    , dst_token_address
     , dst_amount_native
-    , TRIM(sender_address_2::string, '"') as authority_src_chain
-    , TRIM(receipient_address_2::string, '"') as authority_destination_chain
-from {{ source('PROD_LANDING', 'dln_orders_backfil_csv') }}
+from debridge_order_metadata
+union
+select 
+    order_id
+    , maker_src
+    , sender
+    , receiver
+    , src_chain_id
+    , src_token_address
+    , src_amount_native
+    , dst_chain_id
+    , dst_block_timestamp
+    , dst_token_address
+    , dst_amount_native
+from debridge_order_metadata_backfil

--- a/models/staging/debridge/fact_debridge_transfers_with_price_and_metadata.sql
+++ b/models/staging/debridge/fact_debridge_transfers_with_price_and_metadata.sql
@@ -1,0 +1,35 @@
+{{ config(snowflake_warehouse="DEBRIDGE", materialized="table") }}
+
+select
+    transfers.order_id
+    , transfers.src_timestamp
+    , transfers.amount_sent_native
+    , transfers.source_chain
+    , transfers.source_token_decimals
+    , transfers.source_token_symbol
+    , transfers.source_token_address
+    , transfers.amount_sent_adjusted
+    , transfers.amount_sent
+    , transfers.source_tx_hash
+    , transfers.amount_received_native
+    , transfers.amount_received_adjusted
+    , transfers.amount_received
+    , transfers.destination_chain
+    , transfers.destination_token_decimals
+    , transfers.destination_token_symbol
+    , transfers.destination_token_address
+    , transfers.fix_fee_native
+    , transfers.fix_fee_adjusted
+    , transfers.fix_fee
+    , transfers.percentage_fee_native
+    , transfers.percentage_fee_adjusted
+    , transfers.percentage_fee
+    , transfers.category
+    , metadata.sender
+    , metadata.receiver
+    , metadata.dst_block_timestamp
+    , metadata.src_chain_id as metadata_src_chain_id
+    , metadata.src_token_address as metadata_src_token_address
+from {{ref('fact_debridge_transfers_with_prices')}} as transfers
+left join {{ ref('fact_debridge_order_metadata') }} as metadata 
+on transfers.order_id = metadata.order_id


### PR DESCRIPTION
## :pushpin: References

Fixed Bug where ETH debridge asset wasn't priced properly. This was because ETH had the 0x000... contract address. 

No longer null values in amount_sent in the image below:

<img width="1160" alt="Screenshot 2025-04-22 at 5 19 43 PM" src="https://github.com/user-attachments/assets/fe23d406-fd97-4d92-8008-7bf4fb38f391" />


Added Skeleton for debridge metadata. Not super accurate / still WIP because there are 939957 null occurrences.  

<img width="1263" alt="Screenshot 2025-04-22 at 5 20 39 PM" src="https://github.com/user-attachments/assets/d678d6bc-a770-44d7-8a0d-a1de49ce52c1" />


## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [x] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [x] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [ ] Any other relevant information that may be helpful