### PR TITLE
Akhil/base dex volumes fix v2

### DIFF
--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -18,7 +18,7 @@
         AND token_bought_price.price IS NOT NULL 
         AND token_sold_price.price * token_sold_amount != 0
         AND token_bought_price.price * token_bought_amount != 0
-        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) > 0.2
-        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) < 4
+        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) > 0.5
+        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) < 2.5
     GROUP BY 1
 {% endmacro %}

--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -1,9 +1,8 @@
 {% macro extract_dune_dex_volumes(chain) %}
     {% set coingecko_chain = 'avalanche' if chain == 'avalanche_c' 
-        else ('arbitrum-nova' if chain == 'nova' 
         else ('bsc' if chain == 'bnb'
         else ('polygon-zkevm' if chain == 'zkevm'
-        else chain))) %}
+        else chain)) %}
     
     WITH coingecko_latest_prices AS (
         {{ get_multiple_coingecko_price_with_latest(coingecko_chain) }}

--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -1,5 +1,5 @@
 {% macro extract_dune_dex_volumes(chain) %}
-    {% set coingecko_chain = 'avalanche' if chain == 'avalanche_c' 
+    {% set coingecko_chain = 'avalanche' if chain == 'avalanche_c'
         else ('bsc' if chain == 'bnb'
         else ('polygon-zkevm' if chain == 'zkevm'
         else chain)) %}

--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -1,8 +1,7 @@
 {% macro extract_dune_dex_volumes(chain) %}
     {% set coingecko_chain = 'avalanche' if chain == 'avalanche_c'
         else ('bsc' if chain == 'bnb'
-        else ('polygon-zkevm' if chain == 'zkevm'
-        else chain)) %}
+        else chain) %}
     
     WITH coingecko_latest_prices AS (
         {{ get_multiple_coingecko_price_with_latest(coingecko_chain) }}

--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -1,9 +1,24 @@
 {% macro extract_dune_dex_volumes(chain) %}
-    select 
-        block_date::date as date,
-        sum(amount_usd) as daily_volume
-    from {{ source("DUNE_DEX_VOLUMES", "trades")}}
-    where blockchain = '{{chain}}'
-    group by date
-    order by date asc
+    WITH coingecko_latest_prices AS (
+        {{ get_multiple_coingecko_price_with_latest(chain) }}
+    )
+
+    SELECT 
+        block_date::date AS date,
+        sum(amount_usd) AS daily_volume
+    FROM {{ source("DUNE_DEX_VOLUMES", "trades")}}
+    LEFT JOIN coingecko_latest_prices AS token_bought_price
+        ON block_date::date = token_bought_price.date
+        AND lower(token_bought_address_hex) = lower(token_bought_price.contract_address)
+    LEFT JOIN coingecko_latest_prices AS token_sold_price
+        ON block_date::date = token_sold_price.date
+        AND lower(token_sold_address_hex) = lower(token_sold_price.contract_address)
+    WHERE blockchain = '{{ chain }}'
+        AND token_sold_price.price IS NOT NULL
+        AND token_bought_price.price IS NOT NULL 
+        AND token_sold_price.price * token_sold_amount != 0
+        AND token_bought_price.price * token_bought_amount != 0
+        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) > 0.2
+        AND (token_bought_price.price * token_bought_amount) / (token_sold_price.price * token_sold_amount) < 4
+    GROUP BY 1
 {% endmacro %}

--- a/macros/dune/extract_dune_dex_volumes.sql
+++ b/macros/dune/extract_dune_dex_volumes.sql
@@ -1,18 +1,32 @@
 {% macro extract_dune_dex_volumes(chain) %}
+    {% set coingecko_chain = 'avalanche' if chain == 'avalanche_c' 
+        else ('arbitrum-nova' if chain == 'nova' 
+        else ('bsc' if chain == 'bnb'
+        else ('polygon-zkevm' if chain == 'zkevm'
+        else chain))) %}
+    
     WITH coingecko_latest_prices AS (
-        {{ get_multiple_coingecko_price_with_latest(chain) }}
+        {{ get_multiple_coingecko_price_with_latest(coingecko_chain) }}
+    ), 
+
+    partitioned_coingecko_prices AS (
+        SELECT *, 
+            ROW_NUMBER() OVER (PARTITION BY date, contract_address ORDER BY price DESC) AS rn
+        FROM coingecko_latest_prices
     )
 
     SELECT 
         block_date::date AS date,
         sum(amount_usd) AS daily_volume
     FROM {{ source("DUNE_DEX_VOLUMES", "trades")}}
