### PR TITLE
Wes/bananagun fixes

### DIFF
--- a/macros/bananagun/get_bananagun_contracts.sql
+++ b/macros/bananagun/get_bananagun_contracts.sql
@@ -3,6 +3,7 @@ WITH all_contracts AS (
     SELECT
         '{{ chain }}' AS source,
         TO_ADDRESS AS to_address,
+        sysdate() as last_updated_timestamp
     FROM
         {{ chain }}_FLIPSIDE.CORE.FACT_TRACES
     WHERE
@@ -18,10 +19,14 @@ WITH all_contracts AS (
             )
             {% endif %}
         )
+    {% if is_incremental() %}
+        AND block_timestamp > (SELECT dateadd('day', -3, MAX(last_updated_timestamp)) FROM {{ this }})
+    {% endif %}
 )
 SELECT
     source,
     to_address as contract_address,
+    last_updated_timestamp
 FROM
     all_contracts 
     

--- a/macros/bananagun/get_bananagun_fees.sql
+++ b/macros/bananagun/get_bananagun_fees.sql
@@ -2,13 +2,14 @@
     WITH token_prices AS (
         SELECT
             DATE_TRUNC('hour', HOUR) as price_hour,
+            CASE WHEN is_native THEN 'So11111111111111111111111111111111111111111'
+            ELSE TOKEN_ADDRESS END as token_address,
             PRICE as token_price
         FROM
             {% if chain == 'solana' %}
                 SOLANA_FLIPSIDE.PRICE.EZ_PRICES_HOURLY
-                WHERE SYMBOL = 'SOL'
+                WHERE 1=1
                 AND BLOCKCHAIN = 'solana'
-                AND IS_NATIVE = TRUE
             {% else %}
                 ETHEREUM_FLIPSIDE.PRICE.EZ_PRICES_HOURLY
                 WHERE SYMBOL = 'ETH'
@@ -21,6 +22,7 @@
             SELECT
                 'SOLANA' as source,
                 TX_ID as transaction_hash,
+                "INDEX" as index,
                 AMOUNT as fee_amount,
                 BLOCK_TIMESTAMP,
                 fee_amount * tp.token_price as fee_usd
@@ -28,6 +30,7 @@
                 SOLANA_FLIPSIDE.CORE.FACT_TRANSFERS ft
                 LEFT JOIN token_prices tp 
                     ON DATE_TRUNC('hour', ft.BLOCK_TIMESTAMP) = tp.price_hour
+                    AND ft.mint = tp.token_address
             WHERE
                 TX_TO IN (
                     '47hEzz83VFR23rLTEeVm9A7eFzjJwjvdupPPmX3cePqF',
@@ -36,11 +39,14 @@
                 )
                 {% if is_incremental() %}
                     AND BLOCK_TIMESTAMP > (SELECT dateadd('day', -3, MAX(BLOCK_TIMESTAMP)) FROM {{ this }})
+                {% else %}
+                    AND BLOCK_TIMESTAMP > '2023-12-30'
                 {% endif %}
         {% else %}
             SELECT
                 upper('{{ chain }}') as source,
                 TX_HASH as transaction_hash,
+                EVENT_INDEX as index,
                 (PC_DBT_DB.PROD.HEX_TO_INT(substr(DATA, 3, 64))) / pow(10, 18) as fee_amount,
                 BLOCK_TIMESTAMP,
                 fee_amount * tp.token_price as fee_usd
@@ -57,6 +63,7 @@
     SELECT 
         source,
         transaction_hash,
+        index,
         fee_amount,
         BLOCK_TIMESTAMP,
         fee_usd

--- a/macros/bananagun/get_bananagun_fees.sql
+++ b/macros/bananagun/get_bananagun_fees.sql
@@ -58,6 +58,9 @@
                     ON DATE_TRUNC('hour', e.BLOCK_TIMESTAMP) = tp.price_hour
             WHERE
                 TOPICS[0] IN ('0x72015ace03712f361249380657b3d40777dd8f8a686664cab48afd9dbbe4499f','0x0c2a2f565c7774c59e49ef6b3c255329f4d254147e06e724d3a8569bb7bd21ad')
+                {% if is_incremental() %}
+                    AND BLOCK_TIMESTAMP > (SELECT dateadd('day', -3, MAX(BLOCK_TIMESTAMP)) FROM {{ this }})
+                {% endif %}
         {% endif %}
     )
     SELECT 

--- a/macros/bananagun/get_bananagun_metrics.sql
+++ b/macros/bananagun/get_bananagun_metrics.sql
@@ -19,6 +19,9 @@ FROM
     trades
     LEFT JOIN fees ON trades.transaction_hash = fees.transaction_hash
 WHERE fees.fee_usd < 1e6
+{% if is_incremental() %}
+    AND trades.block_timestamp > (SELECT dateadd('day', -3, MAX(trade_date)) FROM {{ this }})
+{% endif %}
 GROUP BY
     trades.block_timestamp::date
 ORDER BY

--- a/models/staging/bananagun/dim_bananagun_base_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_base_contracts.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='contract_address'
     )
 }}
 

