### PR TITLE
Tron Data mIgration part 1: Create upsteam models to move tron from current DP

### DIFF
--- a/macros/address_balances/evm_address_credits.sql
+++ b/macros/address_balances/evm_address_credits.sql
@@ -15,7 +15,7 @@
     {% if is_incremental() %}
         and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
     {% endif %}
-    {% if chain not in ('celo', 'sonic', 'codex') %}
+    {% if chain not in ('celo', 'sonic', 'codex', 'tron', 'kaia') %}
         union all
         select
             block_timestamp

--- a/macros/address_balances/evm_address_debits.sql
+++ b/macros/address_balances/evm_address_debits.sql
@@ -15,7 +15,7 @@
     {% if is_incremental() %}
         and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
     {% endif %}
-    {% if chain not in ('celo', 'sonic', 'codex') %}
+    {% if chain not in ('celo', 'sonic', 'codex', 'tron', 'kaia') %}
         union all
         select
             block_timestamp

--- a/models/staging/tron/fact_tron_address_balances.sql
+++ b/models/staging/tron/fact_tron_address_balances.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="BALANCES_LG", materialized="incremental", unique_key=["block_timestamp", "block_number", "contract_address", "address"])}}
+
+{{ evm_address_balances("tron") }}

--- a/models/staging/tron/fact_tron_address_credits.sql
+++ b/models/staging/tron/fact_tron_address_credits.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="BALANCES_LG", materialized="incremental", unique_key=["transaction_hash", "event_index", "trace_index"])}}
+
+{{ evm_address_credits("tron") }}

--- a/models/staging/tron/fact_tron_address_debits.sql
+++ b/models/staging/tron/fact_tron_address_debits.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="BALANCES_LG", materialized="incremental", unique_key=["transaction_hash", "event_index", "trace_index"])}}
+
+{{ evm_address_debits("tron") }}

--- a/models/staging/tron/fact_tron_token_transfers.sql
+++ b/models/staging/tron/fact_tron_token_transfers.sql
@@ -19,6 +19,23 @@ prices as ({{get_multiple_coingecko_price_with_latest('tron')}})
             and datetime >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
 )
+-- TRON USDT supply for the address below is negative to begin with, this means its first transfer is out 
+-- not in, the data at the beginning of tron is pretty iffy and the block explorer seems to fail the closer you
+-- get to the genesis block. it is only max negative by $10 over its history so I am giving it an inital supply of 10000000/1e6 USDT
+-- THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC is the contract creator
+-- https://tronscan.org/#/tools/advanced-filter?type=transfer&secondType=20&times=1530417600000%2C1556769599999&fromAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&toAddress=THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC&token=TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t&imgUrl=https%3A%2F%2Fstatic.tronscan.org%2Fproduction%2Flogo%2Fusdtlogo.png&tokenName=Tether%20USD&tokenAbbr=USDT&relation=or
+, inital_token_transfers as (
+    --This Transaction is never emitted on chain so the values are hardcoded
+    select block_timestamp, block_number, transaction_hash, transaction_index, event_index, contract_address, from_address, to_address, amount_raw, amount_native
+    from (
+        values 
+        ( '2019-04-16 07:51:09.000'::timestamp, 8418439, '0000000000000000000000000000000000000000000000000000000000000000', -1, 1, 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb', 'THPvaUhoh2Qn2y9THCZML3H815hhFhn5YC', 10000000, 10)
+    ) as t(block_timestamp, block_number, transaction_hash, transaction_index, event_index, contract_address, from_address, to_address, amount_raw, amount_native)
+    {% if is_incremental() %}
+        where block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}
+)
+        
 select
     block_timestamp
     , block_number


### PR DESCRIPTION
1. We are moving off current Data Provider for Tron. 
2. Create Transfers and Balances tables