### PR TITLE
Various Oncall Fixes

### DIFF
--- a/models/projects/convex/raw/fact_convex_pools.sql
+++ b/models/projects/convex/raw/fact_convex_pools.sql
@@ -19,4 +19,5 @@
   FROM {{ source('ETHEREUM_FLIPSIDE', 'fact_decoded_traces') }}
   WHERE to_address = lower('0xF403C135812408BFbE8713b5A23a04b3D48AAE31')
     AND function_name = 'addPool'
-    AND trace_succeeded = TRUE
+    -- Will be replaced by trace_succeeded = TRUE on 2025-05-05
+    AND trace_status = 'SUCCESS'

--- a/models/projects/gains_network/core/ez_gains_network_metrics.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics.sql
@@ -5,7 +5,6 @@
         database="gains_network",
         schema="core",
         alias="ez_metrics",
-        enabled=false,
     )
 }}
 

--- a/models/projects/gains_network/core/ez_gains_network_metrics_by_chain.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics_by_chain.sql
@@ -5,7 +5,6 @@
         database="gains_network",
         schema="core",
         alias="ez_metrics_by_chain",
-        enabled=false,
     )
 }}
 

--- a/models/projects/rabbitx/core/ez_rabbit_x_metrics.sql
+++ b/models/projects/rabbitx/core/ez_rabbit_x_metrics.sql
@@ -5,7 +5,6 @@
         database="rabbit_x",
         schema="core",
         alias="ez_metrics",
-        enabled=false,
     )
 }}
 

--- a/models/projects/rabbitx/core/ez_rabbit_x_metrics_by_chain.sql
+++ b/models/projects/rabbitx/core/ez_rabbit_x_metrics_by_chain.sql
@@ -5,7 +5,6 @@
         database="rabbit_x",
         schema="core",
         alias="ez_metrics_by_chain",
-        enabled=false,
     )
 }}
 

--- a/models/staging/gains/_test_fact_gains_data_v8_v9.yml
+++ b/models/staging/gains/_test_fact_gains_data_v8_v9.yml
@@ -1,5 +1,5 @@
 models:
-- name: fact_gains_trading_volume_unique_traders
+- name: fact_gains_data_v8_v9
   tests:
   - 'dbt_expectations.expect_table_row_count_to_be_between:':
       min_value: 1
@@ -9,11 +9,10 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
-    # Upstream source deprecated in favor of fact_gains_data_v8_v9
-    # - dbt_expectations.expect_row_values_to_have_recent_data:
-    #     datepart: day
-    #     interval: 3
-    #     severity: warn
+    - dbt_expectations.expect_row_values_to_have_recent_data:
+        datepart: day
+        interval: 3
+        severity: warn
   - name: UNIQUE_TRADERS
     tests:
     - not_null

--- a/models/staging/injective/_test_fact_injective_revenue_silver.yml
+++ b/models/staging/injective/_test_fact_injective_revenue_silver.yml
@@ -19,5 +19,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 3
+              interval: 7
               severity: warn

--- a/models/staging/level_finance/_test_fact_level_finance_trading_volume.yml
+++ b/models/staging/level_finance/_test_fact_level_finance_trading_volume.yml
@@ -11,7 +11,7 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 6
         severity: warn
   - name: TRADING_VOLUME
     tests:

--- a/models/staging/level_finance/_test_fact_level_finance_unique_traders.yml
+++ b/models/staging/level_finance/_test_fact_level_finance_unique_traders.yml
@@ -11,7 +11,7 @@ models:
     - dbt_expectations.expect_column_to_exist
     - dbt_expectations.expect_row_values_to_have_recent_data:
         datepart: day
-        interval: 3
+        interval: 6
         severity: warn
   - name: UNIQUE_TRADERS
     tests:

--- a/models/staging/rabbitx/_test_fact_rabbitx_unique_traders.yml
+++ b/models/staging/rabbitx/_test_fact_rabbitx_unique_traders.yml
@@ -9,10 +9,11 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
-    - dbt_expectations.expect_row_values_to_have_recent_data:
-        datepart: day
-        interval: 3
-        severity: warn
+    # Upstream source deprecated
+    # - dbt_expectations.expect_row_values_to_have_recent_data:
+    #     datepart: day
+    #     interval: 3
+    #     severity: warn
   - name: UNIQUE_TRADERS
     tests:
     - not_null

--- a/seeds/supply/hivemapper/hivemapper_daily_premine_unlocks.csv
+++ b/seeds/supply/hivemapper/hivemapper_daily_premine_unlocks.csv
@@ -1,4 +1,4 @@
-date,premine_unlocks
+date,premine_unlocks_native
 2021-04-20,0.00
 2021-04-21,0.00
 2021-04-22,0.00


### PR DESCRIPTION
## :pushpin: References
- Relevant Slack [Thread](https://artemisxyz.slack.com/archives/C05S8H76M08/p1745799500320679)
- Fixing EVM Flipside Migration column for Convex
- Turning on gains and rabbitx models again
- Removing test on rabbitx unique traders that's no longer used
- Adding test for gains v8/v9. Removing old test for api that is no longer updated.
- Lengthening lookback for injective revenue silver test and level finance tests
- Updating col name for hivemapper to `premine_unlocks_native`

Gains
<img width="680" alt="image" src="https://github.com/user-attachments/assets/3a1a0415-ef09-4263-8ad1-06c893708307" />
Rabbitx
<img width="682" alt="image" src="https://github.com/user-attachments/assets/b189c159-1b0f-44f7-a6a7-2213b51d1cd6" />
Level Finance
<img width="664" alt="image" src="https://github.com/user-attachments/assets/30dbbddd-a5bd-4e78-b786-9a68f75bcc40" />

Injective Revenue Silver
<img width="681" alt="image" src="https://github.com/user-attachments/assets/b7470932-ae1c-42fc-baef-cdb7d1824a64" />

Convex (sql compiles and executes)
<img width="811" alt="image" src="https://github.com/user-attachments/assets/66040be0-0665-457d-830a-94615d44530f" />

