### PR TITLE
replace hyphens with underscores

### DIFF
--- a/models/data_hubs/fact_protocol_datahub_gold.sql
+++ b/models/data_hubs/fact_protocol_datahub_gold.sql
@@ -15,5 +15,5 @@ SELECT
     fdmc::number as fdmc,
     token_volume::number as token_volume
 FROM {{ source('PC_DBT_DB', 'fact_datahub_silver') }} dh
-LEFT JOIN {{ source('POSTGRES_REPLICATED', 'core_asset') }} ca ON ca.artemis_id = dh.artemis_id 
+LEFT JOIN {{ source('POSTGRES_REPLICATED', 'core_asset') }} ca ON REPLACE(ca.artemis_id, '-', '_') = dh.artemis_id 
 LEFT JOIN {{ source('POSTGRES_REPLICATED', 'core_assettag') }} cat on cat.asset_id = ca.id AND cat."KEY" = 'groups'


### PR DESCRIPTION
There is a mismatch between some artemis_id in Snowflake and artemis_id in postgres, where the postgres asset has a hyphen and the snowflake asset has an underscore. This PR should fix those mismatches.