### PR TITLE
Fix Foward Filled Address Balances Macro

### DIFF
--- a/macros/address_balances/forward_filled_address_balances.sql
+++ b/macros/address_balances/forward_filled_address_balances.sql
@@ -32,6 +32,7 @@ with
                 else ab.contract_address
             end as contract_address
             , block_timestamp
+            , decimals
             {%if chain == 'solana' %} -- note Solana balances are already decimals adjusted
                 , amount AS balance_raw
             {% else %}


### PR DESCRIPTION
## Summary
- In https://github.com/Artemis-xyz/dbt/pull/1257/files#diff-f4f2ff9b6164c2f47703b9f0761c3d62b530f72d657bdb0b7f4b70020f43f9cc we modified the `forward_filled_address_balances` but were missing the `decimals` column from the `old_balances` CTE

## Test Plan
Compiled SQL
<img width="683" alt="image" src="https://github.com/user-attachments/assets/c151d1d5-c99f-4c6e-960e-c47e6eb841fb" />
SQL with `decimals` col added to the `old_balances` CTE
<img width="935" alt="image" src="https://github.com/user-attachments/assets/d339fbbc-05ad-414a-a133-4afe10ee5ea1" />

