### PR TITLE
April Supply Data Refresh - Injective

### DIFF
--- a/models/staging/injective/fact_injective_defillama_tvl_and_dexvolumes.sql
+++ b/models/staging/injective/fact_injective_defillama_tvl_and_dexvolumes.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="INJECTIVE",
+    )
+}}
+
+with defillama_metrics as (
+    {{ get_defillama_metrics("injective") }}
+)
+select * from defillama_metrics
+

--- a/models/staging/injective/fact_injective_unlocks.sql
+++ b/models/staging/injective/fact_injective_unlocks.sql
@@ -5,19 +5,29 @@
     )
 }}
 
+with outflows_data as (
+    SELECT 
+        DATE_TRUNC('day', block_timestamp) as date,
+        SUM(amount) as outflows
+    FROM 
+        ethereum_flipside.core.ez_token_transfers
+    WHERE 
+        LOWER(contract_address) = LOWER('0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30') -- INJ ERC20 Contract Address
+        AND LOWER(from_address) IN (
+            LOWER('0x7103E07e404D2BC6CE354688E52Ac1f4629EdfCC'), -- Wallet which was initially seeded all 100m INJ
+            LOWER('0x7E233EAfC76243474369bd080238fD6EB36A73CE')  -- Treasury/Escrow wallet 
+        )
+        AND LOWER(to_address) != LOWER('0x7E233EAfC76243474369bd080238fD6EB36A73CE') -- Treasury/Escrow wallet
+    GROUP BY 
+        1
+)
 SELECT 
-    DATE_TRUNC('day', block_timestamp) as date,
-    SUM(amount) as outflows
+    date,
+    CASE 
+        WHEN date = (SELECT MIN(date) FROM outflows_data) THEN outflows + 12000000
+        ELSE outflows
+    END as outflows
 FROM 
-    ethereum_flipside.core.ez_token_transfers
-WHERE 
-    LOWER(contract_address) = LOWER('0xe28b3B32B6c345A34Ff64674606124Dd5Aceca30') -- INJ ERC20 Contract Address
-    AND LOWER(from_address) IN (
-        LOWER('0x7103E07e404D2BC6CE354688E52Ac1f4629EdfCC'), -- Wallet which was initially seeded all 100m INJ
-        LOWER('0x7E233EAfC76243474369bd080238fD6EB36A73CE')  -- Treasury/Escrow wallet 
-    )
-    AND LOWER(to_address) != LOWER('0x7E233EAfC76243474369bd080238fD6EB36A73CE') -- Treasury/Escrow wallet
-GROUP BY 
-    1
+    outflows_data
 ORDER BY 
-    1 DESC
+    date DESC

--- a/models/staging/injective/fact_injective_unlocks.sql
+++ b/models/staging/injective/fact_injective_unlocks.sql
@@ -23,11 +23,8 @@ with outflows_data as (
 )
 SELECT 
     date,
-    CASE 
-        WHEN date = (SELECT MIN(date) FROM outflows_data) THEN outflows + 12000000
-        ELSE outflows
-    END as outflows
+    sum(outflows) as outflows
 FROM 
     outflows_data
-ORDER BY 
-    date DESC
+GROUP BY 
+    date


### PR DESCRIPTION
Add: fact_injective_unlocks table to staging layer
- This table pulls INJ unlocks from raw flipside logs
Add: INJ supply data to injective ez table
Add: defillama queries to fetch injective TVL & dex volumes into ez table
Modify: re-organized & renaming of injective ez-table for clarity & readability

*Note: circulating supply value is above Coingecko & Tokenomist. Our value includes emissions_native. If we were to exclude emissions_native our value would be equal to Coingecko & Tokenomist