### PR TITLE
Rename fact_decoded_event_logs -> ez_decoded_event_logs

### DIFF
--- a/macros/across/across_v2_decode_filled_relay.sql
+++ b/macros/across/across_v2_decode_filled_relay.sql
@@ -15,7 +15,7 @@
             decoded_log:"relayerFeePct"::integer / 1e18 as relayer_fee_pct,
             decoded_log:"message"::string as message,
             '{{ chain }}' as chain
-        from {{chain}}_flipside.core.fact_decoded_event_logs
+        from {{chain}}_flipside.core.ez_decoded_event_logs
         where
             event_name = 'FilledRelay' and block_timestamp < '2025-02-07'
             and

--- a/macros/across/across_v2_decode_funds_deposited.sql
+++ b/macros/across/across_v2_decode_funds_deposited.sql
@@ -13,7 +13,7 @@
         decoded_log:"originToken"::string as origin_token,
         decoded_log:"relayerFeePct"::integer / 1e18 as relayer_fee_pct,
         '{{ chain }}' as chain
-    from {{ chain }}_flipside.core.fact_decoded_event_logs
+    from {{ chain }}_flipside.core.ez_decoded_event_logs
     where block_timestamp < '2025-02-07' and event_name = 'FundsDeposited'
         and
         contract_address = '{{ spot_fee_contract }}'

--- a/macros/across/across_v3_decode_filled_relay.sql
+++ b/macros/across/across_v3_decode_filled_relay.sql
@@ -19,7 +19,7 @@
             decoded_log:"message"::string as message,
             '{{ chain }}' as chain,
             decoded_log
-        from {{chain}}_flipside.core.fact_decoded_event_logs
+        from {{chain}}_flipside.core.ez_decoded_event_logs
         where
             ((event_name = 'FilledV3Relay') or (event_name = 'FilledRelay' and block_timestamp >= '2025-02-07'))
             and

--- a/macros/across/across_v3_decode_funds_deposited.sql
+++ b/macros/across/across_v3_decode_funds_deposited.sql
@@ -19,7 +19,7 @@
         decoded_log:"message"::string as message,
         '{{ chain }}' as chain,
         decoded_log
-    from {{ chain }}_flipside.core.fact_decoded_event_logs
+    from {{ chain }}_flipside.core.ez_decoded_event_logs
     where
         ((event_name = 'V3FundsDeposited') or (event_name = 'FundsDeposited' and block_timestamp >= '2025-02-07'))
         and

