### PR TITLE
Aptos: Adding Token Transfers and Balances

### DIFF
--- a/macros/stablecoins/agg_chain_stablecoin_transfers.sql
+++ b/macros/stablecoins/agg_chain_stablecoin_transfers.sql
@@ -275,7 +275,7 @@
                 select lower(contract_address)
                 from {{ref("fact_" ~chain~ "_stablecoin_contracts")}}
             )
-    {% elif chain in ("mantle", 'sonic') %}
+    {% elif chain in ("mantle", 'sonic', 'kaia') %}
         select
             block_timestamp
             , block_timestamp::date as date

--- a/models/staging/aptos/fact_aptos_address_balances.sql
+++ b/models/staging/aptos/fact_aptos_address_balances.sql
@@ -1,0 +1,3 @@
+{{ config(snowflake_warehouse="BALANCES_LG", materialized="incremental", unique_key=["block_timestamp", "block_number", "contract_address", "address"])}}
+
+{{ evm_address_balances('aptos') }}

--- a/models/staging/aptos/fact_aptos_address_credits.sql
+++ b/models/staging/aptos/fact_aptos_address_credits.sql
@@ -1,0 +1,16 @@
+SELECT 
+    block_timestamp,
+    block_number,
+    tx_hash as transaction_hash,
+    account_address as address,
+    token_address as contract_address,
+    event_index AS event_index,
+    -1 as trace_index,
+    amount AS credit_raw,
+    amount_native AS credit_native,
+FROM aptos_flipside.core.fact_transfers
+WHERE transfer_event = 'DepositEvent'
+    and block_timestamp::date < to_date(sysdate())
+    {% if is_incremental() %}
+        and block_timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}

--- a/models/staging/aptos/fact_aptos_address_debits.sql
+++ b/models/staging/aptos/fact_aptos_address_debits.sql
@@ -8,11 +8,11 @@ SELECT
     token_address as contract_address,
     event_index AS event_index,
     -1 as trace_index,
-    amount AS credit_raw,
-    amount / pow(10, decimals) AS credit_native
+    -1 * amount AS debit_raw,
+    -1 * amount / pow(10, decimals) AS debit_native
 FROM aptos_flipside.core.fact_transfers
 left join aptos_flipside.core.dim_tokens using (token_address)
-WHERE transfer_event = 'DepositEvent'
+WHERE transfer_event = 'WithdrawEvent'
     and block_timestamp::date < to_date(sysdate())
     {% if is_incremental() %}
         and block_timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})

