### PR TITLE
Disable Blast EZ Model to Silence Freshness Alert

### DIFF
--- a/models/projects/blast/core/ez_blast_metrics.sql
+++ b/models/projects/blast/core/ez_blast_metrics.sql
@@ -5,7 +5,8 @@
         snowflake_warehouse="blast",
         database="blast",
         schema="core",
-        alias="ez_metrics"
+        alias="ez_metrics",
+        enabled=false,
     )
 }}
 


### PR DESCRIPTION
## :pushpin: References
- Blast has been deprecated by Flipside
- Disabling this model now as all of the relevant jobs have been turned off, and we'd like to disable the freshness alert

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [ ] Any other relevant information that may be helpful