--- a/models/staging/bananagun/dim_bananagun_base_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_base_contracts.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='contract_address'
     )
 }}

--- a/models/staging/bananagun/dim_bananagun_blast_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_blast_contracts.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='contract_address'
     )
 }}
 

--- a/models/staging/bananagun/dim_bananagun_blast_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_blast_contracts.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='contract_address'
     )
 }}

--- a/models/staging/bananagun/dim_bananagun_ethereum_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_ethereum_contracts.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='contract_address'
     )
 }}
 

--- a/models/staging/bananagun/dim_bananagun_ethereum_contracts.sql
+++ b/models/staging/bananagun/dim_bananagun_ethereum_contracts.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='contract_address'
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_base_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_base_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_base_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_base_fees.sql
@@ -2,7 +2,6 @@
     config(
         materialized='table',
         snowflake_warehouse='BANANAGUN',
-        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_base_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_base_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN',
+        materialized='incremental',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_base_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_base_metrics.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='trade_date'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_base_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_base_metrics.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='trade_date'
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_base_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_base_trades.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key='transaction_hash'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_base_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_base_trades.sql
@@ -1,8 +1,7 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN',
-        unique_key='transaction_hash'
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN')
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_fees.sql
@@ -1,8 +1,7 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN',
-        unique_key=['transaction_hash','index']
+        snowflake_warehouse='BANANAGUN'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_metrics.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='trade_date'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_metrics.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='trade_date'
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_blast_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_trades.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key='transaction_hash'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_blast_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_blast_trades.sql
@@ -1,8 +1,7 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN',
-        unique_key='transaction_hash'
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN')
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN')
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_fees.sql
@@ -1,8 +1,7 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN',
-        unique_key=['transaction_hash','index']
+        snowflake_warehouse='BANANAGUN'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_metrics.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='trade_date'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key='transaction_hash'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
@@ -1,8 +1,7 @@
 {{
     config(
-        materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
-        unique_key='transaction_hash'
+        materialized='table',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN')
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_ethereum_trades.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized='table',
+        materialized='incremental',
         snowflake_warehouse='BANANAGUN',
         unique_key='transaction_hash'
     )

--- a/models/staging/bananagun/fact_bananagun_solana_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_fees.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='ANALYTICS_XL',
+        snowflake_warehouse='BANANAGUN',
         unique_key=['transaction_hash','index']
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_solana_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_fees.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='ANALYTICS_XL',
+        unique_key=['transaction_hash','index']
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_solana_fees.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_fees.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key=['transaction_hash','index']
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_solana_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_metrics.sql
@@ -1,7 +1,8 @@
 {{
     config(
-        materialized='table',
-        snowflake_warehouse='BANANAGUN'
+        materialized='incremental',
+        snowflake_warehouse='BANANAGUN',
+        unique_key='trade_date'
     )
 }}
 

--- a/models/staging/bananagun/fact_bananagun_solana_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_metrics.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='trade_date'
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_solana_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_trades.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN',
+        snowflake_warehouse=var('snowflake_warehouse', default='BANANAGUN'),
         unique_key='transaction_hash'
     )
 }}

--- a/models/staging/bananagun/fact_bananagun_solana_trades.sql
+++ b/models/staging/bananagun/fact_bananagun_solana_trades.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        snowflake_warehouse='BANANAGUN'
+        snowflake_warehouse='BANANAGUN',
+        unique_key='transaction_hash'
     )
 }}
 


### PR DESCRIPTION
Noticed there were a couple of issues in our Bananagun dataset:

**Fees**

Before:
![CleanShot 2025-05-07 at 01 07 34@2x](https://github.com/user-attachments/assets/b6119dda-2b47-4344-82ff-9e58978a0c0f)

After:
![CleanShot 2025-05-07 at 02 42 03@2x](https://github.com/user-attachments/assets/fa028805-3844-4637-9773-b45a344f7e2e)

_Root Cause Analysis_
In the Solana fees model we were assuming all fees paid in SOL, but it looks like recently Banana Gun started accepting fees in other tokens too. 

_Fix_
Added handling for multiple token types.

**Volume**

Before
![CleanShot 2025-05-07 at 01 12 52@2x](https://github.com/user-attachments/assets/f899e495-c3ca-49c9-bfba-81bf2416e4b8)

After:
![CleanShot 2025-05-07 at 02 42 21@2x](https://github.com/user-attachments/assets/16e4104a-63f8-4112-91b7-4f7043de2cbc)

_Root Cause Analysis_
The Solana trading volume model is incremental. The Banana Gun job had previously been turned off until about mid-April 2025 (note this is when the data started getting wonky). It looks like the incremental logic did not use a unique key, leading to duplicate rows added daily from when the job was turned on.

_Fix_
Add a unique key to the solana trades model.

**Other Issues**
In troubleshooting this I learned that Flipside's Solana DEX Swaps table, on which our Banana Gun trading metrics depend, is missing a significant amount of swaps, particularly Raydium swaps. To that end, I made the `fact_bananagun_solana_metrics` table incremetal to preserve our historic data, and only append the new correct data.
