### PR TITLE
Babylon Project Page - v1

### DIFF
--- a/models/projects/babylon/core/ez_babylon_metrics.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics.sql
@@ -31,7 +31,7 @@ WITH babylon_metrics AS (
     select
         defillama_tvl_data.date,
         CASE
-            WHEN defillama_tvl_data.date < '2025-04-25' THEN defillama_tvl_data.tvl
+            WHEN defillama_tvl_data.date < '2025-04-28' THEN defillama_tvl_data.tvl
             ELSE tvl_usd
         END as tvl,
         tvl - LAG(tvl) 

--- a/models/projects/babylon/core/ez_babylon_metrics.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics.sql
@@ -21,11 +21,29 @@ WITH babylon_metrics AS (
         OVER (ORDER BY date) AS tvl_native_net_change
     FROM {{ ref('fact_babylon_metrics') }}
 )
+, defillama_tvl_data as (
+    select
+        date,
+        tvl
+    from {{ ref('fact_babylon_tvl') }}
+)
+, tvl_seeding as (
+    select
+        defillama_tvl_data.date,
+        CASE
+            WHEN defillama_tvl_data.date < '2025-04-25' THEN defillama_tvl_data.tvl
+            ELSE tvl_usd
+        END as tvl,
+        tvl - LAG(tvl) 
+        OVER (ORDER BY defillama_tvl_data.date) AS tvl_net_change
+    from defillama_tvl_data
+    left join babylon_metrics on defillama_tvl_data.date = babylon_metrics.date
+)
 , date_spine AS (
     SELECT
         date
     FROM {{ ref('dim_date_spine') }}
-    where date between (select min(date) from babylon_metrics) and to_date(sysdate())
+    where date between (select min(date) from tvl_seeding) and to_date(sysdate())
 )
 , market_metrics AS (
     {{ get_coingecko_metrics('babylon') }}
@@ -45,8 +63,8 @@ SELECT
     -- Usage Metrics
     , babylon_metrics.tvl_native
     , babylon_metrics.tvl_native_net_change
-    , babylon_metrics.tvl_usd as tvl
-    , babylon_metrics.tvl_net_change as tvl_net_change
+    , tvl_seeding.tvl
+    , tvl_seeding.tvl_net_change
     , babylon_metrics.active_delegations
     , babylon_metrics.total_stakers
 
@@ -57,3 +75,4 @@ SELECT
 FROM date_spine
 LEFT JOIN market_metrics ON date_spine.date = market_metrics.date
 LEFT JOIN babylon_metrics ON date_spine.date = babylon_metrics.date
+LEFT JOIN tvl_seeding ON date_spine.date = tvl_seeding.date

--- a/models/projects/babylon/core/ez_babylon_metrics.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics.sql
@@ -1,0 +1,59 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BABYLON',
+        database='BABYLON',
+        schema='core',
+        alias='ez_metrics'
+    )
+}}
+
+WITH babylon_metrics AS (
+    SELECT
+        date
+        , active_tvl_btc as tvl_native
+        , active_tvl_usd as tvl_usd
+        , active_delegations as active_delegations
+        , total_stakers as total_stakers
+        , active_tvl_usd - LAG(active_tvl_usd) 
+        OVER (ORDER BY date) AS tvl_net_change
+        , active_tvl_btc - LAG(active_tvl_btc) 
+        OVER (ORDER BY date) AS tvl_native_net_change
+    FROM {{ ref('fact_babylon_metrics') }}
+)
+, date_spine AS (
+    SELECT
+        date
+    FROM {{ ref('dim_date_spine') }}
+    where date between (select min(date) from babylon_metrics) and to_date(sysdate())
+)
+, market_metrics AS (
+    {{ get_coingecko_metrics('babylon') }}
+)
+
+SELECT
+    date_spine.date
+
+    -- Standardized Metrics
+
+    -- Market Metrics 
+    , market_metrics.price
+    , market_metrics.market_cap
+    , market_metrics.fdmc
+    , market_metrics.token_volume
+
+    -- Usage Metrics
+    , babylon_metrics.tvl_native
+    , babylon_metrics.tvl_native_net_change
+    , babylon_metrics.tvl_usd as tvl
+    , babylon_metrics.tvl_net_change as tvl_net_change
+    , babylon_metrics.active_delegations
+    , babylon_metrics.total_stakers
+
+    -- Turnover Metrics
+    , market_metrics.token_turnover_circulating
+    , market_metrics.token_turnover_fdv
+
+FROM date_spine
+LEFT JOIN market_metrics ON date_spine.date = market_metrics.date
+LEFT JOIN babylon_metrics ON date_spine.date = babylon_metrics.date

