### PR TITLE
Part 1: Stablecoin Label Migration

### DIFF
--- a/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_with_labels_silver.yml
+++ b/models/metrics/stablecoins/breakdowns/_test_agg_daily_stablecoin_breakdown_with_labels_silver.yml
@@ -1,0 +1,17 @@
+models:
+  - name: agg_daily_stablecoin_breakdown_with_labels_silver
+    tests:
+      - "dbt_expectations.expect_grouped_row_values_to_have_recent_data":
+          group_by: [CHAIN, SYMBOL]
+          timestamp_column: "DATE"
+          datepart: "day"
+          interval: 2
+    columns:
+      - name: "DATE"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist
+      - name: "CHAIN"
+        tests:
+          - not_null
+          - dbt_expectations.expect_column_to_exist

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels.sql
@@ -1,0 +1,37 @@
+{{ config(materialized="incremental", unique_key="unique_id", snowflake_warehouse="STABLECOIN_V2_LG") }}
+{% set list_stablecoin_address = var('list_stablecoin_address', []) %}
+select
+select
+    date,
+    address,
+    name, 
+    friendly_name,
+    icon,
+    artemis_application_id,
+    artemis_category_id,
+    
+    is_wallet,
+
+    contract_address,
+    symbol,
+    
+    stablecoin_transfer_volume,
+    stablecoin_daily_txns,
+    artemis_stablecoin_transfer_volume,
+    artemis_stablecoin_daily_txns,
+    p2p_stablecoin_transfer_volume,
+    p2p_stablecoin_daily_txns,
+    stablecoin_supply,
+    chain,
+    unique_id
+from {{ ref("agg_daily_stablecoin_breakdown_with_labels_silver") }}
+{% if is_incremental() and list_stablecoin_address | length > 0 %}
+    where (
+    {% for stablecoin in list_stablecoin_address %}
+        {% if not loop.first %}or {% endif %}lower(contract_address) = lower('{{ stablecoin }}')
+    {% endfor %}
+    )
+{% endif %}
+{% if is_incremental()  and list_stablecoin_address | length == 0 %}
+    where date >= (select DATEADD('day', -3, max(date)) from {{ this }})
+{% endif %}

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels.sql
@@ -1,7 +1,6 @@
 {{ config(materialized="incremental", unique_key="unique_id", snowflake_warehouse="STABLECOIN_V2_LG") }}
 {% set list_stablecoin_address = var('list_stablecoin_address', []) %}
 select
-select
     date,
     address,
     name, 

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels_silver.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels_silver.sql
@@ -1,0 +1,66 @@
+{{ config(materialized="incremental", unique_key="unique_id", snowflake_warehouse="STABLECOIN_V2_LG") }}
+
+{% set chain_list = ['arbitrum', 'avalanche', 'base', 'bsc', 'celo', 'ethereum', 'mantle', 'optimism', 'polygon', 'solana', 'sui', 'ton', 'tron'] %}
+{% set list_stablecoin_address = var('list_stablecoin_address', []) %}
+{% set stablecoin_models = [] %}
+{% for chain in chain_list %}
+    {% do stablecoin_models.append(ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address_with_labels")) %}
+    {% do stablecoin_models.append(ref("fact_" ~ chain ~ "_stablecoin_contracts")) %}
+{% endfor %}
+
+with
+    daily_data as (
+    {% if is_incremental() and list_stablecoin_address | length > 0 %}
+        -- If specific addresses exist, check if they exist in fact_<chain>_stablecoin_contracts before querying
+        {% for chain in chain_list %}
+            select *
+            from {{ ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address_with_labels") }}
+            where lower (contract_address) IN (
+                select lower(contract_address)
+                from {{ ref("fact_" ~ chain ~ "_stablecoin_contracts") }}
+                where lower(contract_address) IN (
+                    {% for address in list_stablecoin_address %}
+                        lower('{{ address }}'){% if not loop.last %}, {% endif %}
+                    {% endfor %}
+                )
+            )
+            {% if not loop.last %} union all {% endif %}
+        {% endfor %}
+    {% endif %}
+    {% if list_stablecoin_address | length == 0 %}
+        {% for chain in chain_list %}
+            select *
+            from {{ ref("ez_" ~ chain ~ "_stablecoin_metrics_by_address_with_labels") }}
+            {% if is_incremental() %}
+                where date >= (select DATEADD('day', -3, max(date)) from {{ this }})
+            {% endif %}
+            {% if not loop.last %} union all {% endif %}
+        {% endfor %}
+    {% endif %}
+)
+
+select
+    date,
+    address,
+    name, 
+    friendly_name,
+    icon,
+    artemis_application_id,
+    artemis_category_id,
+    
+    is_wallet,
+
+    contract_address,
+    symbol,
+    
+    stablecoin_transfer_volume,
+    stablecoin_daily_txns,
+    artemis_stablecoin_transfer_volume,
+    artemis_stablecoin_daily_txns,
+    p2p_stablecoin_transfer_volume,
+    p2p_stablecoin_daily_txns,
+    stablecoin_supply,
+    chain,
+    unique_id
+from daily_data
+where date < to_date(sysdate())


### PR DESCRIPTION
This is part one of the label migration:
1. Creating the two core stablecoin tables with updated labels. Next it will be important to update the FE logic to support this change and make sure nothing breaks. The largest issue right now will be the Categories and Applications have new names in the table. 