### PR TITLE
standardize launchpad_volumes

### DIFF
--- a/models/projects/believe/core/ez_believe_metrics.sql
+++ b/models/projects/believe/core/ez_believe_metrics.sql
@@ -45,7 +45,7 @@ select
     , token_turnover_fdv
 
     -- Usage Metrics
-    , bst.trading_volume as launchpad_volume
+    , bst.trading_volume as launchpad_volumes
     , bst.txns as launchpad_txns
     , bst.unique_traders as launchpad_dau
     , bcm.coins_minted

--- a/models/projects/believe/core/ez_believe_metrics_by_chain.sql
+++ b/models/projects/believe/core/ez_believe_metrics_by_chain.sql
@@ -46,7 +46,7 @@ select
     , token_turnover_fdv
 
     -- Usage Metrics
-    , bst.trading_volume as launchpad_volume
+    , bst.trading_volume as launchpad_volumes
     , bst.txns as launchpad_txns
     , bst.unique_traders as launchpad_dau
     , bcm.coins_minted


### PR DESCRIPTION
- missing out a letter `s`

ran RETL for backwards compatibility 
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/a3820b55-012a-4b30-a786-34a3b0eac581" />
