### PR TITLE
April Supply Data Refresh - Helium

### DIFF
--- a/models/projects/helium/core/ez_helium_metrics.sql
+++ b/models/projects/helium/core/ez_helium_metrics.sql
@@ -34,14 +34,17 @@ with
         select date, mints_native
         from {{ ref("fact_helium_mints") }}
     ),
+    daily_supply_data as (
+        select * from {{ ref("fact_helium_daily_supply_data") }}
+    ),
     price_data as ({{ get_coingecko_metrics("helium") }})
 select
     date_spine.date
+
+    --Old metrics needed for backwards compatibility
     , coalesce(revenue_data.revenue, 0) as revenue
-    , coalesce(revenue_data.hnt_burned, 0) as burns_native
-    , coalesce(new_mobile_subscribers_data.new_subscribers, 0) as new_subscribers
-    , coalesce(new_hotspot_onboards_data.device_onboards, 0) as device_onboards
     , coalesce(fees_data.fees, 0) as fees
+    , coalesce(mints_data.mints_native, 0) as mints_native
 
     -- Standardized Metrics)
 
@@ -57,12 +60,21 @@ select
     , coalesce(revenue_data.hnt_burned, 0) * coalesce(price_data.price, 0) as burned_cash_flow
     , coalesce(revenue_data.hnt_burned, 0) as burned_cash_flow_native
 
-    -- Supply Metrics
-    , coalesce(mints_data.mints_native, 0) as mints_native
-
     -- Turnover Metrics
     , coalesce(price_data.token_turnover_circulating, 0) as token_turnover_circulating
     , coalesce(price_data.token_turnover_fdv, 0) as token_turnover_fdv
+
+    -- Other Metrics
+    , coalesce(new_mobile_subscribers_data.new_subscribers, 0) as new_subscribers
+    , coalesce(new_hotspot_onboards_data.device_onboards, 0) as device_onboards
+
+    --HNT Token Supply Data
+    , coalesce(daily_supply_data.emissions_native, 0) as emissions_native
+    , coalesce(daily_supply_data.premine_unlocks_native, 0) as premine_unlocks_native
+    , coalesce(daily_supply_data.burns_native, 0) as burns_native
+    , coalesce(daily_supply_data.emissions_native, 0) + coalesce(daily_supply_data.premine_unlocks_native, 0) - coalesce(daily_supply_data.burns_native, 0) as net_supply_change_native
+    , sum(coalesce(daily_supply_data.emissions_native, 0) + coalesce(daily_supply_data.premine_unlocks_native, 0) - coalesce(daily_supply_data.burns_native, 0)) over (order by daily_supply_data.date) as circulating_supply_native
+
 from date_spine
 left join revenue_data using (date)
 left join price_data using (date)
@@ -70,5 +82,6 @@ left join fees_data using (date)
 left join new_mobile_subscribers_data using (date)
 left join new_hotspot_onboards_data using (date)
 left join mints_data using (date)
+left join daily_supply_data using (date)
 where revenue_data.date < to_date(sysdate())
 order by 1 desc

--- a/models/staging/helium/__helium_sources__.yml
+++ b/models/staging/helium/__helium_sources__.yml
@@ -1,0 +1,7 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_helium_gross_emissions
+      - name: raw_helium_token_burns

--- a/models/staging/helium/fact_helium_daily_supply_data.sql
+++ b/models/staging/helium/fact_helium_daily_supply_data.sql
@@ -1,0 +1,30 @@
+{{ config(materialized="table") }}
+
+with gross_emissions as (
+    SELECT
+        date,
+        sum(emissions_native_to_holders) as emissions_native_to_holders,
+        sum(emissions_native_to_treasury) as emissions_native_to_treasury,
+        sum(emissions_native_to_holders) + sum(emissions_native_to_treasury) as emissions_native
+    FROM {{ ref('fact_helium_gross_emissions') }}
+    GROUP BY 1
+),
+premine_unlocks as (
+    SELECT
+        date,
+        sum(hnt_burned) as burns_native
+    FROM {{ ref('fact_helium_token_burns') }}
+    GROUP BY 1
+)
+SELECT
+    gross_emissions.date,
+    gross_emissions.emissions_native_to_holders,
+    gross_emissions.emissions_native_to_treasury,
+    gross_emissions.emissions_native,
+    CASE
+        WHEN gross_emissions.date  = '2023-04-19' THEN 154000000
+        ELSE 0
+    END as premine_unlocks_native,
+    premine_unlocks.burns_native
+FROM gross_emissions
+LEFT JOIN premine_unlocks ON gross_emissions.date = premine_unlocks.date

--- a/models/staging/helium/fact_helium_gross_emissions.sql
+++ b/models/staging/helium/fact_helium_gross_emissions.sql
@@ -1,0 +1,28 @@
+{{ config(materialized="table") }}
+
+with max_extraction as (
+    select max(extraction_date) as max_date
+    from {{ source("PROD_LANDING", "raw_helium_gross_emissions") }}
+),
+latest_data as (
+    select extraction_date::date as date, parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_helium_gross_emissions") }}
+        where extraction_date = (select max_date from max_extraction)
+    ),
+    flattened_data as (
+        select
+            flattened.value:"block_date"::string as date,
+            flattened.value:"holders"::float as emissions_native_to_holders,
+            flattened.value:"treasury"::float as emissions_native_to_treasury,
+            flattened.value:"total"::float as emissions_native_to_total
+        from latest_data, lateral flatten(input => data) as flattened
+    )
+
+select 
+    date,
+    coalesce(emissions_native_to_holders, 0) as emissions_native_to_holders,
+    coalesce(emissions_native_to_treasury, 0) as emissions_native_to_treasury,
+    coalesce(emissions_native_to_total, 0) as emissions_native_to_total
+from flattened_data
+where date < to_date(sysdate())
+order by date desc

--- a/models/staging/helium/fact_helium_token_burns.sql
+++ b/models/staging/helium/fact_helium_token_burns.sql
@@ -1,0 +1,28 @@
+{{ config(materialized="table") }}
+
+with max_extraction as (
+    select max(extraction_date) as max_date
+    from {{ source("PROD_LANDING", "raw_helium_token_burns") }}
+),
+latest_data as (
+    select extraction_date::date as date, parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_helium_token_burns") }}
+        where extraction_date = (select max_date from max_extraction)
+    ),
+    flattened_data as (
+        select
+            flattened.value:"block_date"::string as date,
+            flattened.value:"dc_minted"::float as dc_minted,
+            flattened.value:"hnt_avg_price"::float as hnt_avg_price,
+            flattened.value:"hnt_burned"::float as hnt_burned
+        from latest_data, lateral flatten(input => data) as flattened
+    )
+
+select 
+    date,
+    coalesce(dc_minted, 0) as dc_minted,
+    coalesce(hnt_avg_price, 0) as hnt_avg_price,
+    -1* coalesce(hnt_burned, 0) as hnt_burned
+from flattened_data
+where date < to_date(sysdate())
+order by date desc


### PR DESCRIPTION
Add: helium native emissions
Add: helium token burns
Add: helium daily supply data
Modify: re-organized & re named helium ez-tables for clarity, readability, and standardization

*Note: See gokustats PR from feature/helium_extracts branch for raw Dune & API helium data dumps