### PR TITLE
Fix naming convention

### DIFF
--- a/models/staging/federal_funds/fact_fedfunds_rates.sql
+++ b/models/staging/federal_funds/fact_fedfunds_rates.sql
@@ -25,7 +25,7 @@ flattened as (
 select
   date as timestamp,
   extraction_date,
-  'Fed Funds' as name,
+  'Fed Funds Rate' as name,
   value / 100 as apy,
   null as tvl,
   [] as symbol,


### PR DESCRIPTION
Change name to Fed Funds Rate