-    LEFT JOIN coingecko_latest_prices AS token_bought_price
+    LEFT JOIN partitioned_coingecko_prices AS token_bought_price
         ON block_date::date = token_bought_price.date
         AND lower(token_bought_address_hex) = lower(token_bought_price.contract_address)
-    LEFT JOIN coingecko_latest_prices AS token_sold_price
+        AND token_bought_price.rn = 1
+    LEFT JOIN partitioned_coingecko_prices AS token_sold_price
         ON block_date::date = token_sold_price.date
         AND lower(token_sold_address_hex) = lower(token_sold_price.contract_address)
+        AND token_sold_price.rn = 1
     WHERE blockchain = '{{ chain }}'
         AND token_sold_price.price IS NOT NULL
         AND token_bought_price.price IS NOT NULL 

--- a/models/staging/base/fact_base_daily_dex_volumes.sql
+++ b/models/staging/base/fact_base_daily_dex_volumes.sql
@@ -5,26 +5,4 @@
     )
 }}
 
-select 
-    block_date::date as date,
-    sum(amount_usd) as daily_volume
-from {{ source("DUNE_DEX_VOLUMES", "trades") }}
-where blockchain = 'base'
-  and not (
-    (date = '2025-04-25' and lower(tx_from_hex) in (
-        lower('0x80205B17056BE5F99A9EB028E811C20DDF896F2A'), 
-        lower('0xE3223F7E3343C2C8079F261D59EE1E513086C7C3')
-    ))
-    or
-    (date = '2025-04-29' and lower(tx_from_hex) in (
-        lower('0x80205B17056BE5F99A9EB028E811C20DDF896F2A'), 
-        lower('0xE3223F7E3343C2C8079F261D59EE1E513086C7C3')
-    ))
-    or
-    (date = '2025-05-07' and lower(tx_from_hex) in (
-        lower('0xf14149bde6f7e2573f38aceda6220d7dfff66592')
-    ))
-)
-group by date
-order by date asc
-
+{{ extract_dune_dex_volumes("base") }}

--- a/models/staging/base/fact_base_daily_dex_volumes.sql
+++ b/models/staging/base/fact_base_daily_dex_volumes.sql
@@ -11,14 +11,18 @@ select
 from {{ source("DUNE_DEX_VOLUMES", "trades") }}
 where blockchain = 'base'
   and not (
-    (date = '2025-04-25' and tx_from in (
-        TO_BINARY('80205B17056BE5F99A9EB028E811C20DDF896F2A', 'HEX'), 
-        TO_BINARY('E3223F7E3343C2C8079F261D59EE1E513086C7C3', 'HEX')
+    (date = '2025-04-25' and lower(tx_from_hex) in (
+        lower('0x80205B17056BE5F99A9EB028E811C20DDF896F2A'), 
+        lower('0xE3223F7E3343C2C8079F261D59EE1E513086C7C3')
     ))
     or
-    (date = '2025-04-29' and tx_from in (
-        TO_BINARY('80205B17056BE5F99A9EB028E811C20DDF896F2A', 'HEX'), 
-        TO_BINARY('E3223F7E3343C2C8079F261D59EE1E513086C7C3', 'HEX')
+    (date = '2025-04-29' and lower(tx_from_hex) in (
+        lower('0x80205B17056BE5F99A9EB028E811C20DDF896F2A'), 
+        lower('0xE3223F7E3343C2C8079F261D59EE1E513086C7C3')
+    ))
+    or
+    (date = '2025-05-07' and lower(tx_from_hex) in (
+        lower('0xf14149bde6f7e2573f38aceda6220d7dfff66592')
     ))
 )
 group by date

--- a/models/staging/gnosis/fact_gnosis_daily_dex_volumes.sql
+++ b/models/staging/gnosis/fact_gnosis_daily_dex_volumes.sql
@@ -5,4 +5,10 @@
     )
 }}
 
-{{ extract_dune_dex_volumes("gnosis") }}
+select 
+    block_date::date as date,
+    sum(amount_usd) as daily_volume
+from {{ source("DUNE_DEX_VOLUMES", "trades")}}
+where blockchain = 'gnosis'
+group by date
+order by date asc

--- a/models/staging/kaia/fact_kaia_daily_dex_volumes.sql
+++ b/models/staging/kaia/fact_kaia_daily_dex_volumes.sql
@@ -5,4 +5,10 @@
     )
 }}
 
