### PR TITLE
VALIDATION: April Supply Data Refresh - Etherfi

### DIFF
--- a/models/staging/etherfi/fact_etherfi_tvl.sql
+++ b/models/staging/etherfi/fact_etherfi_tvl.sql
@@ -4,7 +4,7 @@ with liquid as (
     SELECT
         *
     FROM
-        pc_dbt_db.prod.fact_defillama_protocol_tvls
+        {{ref('fact_defillama_protocol_tvls')}}
     WHERE
         defillama_protocol_id = 4429
 ),
@@ -12,7 +12,7 @@ stake as (
     SELECT
         *
     FROM
-        pc_dbt_db.prod.fact_defillama_protocol_tvls
+        {{ref('fact_defillama_protocol_tvls')}}
     WHERE
         defillama_protocol_id = 2626
 )


### PR DESCRIPTION
This PR is more in-depth testing & validation for Etherfi, plus one minor syntax fix.

**Changes:**

Add: etherfi_daily_supply_data (seeded through 7-27-2027)

Add: etherfi liquid tvl _(using defillama API)_

Modify: re-organized etherfi ez-table for clarity & readability

**Key notes:**

1. Etherfi daily supply data was manually constructed from etherfi documentation & seeded through 7-27-2027
2. No additional backed PRs were required to support the supply data extracts for Etherfi

**Testing**

KPIs:
<img width="1431" alt="Etherfi_KPIs_sheets" src="https://github.com/user-attachments/assets/fd0b4350-439e-4874-a762-e44cbae0bf3c" />
![Etherfi_KPIs_snowflake](https://github.com/user-attachments/assets/03387e0e-6b26-4e72-bcc6-de4c4d0f6c61)

Fees:
<img width="1431" alt="Etherfi_Fees_sheets" src="https://github.com/user-attachments/assets/2755b1e4-7bf7-44a0-a22a-f5b1c16acb9c" />
![Etherfi_Fees_snowflake](https://github.com/user-attachments/assets/23be99ba-31e9-4433-a84d-2494836ff2f2)

<img width="1431" alt="Etherfi_Supply_sheets" src="https://github.com/user-attachments/assets/3195d404-78ee-4e91-a338-f22745a90adc" />
![Etherfi_Supply_snowflake](https://github.com/user-attachments/assets/15a222a9-0db0-4396-8a94-416553a47860)
