### PR TITLE
Update FACT_NFT_SALES Schema

### DIFF
--- a/macros/nft/nft_trading_volume.sql
+++ b/macros/nft/nft_trading_volume.sql
@@ -4,7 +4,7 @@
             block_timestamp::date as date,
             '{{ chain }}' as chain,
             sum(coalesce(sales_amount * price, 0)) nft_trading_volume
-        from solana_flipside.nft.fact_nft_sales
+        from solana_flipside.solana_share.fact_nft_sales
         left join
             ({{ get_coingecko_price_with_latest("solana") }}) prices
             on block_timestamp::date = prices.date

--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -20,7 +20,7 @@ sources:
 # SOLANA
 
   - name: SOLANA_FLIPSIDE_NFT
-    schema: NFT
+    schema: SOLANA_SHARE
     database: SOLANA_FLIPSIDE
     tables:
       - name: fact_nft_mints

--- a/models/staging/magiceden/fact_magiceden_solana_transactions.sql
+++ b/models/staging/magiceden/fact_magiceden_solana_transactions.sql
@@ -40,7 +40,7 @@ WITH transaction_data AS (
     FROM 
         solana_flipside.core.fact_transactions t
     JOIN 
-        solana_flipside.nft.fact_nft_sales n
+        solana_flipside.solana_share.fact_nft_sales n
     ON 
         t.tx_id = n.tx_id
     LEFT JOIN 


### PR DESCRIPTION
## Summary
- Flipside has moved the `FACT_NFT_SALES` table from the `NFT` schema to the`SOLANA_SHARE`
- Updating relevant DB relations and dbt sources

## Test Plan
```
SHOW TABLES IN SCHEMA SOLANA_FLIPSIDE.SOLANA_SHARE;
```
<img width="525" alt="image" src="https://github.com/user-attachments/assets/08f27eb8-8345-461e-a11a-411ef42e9cdd" />