-{{ extract_dune_dex_volumes("kaia") }}
+select 
+    block_date::date as date,
+    sum(amount_usd) as daily_volume
+from {{ source("DUNE_DEX_VOLUMES", "trades")}}
+where blockchain = 'kaia'
+group by date
+order by date asc

--- a/models/staging/nova/fact_nova_daily_dex_volumes.sql
+++ b/models/staging/nova/fact_nova_daily_dex_volumes.sql
@@ -5,4 +5,10 @@
     )
 }}
 
-{{ extract_dune_dex_volumes("nova") }}
+select 
+    block_date::date as date,
+    sum(amount_usd) as daily_volume
+from {{ source("DUNE_DEX_VOLUMES", "trades")}}
+where blockchain = 'nova'
+group by date
+order by date asc

--- a/models/staging/polygon_zk/fact_polygon_zk_daily_dex_volumes.sql
+++ b/models/staging/polygon_zk/fact_polygon_zk_daily_dex_volumes.sql
@@ -5,4 +5,10 @@
     )
 }}
 
-{{ extract_dune_dex_volumes("zkevm") }}
+select 
+    block_date::date as date,
+    sum(amount_usd) as daily_volume
+from {{ source("DUNE_DEX_VOLUMES", "trades")}}
+where blockchain = 'zkevm'
+group by date
+order by date asc

--- a/models/staging/polygon_zk/fact_polygon_zk_daily_dex_volumes.sql
+++ b/models/staging/polygon_zk/fact_polygon_zk_daily_dex_volumes.sql
@@ -5,4 +5,4 @@
     )
 }}
 
-{{ extract_dune_dex_volumes("polygon_zk") }}
+{{ extract_dune_dex_volumes("zkevm") }}


### PR DESCRIPTION
I edited the DEX volumes macro to do a left join with our price table and only include transactions where the amount_in_usd / amount_out_usd is between 0.2 and 2. This excludes transactions where $10 of $X is traded for $10000 of $Y as these are rare transactions that unnecessarily inflate the volume. 

For some chains I had to just manually write the DEX volumes script because the CoinGecko table didn't have the chain to check the magnitude. In other cases (Binance and Polygon ZKEVM) I had to change the name of the chain in the macro.

## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [X] Add any relevant data screenshots below

<img width="1047" alt="Screenshot 2025-05-13 at 4 07 22 PM" src="https://github.com/user-attachments/assets/23c0bf30-eb42-47dc-98bb-44e66d95d69c" />

- DBT RUN for base

<img width="1233" alt="Screenshot 2025-05-13 at 6 19 17 PM" src="https://github.com/user-attachments/assets/3719c668-a72a-4efe-aba0-584f89eae652" />

- Comparison of Base DEX volumes pre and post-filter (blue line shows the volumes without the filter and yellow with the filter)

<img width="1233" alt="Screenshot 2025-05-13 at 6 18 01 PM" src="https://github.com/user-attachments/assets/bcec7921-523c-4947-ba79-0321ca2467df" />

- Comparison of Arbitrum DEX volumes pre and post-filter (blue line shows the volumes without the filter and yellow with the filter)

<img width="1233" alt="Screenshot 2025-05-13 at 6 22 17 PM" src="https://github.com/user-attachments/assets/37e29020-c0c8-4507-9fab-0620fd9ed676" />

- Full historical comparison of Arbitrum DEX volumes pre and post-filter (blue line shows the volumes without the filter and yellow with the filter)

<img width="1233" alt="Screenshot 2025-05-13 at 6 30 21 PM" src="https://github.com/user-attachments/assets/fc49e192-108e-4317-a0fa-68eda1c67c45" />

- Full historical comparison of Avalanche DEX volumes pre and post-filter (blue line shows the volumes without the filter and yellow with the filter)

## Other

- [ ] Any other relevant information that may be helpful