--- a/models/staging/aptos/fact_aptos_token_transfers.sql
+++ b/models/staging/aptos/fact_aptos_token_transfers.sql
@@ -1,0 +1,151 @@
+{{ config(
+    materialized="incremental", 
+    unique_key=["tx_hash", "event_index"],
+    ) 
+}}
+
+WITH 
+deposit_events AS (
+    SELECT 
+        block_number,
+        tx_hash,
+        block_timestamp,
+        event_index AS receiving_event_index,
+        account_address AS to_address,
+        amount AS receiving_amount,
+        token_address,
+        ROW_NUMBER() OVER(PARTITION BY tx_hash, token_address ORDER BY event_index) AS rn
+    FROM aptos_flipside.core.fact_transfers
+    WHERE transfer_event = 'DepositEvent'
+        {% if is_incremental() %}
+            and block_timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+        {% endif %}
+),
+withdraw_events AS (
+    SELECT 
+        block_number,
+        tx_hash,
+        block_timestamp,
+        event_index AS withdraw_event_index,
+        account_address AS from_address,
+        amount AS withdraw_amount,
+        token_address,
+        ROW_NUMBER() OVER(PARTITION BY tx_hash, token_address ORDER BY event_index) AS rn
+    FROM aptos_flipside.core.fact_transfers
+    WHERE transfer_event = 'WithdrawEvent'
+        {% if is_incremental() %}
+            and block_timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+        {% endif %}
+),
+tx_event_counts AS (
+    SELECT
+        tx_hash,
+        token_address,
+        sum(CASE WHEN transfer_event = 'DepositEvent' THEN 1 ELSE 0 END) AS deposit_count,
+        sum(CASE WHEN transfer_event = 'WithdrawEvent' THEN 1 ELSE 0 END) AS withdraw_count
+    FROM aptos_flipside.core.fact_transfers
+    {% if is_incremental() %}
+        where block_timestamp > (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+    {% endif %}
+    GROUP BY tx_hash, token_address
+)
+-- Number of deposit events = number of withdraw events
+, case1_matches AS (
+    SELECT
+        w.tx_hash,
+        coalesce(w.block_number, d.block_number) as block_number,
+        coalesce(w.block_timestamp, d.block_timestamp) as block_timestamp,
+        coalesce(w.token_address, d.token_address) as token_address,
+        w.from_address,
+        d.to_address,
+        d.receiving_event_index as event_index,
+        withdraw_amount as amount_raw
+    FROM withdraw_events w
+    JOIN deposit_events d ON w.tx_hash = d.tx_hash and w.rn = d.rn and w.token_address = d.token_address
+    JOIN tx_event_counts c ON w.tx_hash = c.tx_hash and w.token_address = c.token_address
+    WHERE c.deposit_count = c.withdraw_count
+)
+-- Number of deposit events > number of withdraw events
+, case2_matches AS (
+    SELECT
+        w.tx_hash,
+        coalesce(w.block_number, d.block_number) as block_number,
+        coalesce(w.block_timestamp, d.block_timestamp) as block_timestamp,
+        coalesce(w.token_address, d.token_address) as token_address,
+        w.withdraw_event_index,
+        w.from_address,
+        w.withdraw_amount,
+        d.receiving_event_index,
+        d.to_address,
+        d.receiving_amount,
+        ROW_NUMBER() OVER(
+            PARTITION BY d.tx_hash, d.receiving_event_index, d.token_address
+            ORDER BY 
+                ABS(d.receiving_amount - w.withdraw_amount),
+                ABS(d.receiving_event_index - w.withdraw_event_index)
+        ) as match_rank
+    FROM withdraw_events w
+    JOIN tx_event_counts c ON w.tx_hash = c.tx_hash and w.token_address = c.token_address
+    JOIN deposit_events d ON w.tx_hash = d.tx_hash and w.token_address = d.token_address
+    WHERE c.deposit_count > c.withdraw_count
+)
+-- Number of withdraw events > number of deposit events
+, case3_matches AS (
+    SELECT
+        d.tx_hash,
+        COALESCE(d.block_number, w.block_number) AS block_number,
+        COALESCE(d.block_timestamp, w.block_timestamp) AS block_timestamp,
+        COALESCE(d.token_address, w.token_address) AS token_address,
+        w.withdraw_event_index,
+        w.from_address,
+        w.withdraw_amount,
+        d.receiving_event_index,
+        d.to_address,
+        d.receiving_amount,
+        ROW_NUMBER() OVER(
+            PARTITION BY w.tx_hash, w.withdraw_event_index, w.token_address
+            ORDER BY 
+                ABS(d.receiving_amount - w.withdraw_amount),
+                ABS(d.receiving_event_index - w.withdraw_event_index)
+        ) AS match_rank
+    FROM deposit_events d
+    JOIN tx_event_counts c ON d.tx_hash = c.tx_hash and d.token_address = c.token_address
+    JOIN withdraw_events w ON d.tx_hash = w.tx_hash and d.token_address = w.token_address
+    WHERE c.withdraw_count > c.deposit_count
+)
+
+
+select 
+    block_number
+    , block_timestamp
+    , tx_hash
+    , token_address
+    , event_index
+    , from_address
+    , to_address
+    , amount_raw
+from case1_matches
+union all
+select 
+    block_number
+    , block_timestamp
+    , tx_hash
+    , token_address
+    , receiving_event_index as event_index
+    , from_address
+    , to_address
+    , receiving_amount as amount_raw
+from case2_matches
+where match_rank = 1
+union all
+select 
+    block_number
+    , block_timestamp
+    , tx_hash
+    , token_address
+    , withdraw_event_index as event_index
+    , from_address
+    , to_address
+    , withdraw_amount as amount_raw
+from case3_matches
+where match_rank = 1

--- a/models/staging/kaia/fact_kaia_decoded_events.sql
+++ b/models/staging/kaia/fact_kaia_decoded_events.sql
@@ -1,3 +1,3 @@
-{{ config(snowflake_warehouse="KAIA", materialized="incremental", unique_key=["transaction_hash", "event_index"]) }}
+{{ config(snowflake_warehouse="KAIA_LG", materialized="incremental", unique_key=["transaction_hash", "event_index"]) }}
 
 {{ decode_artemis_events('kaia') }}

--- a/models/staging/kaia/fact_kaia_events.sql
+++ b/models/staging/kaia/fact_kaia_events.sql
@@ -1,3 +1,3 @@
-{{ config(materialized="incremental", unique_key=["transaction_hash", "event_index"]) }}
+{{ config(materialized="incremental", snowflake_warehouse="KAIA_LG", unique_key=["transaction_hash", "event_index"]) }}
 
 {{ clean_dune_evm_events("kaia") }}

--- a/models/staging/kaia/fact_kaia_stablecoin_transfers.sql
+++ b/models/staging/kaia/fact_kaia_stablecoin_transfers.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized="incremental", 
-        snowflake_warehouse="STABLECOIN_LG_2", 
+        snowflake_warehouse="KAIA", 
         unique_key=["tx_hash", "index"],
     ) 
 }}

--- a/models/staging/kaia/fact_kaia_token_transfers.sql
+++ b/models/staging/kaia/fact_kaia_token_transfers.sql
@@ -1,2 +1,2 @@
-{{ config(snowflake_warehouse="KAIA", materialized="incremental", unique_key=["transaction_hash", "event_index"]) }}
+{{ config(snowflake_warehouse="KAIA_LG", materialized="incremental", unique_key=["transaction_hash", "event_index"]) }}
 {{ token_transfer_events('kaia') }}


### PR DESCRIPTION
1. Create the aptos token transfers table


To do:
1. Create the balances pipeline, credit and debits will not rely on transfers because the transfers code is complicated and meant to estimate transfers not be an exact amount for transfers. This is because token transfers for aptos is complicated. The move blockchain works by create new objects rather than emitting an event like the EVM.
3. Create the Stablecoin pipeline