--- a/models/projects/babylon/core/ez_babylon_metrics.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics.sql
@@ -76,3 +76,4 @@ FROM date_spine
 LEFT JOIN market_metrics ON date_spine.date = market_metrics.date
 LEFT JOIN babylon_metrics ON date_spine.date = babylon_metrics.date
 LEFT JOIN tvl_seeding ON date_spine.date = tvl_seeding.date
+WHERE date_spine.date < to_date(sysdate())

--- a/models/projects/babylon/core/ez_babylon_metrics_by_chain.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics_by_chain.sql
@@ -42,10 +42,5 @@ SELECT
     , babylon_metrics.active_delegations
     , babylon_metrics.total_stakers
 
-    -- Turnover Metrics
-    , market_metrics.token_turnover_circulating
-    , market_metrics.token_turnover_fdv
-
 FROM date_spine
-LEFT JOIN market_metrics ON date_spine.date = market_metrics.date
 LEFT JOIN babylon_metrics ON date_spine.date = babylon_metrics.date

--- a/models/projects/babylon/core/ez_babylon_metrics_by_chain.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics_by_chain.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BABYLON',
+        database='BABYLON',
+        schema='core',
+        alias='ez_metrics_by_chain'
+    )
+}}
+
+WITH babylon_metrics AS (
+    SELECT
+        date
+        , active_tvl_btc as tvl_native
+        , active_tvl_usd as tvl_usd
+        , active_delegations as active_delegations
+        , total_stakers as total_stakers
+        , active_tvl_usd - LAG(active_tvl_usd) 
+        OVER (ORDER BY date) AS tvl_net_change
+        , active_tvl_btc - LAG(active_tvl_btc) 
+        OVER (ORDER BY date) AS tvl_native_net_change
+    FROM {{ ref('fact_babylon_metrics') }}
+)
+, date_spine AS (
+    SELECT
+        date
+    FROM {{ ref('dim_date_spine') }}
+    where date between (select min(date) from babylon_metrics) and to_date(sysdate())
+)
+
+SELECT
+    date_spine.date,
+    'bitcoin' as chain
+
+    -- Standardized Metrics
+
+    -- Usage Metrics
+    , babylon_metrics.tvl_native
+    , babylon_metrics.tvl_native_net_change
+    , babylon_metrics.tvl_usd as tvl
+    , babylon_metrics.tvl_net_change as tvl_net_change
+    , babylon_metrics.active_delegations
+    , babylon_metrics.total_stakers
+
+    -- Turnover Metrics
+    , market_metrics.token_turnover_circulating
+    , market_metrics.token_turnover_fdv
+
+FROM date_spine
+LEFT JOIN market_metrics ON date_spine.date = market_metrics.date
+LEFT JOIN babylon_metrics ON date_spine.date = babylon_metrics.date

--- a/models/staging/babylon/__babylon_sources__.yml
+++ b/models/staging/babylon/__babylon_sources__.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: PROD_LANDING
+    schema: PROD_LANDING
+    database: LANDING_DATABASE
+    tables:
+      - name: raw_babylon_metrics

