### PR TITLE
fix commas in final select

### DIFF
--- a/models/projects/cetus/core/ez_cetus_metrics.sql
+++ b/models/projects/cetus/core/ez_cetus_metrics.sql
@@ -16,8 +16,8 @@ with cetus_tvl as (
 )
 
 select
-    cetus_tvl.date,
-    'Defillama' as source,
+    cetus_tvl.date
+    , 'Defillama' as source
 
     -- Standardized Metrics
     , cetus_tvl.tvl

--- a/models/projects/pharaoh/core/ez_pharaoh_metrics.sql
+++ b/models/projects/pharaoh/core/ez_pharaoh_metrics.sql
@@ -16,8 +16,8 @@ with pharaoh_tvl as (
 )
 
 select
-    pharaoh_tvl.date,
-    'Defillama' as source,
+    pharaoh_tvl.date
+    , 'Defillama' as source
 
     -- Standardized Metrics
     , pharaoh_tvl.tvl


### PR DESCRIPTION
There was an extra comma the final select statements of both Cetus and Pharaoh which was causing the models to fail. 

Both models run now:
![CleanShot 2025-05-07 at 17 26 44@2x](https://github.com/user-attachments/assets/82d0e1f0-2a9d-4a1c-aba2-4d5be4eb40a4)
