### PR TITLE
fix jupiter agg volume

### DIFF
--- a/models/staging/jupiter/fact_jupiter_swap_metrics.sql
+++ b/models/staging/jupiter/fact_jupiter_swap_metrics.sql
@@ -32,12 +32,11 @@ WHERE 1=1
                 )
         )
     AND succeeded
-    AND token_out_address not in ('2TLDx5M7Z9pfUPbHAboYeTEq6ShzaGhnCwWkfvVyPFyD', 'v62Jv9pwMTREWV9f6TetZfMafV254vo99p7HSF25BPr', '4h41QKUkQPd2pCAFXNNgZUyGUxQ6E7fMexaZZHziCvhh') -- Filter JEET token and Ggs Solana
-    AND token_in_address not in (
+    AND coalesce(token_in_address, token_out_address) not in (
         '2TLDx5M7Z9pfUPbHAboYeTEq6ShzaGhnCwWkfvVyPFyD', 
         '6FupkbAC2UvnqFYZp69yJ2S3BYo1Va8V9jTho9wJpump',
         'v62Jv9pwMTREWV9f6TetZfMafV254vo99p7HSF25BPr',
         '4h41QKUkQPd2pCAFXNNgZUyGUxQ6E7fMexaZZHziCvhh'
-    ) -- Filter these tokens too
+    ) -- Filter these bad tokens
     AND fee_amount_usd < 1e5
 GROUP BY 1, 2, 3


### PR DESCRIPTION
Our data for recent days showing ~500m in volume was incorrect. The root cause is a peculiarity with how SQL handles NULL values in filters. This was causing some swaps to be filtered out from the final aggregation.

I also noticed our data around dates like Jan 19th, when the TRUMP token launched, seem to be significantly smaller than Dune's data by up to 50% on some days. After poking around it seems there is a difference in methodology. Dune/DFL calculate volume as the sum of all DEX swaps executed as a result of a Jupiter swap. That means if I want to swap 1 USDC for 1 USDT, and Jupiter finds the best route for this to be swapping 1 USDC -> 1 PYUSD then 1 PYUSD -> 1 USDT, this will be counted as $2 in volume instead of $1. This reflects the amount of DEX volume that is enabled/originated via Jupiter. The way we calculate it is if I want to swap 1 USDC for 1 USDT, regardless of the swap route it is counted as $1 in volume, as that is the user's intent.

![CleanShot 2025-04-23 at 09 42 19@2x](https://github.com/user-attachments/assets/0f0391a5-7ef3-42d8-9005-8c989e5f5507)

![CleanShot 2025-04-23 at 09 42 40@2x](https://github.com/user-attachments/assets/51790fca-5c73-4d0a-96d0-bcc4e65d1bbf)
