### PR TITLE
Switch to goldsky fundamentals

### DIFF
--- a/macros/goldsky/get_goldsky_chain_fundamental_metrics.sql
+++ b/macros/goldsky/get_goldsky_chain_fundamental_metrics.sql
@@ -1,11 +1,11 @@
-{% macro get_goldsky_chain_fundamental_metrics(chain) %}
+{% macro get_goldsky_chain_fundamental_metrics(chain, model_version='') %}
     {% if chain == "bob" %}
         select
             to_timestamp(block_timestamp)::date as date
             , count (distinct from_address) as daa
             , count(*) as txns
             , sum((receipt_gas_used * effective_gas_price) + l1_fee) / 1e18 as fees_native
-        from {{ ref("fact_" ~ chain ~ "_transactions") }}
+        from {{ ref("fact_" ~ chain ~ "_transactions" ~ (model_version)) }}
         where gas > 0
         group by to_timestamp(block_timestamp)::date
     {% else %}
@@ -14,7 +14,7 @@
             , count (distinct from_address) as daa
             , count(*) as txns
             , sum((receipt_effective_gas_price * receipt_gas_used) + receipt_l1_fee) / 1e18 as fees_native
-        from {{ ref("fact_" ~ chain ~ "_transactions") }}
+        from {{ ref("fact_" ~ chain ~ "_transactions" ~ (model_version)) }}
         where gas > 0
         group by to_timestamp(block_timestamp)::date
     {% endif %}

--- a/models/projects/blast/core/ez_blast_metrics.sql
+++ b/models/projects/blast/core/ez_blast_metrics.sql
@@ -10,9 +10,10 @@
 }}
 
 with
-    fundamental_data as ({{ get_fundamental_data_for_chain("blast", "v2") }})
+    fundamental_data as ({{ get_goldsky_chain_fundamental_metrics("blast", "_v2") }})
     , defillama_data as ({{ get_defillama_metrics("blast") }})
     , price_data as ({{ get_coingecko_metrics("blast") }})
+    , eth_price as ({{ get_coingecko_metrics("ethereum") }})
     , contract_data as ({{ get_contract_metrics("blast") }})
     -- NOTE, this says l1 data cost, but that's inaccurate
     -- its both data and execution cost, but I'm following convention for now and we don't publish 
@@ -39,13 +40,12 @@ select
     )) as date
     , 'blast' as chain
     , txns
-    , dau
+    , daa as dau
     , wau
     , mau
     , fees_native
-    , fees
+    , fees_native * eth_price.price AS fees
     , fees / txns as avg_txn_fee
-    , median_txn_fee
     , l1_data_cost_native
     , l1_data_cost
     , coalesce(fees_native, 0) - l1_data_cost_native as revenue_native  -- supply side: fees paid to squencer - fees paied to l1 (L2 Revenue)
@@ -54,9 +54,9 @@ select
     , dune_dex_volumes_blast.dex_volumes as dex_volumes
     -- Standardized Metrics
     -- Market Data Metrics
-    , price
-    , market_cap
-    , fdmc
+    , price_data.price
+    , price_data.market_cap
+    , price_data.fdmc
     , tvl
     -- Chain Usage metrics
     , txns as chain_txns
@@ -64,16 +64,15 @@ select
     , wau AS chain_wau
     , mau AS chain_mau
     , avg_txn_fee AS chain_avg_txn_fee
-    , returning_users
-    , new_users
-    , low_sleep_users
-    , high_sleep_users
-    , dau_over_100 AS dau_over_100_balance
+    -- , returning_users
+    -- , new_users
+    -- , low_sleep_users
+    -- , high_sleep_users
+    -- , dau_over_100 AS dau_over_100_balance
     , dune_dex_volumes_blast.dex_volumes as chain_spot_volume
     -- Cashflow metrics
     , fees_native AS gross_protocol_revenue_native
     , fees AS gross_protocol_revenue
-    , median_txn_fee AS chain_median_txn_fee
     , revenue_native AS burned_cash_flow_native
     , revenue AS burned_cash_flow
     , l1_data_cost_native AS l1_cash_flow_native
@@ -95,5 +94,6 @@ left join expenses_data on fundamental_data.date = expenses_data.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join blast_dex_volumes as dune_dex_volumes_blast on fundamental_data.date = dune_dex_volumes_blast.date
 left join price_data on fundamental_data.date = price_data.date
+left join eth_price on fundamental_data.date = eth_price.date
 left join premine_emissions on fundamental_data.date = premine_emissions.date
 where fundamental_data.date < to_date(sysdate())


### PR DESCRIPTION
## Summary
- Switch to Goldsky fundamentals macro
- Properly compute fees off of `receipt_l1_fee`, `receipt_effective_gas_price`, `receipt_gas_used`
- Switch dedup logic to be based off of `QUALIFY`

## Test Plan
<img width="1328" alt="image" src="https://github.com/user-attachments/assets/0e9ca774-7bc2-4b29-af74-5cb911afda6e" />
