### PR TITLE
Update Flipside Solana NFT Schema

### DIFF
--- a/macros/nft/nft_trading_volume.sql
+++ b/macros/nft/nft_trading_volume.sql
@@ -4,7 +4,7 @@
             block_timestamp::date as date,
             '{{ chain }}' as chain,
             sum(coalesce(sales_amount * price, 0)) nft_trading_volume
-        from solana_flipside.solana_share.fact_nft_sales
+        from solana_flipside.nft.ez_nft_sales
         left join
             ({{ get_coingecko_price_with_latest("solana") }}) prices
             on block_timestamp::date = prices.date

--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -20,11 +20,11 @@ sources:
 # SOLANA
 
   - name: SOLANA_FLIPSIDE_NFT
-    schema: SOLANA_SHARE
+    schema: NFT
     database: SOLANA_FLIPSIDE
     tables:
       - name: fact_nft_mints
-      - name: fact_nft_sales
+      - name: ez_nft_sales
 
   - name: SOLANA_FLIPSIDE
     schema: CORE

--- a/models/staging/injective/_test_fact_injective_revenue_silver.yml
+++ b/models/staging/injective/_test_fact_injective_revenue_silver.yml
@@ -19,5 +19,5 @@ models:
           - dbt_expectations.expect_column_to_exist
           - dbt_expectations.expect_row_values_to_have_recent_data:
               datepart: day
-              interval: 7
+              interval: 8
               severity: warn

--- a/models/staging/magiceden/fact_magiceden_solana_transactions.sql
+++ b/models/staging/magiceden/fact_magiceden_solana_transactions.sql
@@ -40,7 +40,7 @@ WITH transaction_data AS (
     FROM 
         solana_flipside.core.fact_transactions t
     JOIN 
-        solana_flipside.solana_share.fact_nft_sales n
+        solana_flipside.nft.ez_nft_sales n
     ON 
         t.tx_id = n.tx_id
     LEFT JOIN 

--- a/models/staging/metaplex/fact_metaplex_sales.sql
+++ b/models/staging/metaplex/fact_metaplex_sales.sql
@@ -10,7 +10,7 @@
 SELECT 
     s.*
 FROM 
-    {{ source('SOLANA_FLIPSIDE_NFT', 'fact_nft_sales') }} AS s
+    {{ source('SOLANA_FLIPSIDE_NFT', 'ez_nft_sales') }} AS s
 JOIN 
     {{ ref('fact_metaplex_mints') }} AS m ON s.mint = m.mint
 {% if is_incremental() %}


### PR DESCRIPTION
## Summary
- Updating schema from `SOLANA_SHARE` to `NFT`
- Loosening interval of test on `fact_injective_revenue_silver` due to off-by-one error
<img width="648" alt="image" src="https://github.com/user-attachments/assets/a57393f8-dc53-49e6-8bfb-d28890b8af4a" />