--- a/models/staging/babylon/fact_babylon_metrics.sql
+++ b/models/staging/babylon/fact_babylon_metrics.sql
@@ -1,0 +1,107 @@
+{{
+    config(
+        materialized="table",
+        alias="fact_babylon_metrics",
+    )
+}}
+
+WITH parsed_data AS (
+  SELECT
+    DATE(EXTRACTION_DATE) as date,
+    EXTRACTION_DATE,
+    PARSE_JSON(SOURCE_JSON):data as json_data
+  FROM {{ source('PROD_LANDING', 'raw_babylon_metrics') }}
+),
+ranked_data AS (
+  SELECT
+    date,
+    EXTRACTION_DATE,
+    json_data,
+    ROW_NUMBER() OVER (PARTITION BY date ORDER BY EXTRACTION_DATE DESC) as rn
+  FROM parsed_data
+)
+, latest_data as (
+  SELECT
+    date,
+    json_data:active_delegations::FLOAT as active_delegations,
+    json_data:active_tvl::FLOAT as active_tvl,
+    json_data:active_tvl::FLOAT / 1e8 as active_tvl_btc,
+    json_data:btc_price_usd::FLOAT as btc_price_usd,
+    active_tvl_btc * btc_price_usd as active_tvl_usd,
+    json_data:pending_tvl::FLOAT as pending_tvl,
+    json_data:total_delegations::FLOAT as total_delegations,
+    json_data:total_stakers::FLOAT as total_stakers,
+    json_data:total_tvl::FLOAT as total_tvl,
+    json_data:unconfirmed_tvl::FLOAT as unconfirmed_tvl
+  FROM ranked_data
+  WHERE rn = 1
+  ORDER BY date
+)
+,
+date_spine AS (
+  SELECT date
+  FROM {{ ref('dim_date_spine') }}
+  WHERE date BETWEEN (SELECT MIN(date) FROM latest_data) AND TO_DATE(SYSDATE())
+),
+front_filled_data AS (
+  SELECT
+    ds.date,
+    COALESCE(
+      ld.active_delegations,
+      LAST_VALUE(ld.active_delegations) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS active_delegations,
+    COALESCE(
+      ld.active_tvl,
+      LAST_VALUE(ld.active_tvl) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS active_tvl,
+    COALESCE(
+      ld.active_tvl_btc,
+      LAST_VALUE(ld.active_tvl_btc) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS active_tvl_btc,
+    COALESCE(
+      ld.btc_price_usd,
+      LAST_VALUE(ld.btc_price_usd) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS btc_price_usd,
+    COALESCE(
+      ld.active_tvl_usd,
+      LAST_VALUE(ld.active_tvl_usd) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS active_tvl_usd,
+    COALESCE(
+      ld.pending_tvl,
+      LAST_VALUE(ld.pending_tvl) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS pending_tvl,
+    COALESCE(
+      ld.total_delegations,
+      LAST_VALUE(ld.total_delegations) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS total_delegations,
+    COALESCE(
+      ld.total_stakers,
+      LAST_VALUE(ld.total_stakers) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS total_stakers,
+    COALESCE(
+      ld.total_tvl,
+      LAST_VALUE(ld.total_tvl) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS total_tvl,
+    COALESCE(
+      ld.unconfirmed_tvl,
+      LAST_VALUE(ld.unconfirmed_tvl) IGNORE NULLS OVER (ORDER BY ds.date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+      0
+    ) AS unconfirmed_tvl
+  FROM date_spine ds
+  LEFT JOIN latest_data ld ON ds.date = ld.date
+)
+
+SELECT *
+FROM front_filled_data
+ORDER BY date
+
+

--- a/models/staging/babylon/fact_babylon_tvl.sql
+++ b/models/staging/babylon/fact_babylon_tvl.sql
@@ -1,4 +1,4 @@
-{{ config(materialized="table") }}
+{{ config(materialized="incremental") }}
 
 with tvl as (
     SELECT
@@ -13,3 +13,6 @@ SELECT
     tvl
 FROM tvl
 WHERE date < to_date(sysdate())
+{% if is_incremental() %}
+    and date >= (select max(date) from {{ this }})
+{% endif %}

--- a/models/staging/babylon/fact_babylon_tvl.sql
+++ b/models/staging/babylon/fact_babylon_tvl.sql
@@ -1,0 +1,15 @@
+{{ config(materialized="table") }}
+
+with tvl as (
+    SELECT
+        *
+    FROM
+        {{ref('fact_defillama_protocol_tvls')}}
+    WHERE
+        defillama_protocol_id = 5258
+)
+SELECT
+    date,
+    tvl
+FROM tvl
+WHERE date < to_date(sysdate())


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [x] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [x] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist -- CAD TO ADD AS A P1 FAST FOLLOW

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below
<img width="1134" alt="Screenshot 2025-04-25 at 12 14 30 PM" src="https://github.com/user-attachments/assets/749d9bdb-1e4b-4ecd-b21d-5149b1066ee0" />
<img width="1134" alt="Screenshot 2025-04-25 at 12 14 39 PM" src="https://github.com/user-attachments/assets/357f91cb-820c-4c23-8149-bc2b63cdd563" />


**Key Notes:**
1. TVL numbers from the start of the data until 4-28-2025 are seeded from the defillama API. For all dates after 4-25-2025 tvl is pulled directly from Babylon's API
2. CAD write up for Babylon will be a fast follow

## Other

- [x] Any other relevant information that may be helpful