### PR TITLE
Update Flipside Arb Token Transfers Table

### DIFF
--- a/models/staging/pendle/fact_pendle_token_incentives_by_chain_silver.sql
+++ b/models/staging/pendle/fact_pendle_token_incentives_by_chain_silver.sql
@@ -26,7 +26,7 @@ with agg as(
         , sum(raw_amount_precise::number / 1e18) as amt_pendle
         , SUM(raw_amount_precise::number / 1e18 * p.price) as amt_usd
     from
-        arbitrum_flipside.core.fact_token_transfers
+        arbitrum_flipside.core.ez_token_transfers
         left join arbitrum_flipside.price.ez_prices_hourly p ON p.hour = date_trunc('hour', block_timestamp)
         AND p.token_address = lower('0x0c880f6761F1af8d9Aa9C466984b80DAb9a8c9e8')
     where


### PR DESCRIPTION
## Summary
- `FACT_TOKEN_TRANSFERS` is no longer provided by flipside
## Test Plan
- All necessary columns are available in `EZ_TOKEN_TRANSFERS`

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/98a939f9-bd9f-4a0d-813a-eceb9c6b6ed5" />
- Compiled SQL executes 
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/980acbf5-c3b6-4d17-9db2-134a5884beab" />

