### PR TITLE
Add missing by_chain metrics

### DIFF
--- a/models/projects/bananagun/core/ez_bananagun_metrics_by_chain.sql
+++ b/models/projects/bananagun/core/ez_bananagun_metrics_by_chain.sql
@@ -16,6 +16,7 @@ with metrics as (
 SELECT
     date
     , chain
+    , coalesce(metrics.trading_volume, 0) as trading_volume
 
     --Standardized Metrics
 

--- a/models/projects/convex/core/ez_convex_metrics_by_chain.sql
+++ b/models/projects/convex/core/ez_convex_metrics_by_chain.sql
@@ -93,6 +93,7 @@ select
     , fees_and_revenue.revenue - token_incentives.token_incentives as earnings
     , treasury.treasury as treasury_value
     , net_treasury.net_treasury as net_treasury_value
+    , tvl.tvl as net_deposits
 
     -- Standardized Metrics
 

--- a/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
@@ -42,6 +42,8 @@ select
     , 'starkware' as chain
     , trading_volume_data.trading_volume
     , unique_traders_data.unique_traders
+    , NULL as txn_fees
+    , NULL AS trading_fees
     -- standardize metrics
     , trading_volume_data.trading_volume as perp_volume
     , unique_traders_data.unique_traders as perp_dau
@@ -55,6 +57,8 @@ select
     , 'dydx' as chain
     , trading_volume
     , unique_traders
+    , txn_fees
+    , trading_fees
     -- standardize metrics
     , trading_volume as perp_volume
     , unique_traders as perp_dau

--- a/models/projects/liquity/core/ez_liquity_metrics_by_chain.sql
+++ b/models/projects/liquity/core/ez_liquity_metrics_by_chain.sql
@@ -91,6 +91,7 @@ select
     , coalesce(treasury_native.own_token_treasury, 0) as treasury_value_native
     , coalesce(net_treasury.net_treasury, 0) as net_treasury_value
     , coalesce(os.outstanding_supply, 0) as outstanding_supply
+    , coalesce(tvl.tvl, 0) as net_deposits
 
     -- Standardized Metrics
 


### PR DESCRIPTION
## Summary
- Add missing metrics to the by_chain ez table for a few assets
- Necessary for https://github.com/Artemis-xyz/gokustats-back-end/pull/3550

## Test Plan
- `dbt run -s ez_bananagun_metrics_by_chain -s ez_convex_metrics_by_chain -s ez_dydx_metrics_by_chain -s ez_liquity_metrics_by_chain`