### PR TITLE
Fix aptos transfers incrmental runs

### DIFF
--- a/models/staging/aptos/fact_aptos_token_transfers.sql
+++ b/models/staging/aptos/fact_aptos_token_transfers.sql
@@ -1,7 +1,7 @@
 {{ config(
     materialized="incremental", 
     snowflake_warehouse="APTOS_LG",
-    unique_key=["tx_hash", "event_index"],
+    unique_key=["transaction_hash", "event_index"],
     ) 
 }}
 


### PR DESCRIPTION
1. Aptos Incremental Token Transfers is borked because fo the unique key