### PR TITLE
Update near actions

### DIFF
--- a/macros/wallets/distinct_eoa_addresses.sql
+++ b/macros/wallets/distinct_eoa_addresses.sql
@@ -17,6 +17,7 @@
         select distinct tx_signer as address, 'signer' as address_type
         from near_flipside.core.fact_transactions
         --tx_singer is a contract: https://flipsidecrypto.github.io/near-models/#!/model/model.near.core__fact_actions_events_function_call
-        where tx_signer not in (select receiver_id from near_flipside.core.fact_actions_events_function_call where method_name is not null)
+        -- receipt_receiver_id is a contract: https://flipsidecrypto.github.io/near-models/#!/model/model.near_models.core__ez_actions
+        where tx_signer not in (select receipt_receiver_id from near_flipside.core.ez_actions where method_name is not null)
     {% endif %}
 {% endmacro %}

--- a/macros/wallets/distinct_eoa_addresses.sql
+++ b/macros/wallets/distinct_eoa_addresses.sql
@@ -18,6 +18,6 @@
         from near_flipside.core.fact_transactions
         --tx_singer is a contract: https://flipsidecrypto.github.io/near-models/#!/model/model.near.core__fact_actions_events_function_call
         -- receipt_receiver_id is a contract: https://flipsidecrypto.github.io/near-models/#!/model/model.near_models.core__ez_actions
-        where tx_signer not in (select receipt_receiver_id from near_flipside.core.ez_actions where method_name is not null)
+        where tx_signer not in (select receipt_receiver_id from near_flipside.core.ez_actions where action_data:method_name is not null)
     {% endif %}
 {% endmacro %}

--- a/models/dimensions/contracts/dim_flipside_near_contracts.sql
+++ b/models/dimensions/contracts/dim_flipside_near_contracts.sql
@@ -4,7 +4,7 @@ with
     deployed_contracts as (
         select tx_signer as address,
         max(ft.modified_timestamp) as modified_timestamp
-        from near_flipside.core.fact_actions_events fae
+        from near_flipside.core.ez_actions fae
         join
             near_flipside.core.fact_transactions ft
             on fae.tx_hash

--- a/models/dimensions/contracts/dim_flipside_near_contracts.sql
+++ b/models/dimensions/contracts/dim_flipside_near_contracts.sql
@@ -2,14 +2,14 @@
 
 with
     deployed_contracts as (
-        select tx_signer as address,
+        select ea.tx_signer as address,
         max(ft.modified_timestamp) as modified_timestamp
-        from near_flipside.core.ez_actions fae
+        from near_flipside.core.ez_actions ea
         join
             near_flipside.core.fact_transactions ft
-            on fae.tx_hash
+            on ea.tx_hash
             = ft.tx_hash
-        where fae.action_name = 'DeployContract' and ft.tx_receiver = ft.tx_signer
+        where ea.action_name = 'DeployContract' and ft.tx_receiver = ft.tx_signer
         group by 1
     ),
     contracts_tagged as (

--- a/models/staging/near/fact_near_contracts.sql
+++ b/models/staging/near/fact_near_contracts.sql
@@ -2,7 +2,7 @@
 select
     date_trunc('week', near_flipside.core.ez_actions.block_timestamp) as date,
     count(*) contracts_deployed,
-    count(distinct(tx_signer)) contract_deployers,
+    count(distinct(ez_actions.tx_signer)) contract_deployers,
     'near' as chain
 from near_flipside.core.ez_actions
 join

--- a/models/staging/near/fact_near_contracts.sql
+++ b/models/staging/near/fact_near_contracts.sql
@@ -1,13 +1,13 @@
 {{ config(materialized="view") }}
 select
-    date_trunc('week', near_flipside.core.fact_actions_events.block_timestamp) as date,
+    date_trunc('week', near_flipside.core.ez_actions.block_timestamp) as date,
     count(*) contracts_deployed,
     count(distinct(tx_signer)) contract_deployers,
     'near' as chain
-from near_flipside.core.fact_actions_events
+from near_flipside.core.ez_actions
 join
     near_flipside.core.fact_transactions
-    on near_flipside.core.fact_actions_events.tx_hash
+    on near_flipside.core.ez_actions.tx_hash
     = near_flipside.core.fact_transactions.tx_hash
 where action_name = 'DeployContract'
 group by 1

--- a/models/staging/near/fact_near_da_metrics.sql
+++ b/models/staging/near/fact_near_da_metrics.sql
@@ -11,11 +11,11 @@ with
             tx_hash,
             block_timestamp::date as date,
             receipt_signer_id as submitter,
-            len(action_data::string) * 6 / 8 as bytes
+            len(action_data:args::VARCHAR) * 6 / 8 as bytes
         from near_flipside.core.ez_actions
         --Will need to scale out as more l2s use nearDA, right now just one tho
         where receipt_signer_id = 'vsl-submitter.near'
-            and action_name = 'submit' 
+            and action_data:method_name::VARCHAR = 'submit'
     ),
     blob_gas_fees as (
         select 

--- a/models/staging/near/fact_near_da_metrics.sql
+++ b/models/staging/near/fact_near_da_metrics.sql
@@ -10,12 +10,12 @@ with
         select 
             tx_hash,
             block_timestamp::date as date,
-            signer_id as submitter,
-            len(args::string) * 6 / 8 as bytes
-        from near_flipside.core.fact_actions_events_function_call
+            receipt_signer_id as submitter,
+            len(action_data::string) * 6 / 8 as bytes
+        from near_flipside.core.ez_actions
         --Will need to scale out as more l2s use nearDA, right now just one tho
-        where signer_id = 'vsl-submitter.near'
-            and method_name = 'submit' 
+        where receipt_signer_id = 'vsl-submitter.near'
+            and action_name = 'submit' 
     ),
     blob_gas_fees as (
         select 


### PR DESCRIPTION
## Summary
- Near actions tables have been deprecated in favor of `ez_actions`
- Docs for new table in question https://flipsidecrypto.github.io/near-models/#!/model/model.near_models.core__ez_actions


## Test Plan

 - `fact_near_da_metrics`
 Prod
<img width="654" alt="image" src="https://github.com/user-attachments/assets/0291d3ef-4eba-4ccb-a89a-4845861ff0e2" />

Compiled SQL

<img width="519" alt="image" src="https://github.com/user-attachments/assets/3b794b2a-cd8e-496f-8ab5-00486a641ef9" />

 - `fact_near_contracts`
<img width="801" alt="image" src="https://github.com/user-attachments/assets/e1fb546a-9a6c-4271-9279-56af4b482195" />

 - `dim_flipside_near_contracts`
<img width="744" alt="image" src="https://github.com/user-attachments/assets/5be213f4-96ea-49f9-b86d-905d4baed76e" />


 - `dim_near_eoa_addresses`
 Can't verify the prod data because it's a view that no longer works
<img width="1129" alt="image" src="https://github.com/user-attachments/assets/2520f8a3-8916-43dd-b0e9-8bcd66940efd" />