--- a/macros/bridge/stargate_STGholders.sql
+++ b/macros/bridge/stargate_STGholders.sql
@@ -46,7 +46,7 @@ net_staked_withdrawal AS (
     select 
         lower(fded.decoded_log:from::STRING) as staker_address
         , sum(fded.decoded_log:value::NUMERIC / 1e18) as value
-    from {{chain}}_flipside.core.fact_decoded_event_logs fded
+    from {{chain}}_flipside.core.ez_decoded_event_logs fded
     where 
         lower(fded.contract_address) = lower('{{token_contract_address}}')
         and lower(fded.decoded_log:to::STRING) = lower('{{stake_contract_address}}')
@@ -57,7 +57,7 @@ net_staked_withdrawal AS (
     select 
         lower(fded.decoded_log:to::STRING) as staker_address
         , sum(fded.decoded_log:value::NUMERIC / 1e18) * -1 as value
-    from {{chain}}_flipside.core.fact_decoded_event_logs fded
+    from {{chain}}_flipside.core.ez_decoded_event_logs fded
     where 
         lower(fded.contract_address) = lower('{{token_contract_address}}')
         and lower(fded.decoded_log:from::STRING) = lower('{{stake_contract_address}}')
@@ -68,7 +68,7 @@ net_staked_withdrawal AS (
     select 
         lower(fded.decoded_log:provider::STRING) as staker_address
         , sum(fded.decoded_log:value::NUMERIC / 1e18) as value
-    from {{chain}}_flipside.core.fact_decoded_event_logs fded
+    from {{chain}}_flipside.core.ez_decoded_event_logs fded
     where 
         lower(fded.contract_address) = lower('{{stake_contract_address}}') 
         and fded.event_name = 'Deposit'
@@ -79,7 +79,7 @@ net_staked_withdrawal AS (
     select 
         lower(fdew.decoded_log:provider::STRING) as staker_address
         , sum(fdew.decoded_log:value::NUMERIC / 1e18) * -1 as value
-    from {{chain}}_flipside.core.fact_decoded_event_logs fdew
+    from {{chain}}_flipside.core.ez_decoded_event_logs fdew
     where 
         lower(fdew.contract_address) = lower('{{stake_contract_address}}')
         and fdew.event_name = 'Withdraw'

--- a/macros/bridge/stargate_fees.sql
+++ b/macros/bridge/stargate_fees.sql
@@ -6,7 +6,7 @@ WITH dvn_fees AS (
         tx_hash,
         contract_address,
         max_by(decoded_log:"fees"[0] / 1e18, date) as dvnFees
-    FROM {{chain}}_flipside.core.fact_decoded_event_logs
+    FROM {{chain}}_flipside.core.ez_decoded_event_logs
     WHERE lower(contract_address) = lower('{{fees_contract_address}}') and decoded_log:"fees"[0] is not null
     GROUP BY 1, 2, 3
 
@@ -17,7 +17,7 @@ executor_fees AS (
         tx_hash,
         contract_address,
         max_by(decoded_log:"fee" / 1e18, date) as executorFees
-    FROM {{chain}}_flipside.core.fact_decoded_event_logs
+    FROM {{chain}}_flipside.core.ez_decoded_event_logs
     WHERE lower(contract_address) = lower('{{fees_contract_address}}') 
     AND event_name = 'ExecutorFeePaid' 
     AND decoded_log:"fee" / 1e18 < 10 -- To remove outliers

--- a/macros/native_bridges/superchain_l1_native_bridges.sql
+++ b/macros/native_bridges/superchain_l1_native_bridges.sql
@@ -41,7 +41,7 @@ select
         when event_name = 'ERC20WithdrawalFinalized' then 'withdrawal' 
         when event_name = 'ETHWithdrawalFinalized' then 'withdrawal'
     end as action
-from ethereum_flipside.core.fact_decoded_event_logs
+from ethereum_flipside.core.ez_decoded_event_logs
 where
     contract_address = lower('{{ contract_address }}')
     and event_name in ('ETHDepositInitiated', 'ETHWithdrawalFinalized', 'ERC20DepositInitiated', 'ERC20WithdrawalFinalized')

--- a/macros/native_bridges/superchain_l2_native_bridges.sql
+++ b/macros/native_bridges/superchain_l2_native_bridges.sql
@@ -36,7 +36,7 @@
             when event_name = 'WithdrawalInitiated' then 'withdrawal'
             when event_name = 'DepositFinalized' then 'deposit' 
         end as action
-    from {{chain}}_flipside.core.fact_decoded_event_logs
+    from {{chain}}_flipside.core.ez_decoded_event_logs
     where
         contract_address = lower('0x4200000000000000000000000000000000000010')
         and event_name in ('WithdrawalInitiated', 'DepositFinalized')

--- a/macros/perps/mux_decoding.sql
+++ b/macros/perps/mux_decoding.sql
@@ -18,7 +18,7 @@
         end as trading_volume,
         decoded_log:"trader"::string as trader,
         '{{ chain }}' as chain
-    from {{ chain }}_flipside.core.fact_decoded_event_logs
+    from {{ chain }}_flipside.core.ez_decoded_event_logs
     where
         contract_address = lower('{{ liquidity_contract }}')
         and (event_name in ('ClosePosition', 'OpenPosition'))

--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -61,7 +61,6 @@ sources:
       - name: ez_decoded_event_logs
       - name: fact_event_logs
       - name: fact_blocks
-      - name: fact_decoded_event_logs
       - name: fact_decoded_traces
       - name: ez_token_transfers
       - name: ez_decoded_traces
@@ -103,7 +102,6 @@ sources:
       - name: ez_decoded_event_logs
       - name: fact_event_logs
       - name: fact_blocks
-      - name: fact_decoded_event_logs
       - name: ez_token_transfers
       - name: ez_native_transfers
       - name: fact_traces
@@ -125,7 +123,6 @@ sources:
       - name: ez_decoded_event_logs
       - name: fact_event_logs
       - name: fact_blocks
-      - name: fact_decoded_event_logs
       - name: ez_token_transfers
       - name: ez_native_transfers
 
@@ -144,7 +141,6 @@ sources:
       - name: ez_decoded_event_logs
       - name: fact_event_logs
       - name: fact_blocks
-      - name: fact_decoded_event_logs
       - name: ez_token_transfers
       - name: ez_native_transfers
       - name: fact_traces

--- a/models/projects/eigenlayer/raw/fact_restaked_native_eth.sql
+++ b/models/projects/eigenlayer/raw/fact_restaked_native_eth.sql
@@ -32,7 +32,7 @@ EigenPods AS (
         decoded_log:eigenPod::STRING AS eigenpod_address,
         DATE_TRUNC('day', block_timestamp) AS day_of_pod_deployed_event
     FROM 
-        {{ source("ETHEREUM_FLIPSIDE", "fact_decoded_event_logs")}}-- flipside table 'ethereum.core.fact_decoded_event_logs'
+        {{ source("ETHEREUM_FLIPSIDE", "ez_decoded_event_logs")}}-- flipside table 'ethereum.core.ez_decoded_event_logs'
     WHERE 
         contract_address = lower('0x91E677b07F7AF907ec9a428aafA9fc14a0d3A338')
         AND event_name = 'PodDeployed'

--- a/models/projects/flow/core/ez_flow_metrics.sql
+++ b/models/projects/flow/core/ez_flow_metrics.sql
@@ -57,7 +57,7 @@ select
     , dau_txn_data.chain
     , defillama_data.dex_volumes as dex_volumes
     , defillama_data.tvl as tvl
-
+    , nft_metrics.nft_trading_volume
     -- Standardized Metrics
 
     -- Market Metrics

--- a/models/projects/goldfinch/raw/dim_migratedtranchepools_addresses.sql
+++ b/models/projects/goldfinch/raw/dim_migratedtranchepools_addresses.sql
@@ -8,6 +8,6 @@
     )
 }}
 
-select distinct contract_address as migratedtranchepool_address from ethereum_flipside.core.fact_decoded_event_logs
+select distinct contract_address as migratedtranchepool_address from ethereum_flipside.core.ez_decoded_event_logs
 where event_name = 'PaymentApplied'
 and contract_address <> '0xd52dc1615c843c30f2e4668e101c0938e6007220'

--- a/models/projects/goldfinch/raw/fact_creditdesk_drawdownmade.sql
+++ b/models/projects/goldfinch/raw/fact_creditdesk_drawdownmade.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:borrower::string AS addr,
     decoded_log:drawdownAmount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DrawdownMade'
     AND LOWER(contract_address) = '0xd52dc1615c843c30f2e4668e101c0938e6007220'

--- a/models/projects/goldfinch/raw/fact_investorrewards_depositedandstaked.sql
+++ b/models/projects/goldfinch/raw/fact_investorrewards_depositedandstaked.sql
@@ -18,7 +18,7 @@ SELECT
     decoded_log:user::string AS addr,
     decoded_log:depositedAmount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DepositedAndStaked'
     AND contract_address = lower('0xfd6ff39da508d281c2d255e9bbbfab34b6be60c3')

--- a/models/projects/goldfinch/raw/fact_investorrewards_unstakedandwithdrew.sql
+++ b/models/projects/goldfinch/raw/fact_investorrewards_unstakedandwithdrew.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:user::string AS addr,
     decoded_log:usdcReceivedAmount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'UnstakedAndWithdrew'
     AND LOWER(contract_address) = '0xfd6ff39da508d281c2d255e9bbbfab34b6be60c3'

--- a/models/projects/goldfinch/raw/fact_investorrewards_unstakedandwithdrewmultiple.sql
+++ b/models/projects/goldfinch/raw/fact_investorrewards_unstakedandwithdrewmultiple.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:user::string AS addr,
     decoded_log:usdcReceivedAmount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'UnstakedAndWithdrewMultiple'
     AND LOWER(contract_address) = '0xfd6ff39da508d281c2d255e9bbbfab34b6be60c3'

--- a/models/projects/goldfinch/raw/fact_migratedtranchedpool_depositmade.sql
+++ b/models/projects/goldfinch/raw/fact_migratedtranchedpool_depositmade.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:owner::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DepositMade'
     AND 

--- a/models/projects/goldfinch/raw/fact_migratedtranchedpool_drawdownmade.sql
+++ b/models/projects/goldfinch/raw/fact_migratedtranchedpool_drawdownmade.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:borrower::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DrawdownMade'
     AND contract_address IN (SELECT migratedtranchepool_address FROM {{ref('dim_migratedtranchepools_addresses')}})

--- a/models/projects/goldfinch/raw/fact_migratedtranchedpool_paymentapplied.sql
+++ b/models/projects/goldfinch/raw/fact_migratedtranchedpool_paymentapplied.sql
@@ -17,7 +17,7 @@ SELECT
     decoded_log:principalAmount::number / 1e6 AS principal_amount,
     decoded_log:reserveAmount::number / 1e6 AS reserve_amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'PaymentApplied'
     AND contract_address IN (SELECT migratedtranchepool_address FROM {{ref('dim_migratedtranchepools_addresses')}})

--- a/models/projects/goldfinch/raw/fact_migratedtranchedpool_reservefundscollected.sql
+++ b/models/projects/goldfinch/raw/fact_migratedtranchedpool_reservefundscollected.sql
@@ -15,7 +15,7 @@ SELECT
     NULL AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'ReserveFundsCollected'
     AND contract_address IN (SELECT migratedtranchepool_address FROM {{ref('dim_migratedtranchepools_addresses')}})

--- a/models/projects/goldfinch/raw/fact_migratedtranchedpool_withdrawalmade.sql
+++ b/models/projects/goldfinch/raw/fact_migratedtranchedpool_withdrawalmade.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:interestWithdrawn::number / 1e6 AS interest_withdrawn,
     decoded_log:principalWithdrawn::number / 1e6 AS principal_withdrawn
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalMade'
     AND (contract_address IN (SELECT migratedtranchepool_address FROM {{ref('dim_migratedtranchepools_addresses')}})

--- a/models/projects/goldfinch/raw/fact_pool_depositmade.sql
+++ b/models/projects/goldfinch/raw/fact_pool_depositmade.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:capitalProvider::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DepositMade'
     AND contract_address = lower('0xB01b315e32D1D9B5CE93e296D483e1f0aAD39E75')

--- a/models/projects/goldfinch/raw/fact_pool_interestcollected.sql
+++ b/models/projects/goldfinch/raw/fact_pool_interestcollected.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:poolAmount::number / 1e6 AS pool_amount,
     decoded_log:reserveAmount::number / 1e6 AS reserve_amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'InterestCollected'
     AND LOWER(contract_address) = '0xb01b315e32d1d9b5ce93e296d483e1f0aad39e75'

--- a/models/projects/goldfinch/raw/fact_pool_principalcollected.sql
+++ b/models/projects/goldfinch/raw/fact_pool_principalcollected.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:payer::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'PrincipalCollected'
     AND LOWER(contract_address) = '0xb01b315e32d1d9b5ce93e296d483e1f0aad39e75'

--- a/models/projects/goldfinch/raw/fact_pool_principalwrittendown.sql
+++ b/models/projects/goldfinch/raw/fact_pool_principalwrittendown.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:creditline::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'PrincipalWrittendown'
     AND LOWER(contract_address) = '0xb01b315e32d1d9b5ce93e296d483e1f0aad39e75'

--- a/models/projects/goldfinch/raw/fact_pool_reservefundscollected.sql
+++ b/models/projects/goldfinch/raw/fact_pool_reservefundscollected.sql
@@ -15,7 +15,7 @@ SELECT
     NULL AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'ReserveFundsCollected'
     AND LOWER(contract_address) = '0xb01b315e32d1d9b5ce93e296d483e1f0aad39e75'

--- a/models/projects/goldfinch/raw/fact_pool_withdrawalmade.sql
+++ b/models/projects/goldfinch/raw/fact_pool_withdrawalmade.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:userAmount::number / 1e6 AS user_amount,
     decoded_log:reserveAmount::number / 1e6 AS reserve_amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalMade'
     AND contract_address = lower('0xB01b315e32D1D9B5CE93e296D483e1f0aAD39E75')

--- a/models/projects/goldfinch/raw/fact_seniorpool_depositmade.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_depositmade.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:capitalProvider::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'DepositMade'
     AND contract_address = lower('0x8481a6EbAf5c7DABc3F7e09e44A89531fd31F822')

--- a/models/projects/goldfinch/raw/fact_seniorpool_interestcollected.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_interestcollected.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:payer::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'InterestCollected'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_investmentmadeinjunior.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_investmentmadeinjunior.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:tranchedPool::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'InvestmentMadeInJunior'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_investmentmadeinsenior.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_investmentmadeinsenior.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:tranchedPool::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'InvestmentMadeInSenior'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_principalcollected.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_principalcollected.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:payer::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'PrincipalCollected'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_principalwrittendown.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_principalwrittendown.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:tranchedPool::string AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'PrincipalWrittenDown'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_reservefundscollected.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_reservefundscollected.sql
@@ -15,7 +15,7 @@ SELECT
     NULL AS addr,
     decoded_log:amount::number / 1e6 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'ReserveFundsCollected'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_withdrawaladdedto.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_withdrawaladdedto.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:operator::string AS addr,
     decoded_log:fiduRequested::number / 1e18 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalAddedTo'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'  

--- a/models/projects/goldfinch/raw/fact_seniorpool_withdrawalcanceled.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_withdrawalcanceled.sql
@@ -16,7 +16,7 @@ SELECT
     decoded_log:fiduCanceled::number / 1e18 AS fidu_canceled,
     decoded_log:reserveFidu::number / 1e18 AS reserve_fidu
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalCanceled'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_withdrawalmade.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_withdrawalmade.sql
@@ -17,7 +17,7 @@ SELECT
     decoded_log:userAmount::number / 1e6 AS user_amount,
     decoded_log:reserveAmount::number / 1e6 AS reserve_amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalMade'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/goldfinch/raw/fact_seniorpool_withdrawalrequested.sql
+++ b/models/projects/goldfinch/raw/fact_seniorpool_withdrawalrequested.sql
@@ -15,7 +15,7 @@ SELECT
     decoded_log:operator::string AS addr,
     decoded_log:fiduRequested::number / 1e18 AS amount
 FROM 
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE 
     event_name = 'WithdrawalRequested'
     AND LOWER(contract_address) = '0x8481a6ebaf5c7dabc3f7e09e44a89531fd31f822'

--- a/models/projects/uniswap/raw/fact_uniswap_token_incentives.sql
+++ b/models/projects/uniswap/raw/fact_uniswap_token_incentives.sql
@@ -22,7 +22,7 @@ with prices as (
         'UNI' as token,
         sum(l.decoded_log:reward::number / 1e18) as reward_native
     FROM
-        ethereum_flipside.core.fact_decoded_event_logs l
+        ethereum_flipside.core.ez_decoded_event_logs l
     WHERE
         contract_address in (
             lower('0xca35e32e7926b96a9988f61d510e038108d8068e')

--- a/models/staging/across/fact_across_uba_transfers.sql
+++ b/models/staging/across/fact_across_uba_transfers.sql
@@ -18,7 +18,7 @@ with uba_across_data as (
         decoded_log:"originChainId"::integer as origin_chain_id,
         decoded_log:"realizedLpFeePct"::integer / 1e18 as realized_lp_fee_pct,
         decoded_log:"updatableRelayData":"relayerFeePct"::integer / 1e18 as relayer_fee_pct
-    from ethereum_flipside.core.fact_decoded_event_logs
+    from ethereum_flipside.core.ez_decoded_event_logs
     where
         event_name = 'FilledRelay'
         and contract_address = '0x5c7bcd6e7de5423a257d81b442095a1a6ced35c5'
@@ -50,7 +50,7 @@ with uba_across_data as (
         decoded_log:"originChainId"::integer as origin_chain_id,
         decoded_log:"realizedLpFeePct"::integer / 1e18 as realized_lp_fee_pct,
         decoded_log:"updatableRelayData":"relayerFeePct" / 1e18 as relayer_fee_pct
-    from arbitrum_flipside.core.fact_decoded_event_logs
+    from arbitrum_flipside.core.ez_decoded_event_logs
     where
         event_name = 'FilledRelay'
         and contract_address = '0xe35e9842fceaca96570b734083f4a58e8f7c5f2a'
@@ -86,7 +86,7 @@ with uba_across_data as (
         decoded_log:"originChainId"::integer as origin_chain_id,
         decoded_log:"realizedLpFeePct"::integer / 1e18 as realized_lp_fee_pct,
         decoded_log:"updatableRelayData":"relayerFeePct" / 1e18 as relayer_fee_pct
-    from optimism_flipside.core.fact_decoded_event_logs
+    from optimism_flipside.core.ez_decoded_event_logs
     where
         event_name = 'FilledRelay'
         and contract_address = '0x6f26bf09b1c792e3228e5467807a900a503c0281'
@@ -118,7 +118,7 @@ with uba_across_data as (
         decoded_log:"originChainId"::integer as origin_chain_id,
         decoded_log:"realizedLpFeePct"::integer / 1e18 as realized_lp_fee_pct,
         decoded_log:"updatableRelayData":"relayerFeePct" / 1e18 as relayer_fee_pct
-    from polygon_flipside.core.fact_decoded_event_logs
+    from polygon_flipside.core.ez_decoded_event_logs
     where
         event_name = 'FilledRelay'
         and contract_address = '0x9295ee1d8c5b022be115a2ad3c30c72e34e7f096'

--- a/models/staging/across/fact_across_v1_transfers.sql
+++ b/models/staging/across/fact_across_v1_transfers.sql
@@ -39,7 +39,7 @@ with
             decoded_log:"depositData":"instantRelayFeePct"::integer / 1e18
             + decoded_log:"depositData":"slowRelayFeePct"::integer
             / 1e18 as relayer_fee_pct
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address in (select contract_address from v1_contracts)
             and event_name = 'DepositRelayed'

--- a/models/staging/avalanche/fact_avalanche_bridge_transfers.sql
+++ b/models/staging/avalanche/fact_avalanche_bridge_transfers.sql
@@ -39,7 +39,7 @@ with
             contract_address as token_address,
             'ethereum' as source_chain,
             'avalanche' as destination_chain
-        from avalanche_flipside.core.fact_decoded_event_logs
+        from avalanche_flipside.core.ez_decoded_event_logs
         where
             tx_hash in (select * from txs) and event_name = 'Mint'
             {% if is_incremental() %}
@@ -64,7 +64,7 @@ with
             contract_address as token_address,
             'avalanche' as source_chain,
             'ethereum' as destination_chain
-        from avalanche_flipside.core.fact_decoded_event_logs
+        from avalanche_flipside.core.ez_decoded_event_logs
         where
             contract_address in (select * from tokens)
             and event_name = 'Transfer'
@@ -99,7 +99,7 @@ with
             contract_address as token_address,
             'bitcoin' as source_chain,
             'avalanche' as destination_chain
-        from avalanche_flipside.core.fact_decoded_event_logs
+        from avalanche_flipside.core.ez_decoded_event_logs
         where
             tx_hash in (select * from txs) and event_name = 'Mint'
             {% if is_incremental() %}
@@ -124,7 +124,7 @@ with
             contract_address as token_address,
             'avalanche' as source_chain,
             'bitcoin' as destination_chain
-        from avalanche_flipside.core.fact_decoded_event_logs
+        from avalanche_flipside.core.ez_decoded_event_logs
         where
             contract_address in (select * from tokens)
             and event_name = 'Transfer'

--- a/models/staging/base/fact_base_bridge_transfers.sql
+++ b/models/staging/base/fact_base_bridge_transfers.sql
@@ -85,7 +85,7 @@ with
                     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
                     'base' as source_chain,
                     'ethereum' as destination_chain
-                from ethereum_flipside.core.fact_decoded_event_logs
+                from ethereum_flipside.core.ez_decoded_event_logs
                 where
                     contract_address
                     = lower('0x3154Cf16ccdb4C6d922629664174b904d80F2C35')
@@ -145,7 +145,7 @@ with
             decoded_log:"l1Token" as token_address,
             'ethereum' as source_chain,
             'base' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x3154Cf16ccdb4C6d922629664174b904d80F2C35')
             and event_name = 'ERC20DepositInitiated'
@@ -169,7 +169,7 @@ with
             decoded_log:"l1Token" as token_address,
             'base' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x3154Cf16ccdb4C6d922629664174b904d80F2C35')
             and event_name = 'ERC20WithdrawalFinalized'

--- a/models/staging/ethena/fact_ethena_collateral_fees.sql
+++ b/models/staging/ethena/fact_ethena_collateral_fees.sql
@@ -4,7 +4,7 @@ SELECT
         TRY_TO_NUMBER(NULLIF(DECODED_LOG:usde_amount :: STRING, '')) / 1e21
     ) AS collateral_fee
 FROM
-    ethereum_flipside.core.fact_decoded_event_logs
+    ethereum_flipside.core.ez_decoded_event_logs
 WHERE
     contract_address = '0x2cc440b721d2cafd6d64908d6d8c4acc57f8afc3'
     AND event_name = 'Mint'

--- a/models/staging/linea/fact_linea_gas_gas_usd_revenue.sql
+++ b/models/staging/linea/fact_linea_gas_gas_usd_revenue.sql
@@ -3,7 +3,7 @@ with
     prices as ({{ get_coingecko_price_with_latest("ethereum") }}),
     linea_submission_and_finalization_transactions as (
         select distinct tx_hash,
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             lower(contract_address)
             = lower('0xd19d4B5d358258f05D7B411E21A1460D11B0876F')

--- a/models/staging/maple/fact_maple_Pool_evt_Claim.sql
+++ b/models/staging/maple/fact_maple_Pool_evt_Claim.sql
@@ -11,7 +11,7 @@ with pools as (
         decoded_log:pool as pool_address,
         decoded_log:liquidityAsset as pool_liquidity_asset
     FROM
-        {{ source('ETHEREUM_FLIPSIDE', 'fact_decoded_event_logs') }}
+        {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
     WHERE CONTRACT_ADDRESS = lower('0x2Cd79F7f8b38B9c0D80EA6B230441841A31537eC')
     AND event_name = 'PoolCreated'
 )

--- a/models/staging/optimism/fact_optimism_bridge_transfers.sql
+++ b/models/staging/optimism/fact_optimism_bridge_transfers.sql
@@ -43,7 +43,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'optimism' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1')
             and event_name = 'ETHWithdrawalFinalized'
@@ -67,7 +67,7 @@ with
             decoded_log:"l1Token" as token_address,
             'ethereum' as source_chain,
             'optimism' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1')
             and event_name = 'ERC20DepositInitiated'
@@ -91,7 +91,7 @@ with
             decoded_log:"l1Token" as token_address,
             'optimism' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1')
             and event_name = 'ERC20WithdrawalFinalized'

--- a/models/staging/polygon/fact_polygon_pos_bridge_transfers.sql
+++ b/models/staging/polygon/fact_polygon_pos_bridge_transfers.sql
@@ -43,7 +43,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'polygon' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x8484Ef722627bf18ca5Ae6BcF031c23E6e922B30')
             and event_name = 'ExitedEther'

--- a/models/staging/stargate/fact_stargate_v2_bsc_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_bsc_treasury_balance.sql
@@ -62,7 +62,7 @@ treasury_data as (
         , '0x5692db8177a81a6c6afc8084c2976c9933ec1bab' as contract_address
         , 'veCAKE' as symbol
         , decoded_log:value::float/1e18 as balance_native
-    from bsc_flipside.core.fact_decoded_event_logs
+    from bsc_flipside.core.ez_decoded_event_logs
     where contract_address = lower('0x5692db8177a81a6c6afc8084c2976c9933ec1bab')
         and lower(decoded_log:locker::string) = lower('0x6e690075eedBC52244Dd4822D9F7887d4f27442F')
         and event_name = 'Deposit'

--- a/models/staging/starknet/fact_starknet_bridge_transfers.sql
+++ b/models/staging/starknet/fact_starknet_bridge_transfers.sql
@@ -43,7 +43,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'starknet' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419')
             and event_name = 'LogWithdrawal'

--- a/models/staging/usual/fact_usd0pp_tvl.sql
+++ b/models/staging/usual/fact_usd0pp_tvl.sql
@@ -21,7 +21,7 @@ WITH user_balance AS (
       LOWER(contract_address) AS contract_address,
       -CAST(decoded_log:"value" AS NUMERIC) / 1e18 AS amount
     FROM 
-      ethereum_flipside.core.fact_decoded_event_logs
+      ethereum_flipside.core.ez_decoded_event_logs
     WHERE 
       LOWER(decoded_log:"from") != '0x0000000000000000000000000000000000000000'
       AND LOWER(contract_address) IN ('0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5', '0x35d8949372d46b7a3d5a56006ae77b215fc69bc0')
@@ -36,7 +36,7 @@ WITH user_balance AS (
       LOWER(contract_address) AS contract_address,
       CAST(decoded_log:"value" AS NUMERIC) / 1e18 AS amount
     FROM 
-      ethereum_flipside.core.fact_decoded_event_logs
+      ethereum_flipside.core.ez_decoded_event_logs
     WHERE 
       LOWER(decoded_log:"to") != '0x0000000000000000000000000000000000000000'
       AND LOWER(contract_address) IN ('0x73a15fed60bf67631dc6cd7bc5b6e8da8190acf5', '0x35d8949372d46b7a3d5a56006ae77b215fc69bc0')

--- a/models/staging/usual/fact_usual_burn_mint.sql
+++ b/models/staging/usual/fact_usual_burn_mint.sql
@@ -45,7 +45,7 @@ net_balance AS (
             THEN -decoded_log:"value" / 1e18
             ELSE 0
         END) AS tokens_mint
-    FROM ethereum_flipside.core.fact_decoded_event_logs
+    FROM ethereum_flipside.core.ez_decoded_event_logs
     WHERE 
         LOWER(contract_address) = LOWER('0xC4441c2BE5d8fA8126822B9929CA0b81Ea0DE38E')
         AND event_name = 'Transfer'

--- a/models/staging/zksync/fact_zksync_era_bridge_transfers.sql
+++ b/models/staging/zksync/fact_zksync_era_bridge_transfers.sql
@@ -42,7 +42,7 @@ with
             '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' as token_address,
             'zksync' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x32400084C286CF3E17e7B677ea9583e60a000324')
             and event_name = 'EthWithdrawalFinalized'
@@ -66,7 +66,7 @@ with
             decoded_log:"l1Token" as token_address,
             'ethereum' as source_chain,
             'zksync' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063')
             and event_name = 'DepositInitiated'
@@ -90,7 +90,7 @@ with
             decoded_log:"l1Token" as token_address,
             'zksync' as source_chain,
             'ethereum' as destination_chain
-        from ethereum_flipside.core.fact_decoded_event_logs
+        from ethereum_flipside.core.ez_decoded_event_logs
         where
             contract_address = lower('0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063')
             and event_name = 'WithdrawalFinalized'


### PR DESCRIPTION
## :pushpin: References
- Migrate from the fact_decoded_event_logs views to the new ez_decoded_event_logs tables for Flipside EVM Data
- Updating all references in sql and yml files

Decoded logs have been moved from views -> more performant tables for EVM chains. First example for Base
- <img width="655" alt="image" src="https://github.com/user-attachments/assets/d50a93b7-f425-46f2-b5f2-d63babd4e554" />
<img width="641" alt="image" src="https://github.com/user-attachments/assets/ded45667-b17b-44c1-b54f-39dee8dba607" />

For Polygon, both exist in the meantime until standardization is complete
<img width="661" alt="image" src="https://github.com/user-attachments/assets/2b9d9e78-fe86-4ca6-a73e-b9932cf8e2fe" />
<img width="617" alt="image" src="https://github.com/user-attachments/assets/5c3675cc-9ccd-4db3-acc4-b81a46749b14" />

## Test Plan
- Comparing row counts between fact and ez tables for a chain that hasn't undergone standardization yet (polygon)
<img width="919" alt="image" src="https://github.com/user-attachments/assets/23b2546b-2e7b-4963-a4e8-3ad47f33c9ab" />
<img width="909" alt="image" src="https://github.com/user-attachments/assets/ed0d13a5-d206-4d62-930d-67743cccedb3" />

Cols in fact table:
```
BLOCK_NUMBER
BLOCK_TIMESTAMP
TX_HASH
EVENT_INDEX
CONTRACT_ADDRESS
EVENT_NAME
DECODED_LOG
FULL_DECODED_LOG
FACT_DECODED_EVENT_LOGS_ID
INSERTED_TIMESTAMP
MODIFIED_TIMESTAMP
```

cols in ez table
```
BLOCK_NUMBER
BLOCK_TIMESTAMP
TX_HASH
EVENT_INDEX
CONTRACT_ADDRESS
TOPICS
TOPIC_0
TOPIC_1
TOPIC_2
TOPIC_3
DATA
EVENT_REMOVED
ORIGIN_FROM_ADDRESS
ORIGIN_TO_ADDRESS
ORIGIN_FUNCTION_SIGNATURE
TX_SUCCEEDED
EVENT_NAME
FULL_DECODED_LOG
DECODED_LOG
CONTRACT_NAME
EZ_DECODED_EVENT_LOGS_ID
INSERTED_TIMESTAMP
MODIFIED_TIMESTAMP
TX_STATUS
```

Only column that was re-named is `FACT_DECODED_EVENT_LOGS_ID` which we don't use