### PR TITLE
feature/balancer token incentives

### DIFF
--- a/models/projects/balancer/core/ez_balancer_metrics.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics.sql
@@ -32,7 +32,7 @@ with date_spine as (
     SELECT
         date,
         sum(amount_usd) as token_incentives_usd
-    FROM {{ ref('fact_balancer_token_incentives') }}
+    FROM {{ ref('fact_balancer_token_incentives_all_chains') }}
     group by 1
 )
 , all_tvl as (

--- a/models/projects/balancer/core/ez_balancer_metrics_by_chain.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics_by_chain.sql
@@ -35,16 +35,20 @@ with swap_metrics as (
 , token_incentives as (
     SELECT
         date,
-        'ethereum' as chain,
+        case
+            when chain ilike '%ethereum%' then 'ethereum'
+            else chain 
+        end as chain,
         sum(amount_usd) as token_incentives
-    FROM {{ ref('fact_balancer_token_incentives') }}
+    FROM {{ ref('fact_balancer_token_incentives_all_chains') }}
     group by 1,2
 )
 
 , treasury_by_chain as (
     SELECT
         date,
-        'ethereum' as chain,
+        case when chain ilike '%ethereum%' then 'ethereum'
+        else chain end as chain,
         sum(usd_balance) as usd_balance
     FROM {{ ref('fact_balancer_treasury_by_token') }}
     group by 1,2

--- a/models/projects/balancer/raw/fact_balancer_token_incentives_all_chains.sql
+++ b/models/projects/balancer/raw/fact_balancer_token_incentives_all_chains.sql
@@ -1,0 +1,135 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='BALANCER',
+        database='BALANCER',
+        schema='raw',
+        alias='fact_balancer_token_incentives_all_chains'
+    )
+}}
+
+with merkle_redeem as (
+    select
+        block_timestamp::date as date,
+        price,
+        decimals,
+        decoded_log:_balance::NUMBER as amount,
+        decoded_log:_claimant::STRING as recipient_address,
+        (decoded_log:_balance::NUMBER / pow(10, decimals)) * price as amount_usd
+    from {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    left join {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} 
+        on lower('0xba100000625a3754423978a60c9317c58a424e3d') = token_address -- BAL token
+        and date_trunc('hour', block_timestamp) = hour
+    where contract_address = lower('0x6d19b2bf3a36a61530909ae65445a906d98a2fa8')
+    and event_name = 'Claimed'
+)
+, merkle_orchard as (
+    select
+        block_timestamp::date as date,
+        price,
+        decimals,
+        decoded_log,
+        decoded_log:amount::NUMBER as amount,
+        decoded_log:claimer::STRING as recipient_address,
+        decoded_log:token::STRING as token_address,
+        (decoded_log:amount::NUMBER / pow(10, decimals)) * price as amount_usd
+    from {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    left join {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} 
+        on lower('0xba100000625a3754423978a60c9317c58a424e3d') = token_address -- BAL token
+        and date_trunc('hour', block_timestamp) = hour
+    where contract_address = lower('0xdae7e32adc5d490a43ccba1f0c736033f2b4efca')
+    and event_name = 'DistributionClaimed'
+    and decoded_log:token::STRING = lower('0xba100000625a3754423978a60c9317c58a424e3d')
+)
+, merkle_orchard_arbitrum as (
+    select
+        block_timestamp::date as date,
+        price,
+        decimals,
+        decoded_log,
+        decoded_log:amount::NUMBER as amount,
+        decoded_log:claimer::STRING as recipient_address,
+        decoded_log:token::STRING as token_address,
+        lower(decoded_log:token::STRING) as lower_token_address,
+        (decoded_log:amount::NUMBER / pow(10, decimals)) * price as amount_usd
+    from {{ source('ARBITRUM_FLIPSIDE', 'ez_decoded_event_logs') }} a
+    left join {{ source('ARBITRUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }} t
+        on t.token_address = '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8' -- BAL token
+        and date_trunc('hour', block_timestamp) = hour
+    where contract_address = lower('0x751A0bC0e3f75b38e01Cf25bFCE7fF36DE1C87DE')
+    and event_name = 'DistributionClaimed'
+    and lower_token_address = '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8' --lower('0x040d1EdC9569d4Bab2D15287Dc5A4F10F56a56B8 ')
+)
+
+, merkle_orchard_polygon as (
+    select
+        block_timestamp::date as date,
+        price,
+        decimals,
+        decoded_log,
+        decoded_log:amount::NUMBER as amount,
+        decoded_log:claimer::STRING as recipient_address,
+        decoded_log:token::STRING as token_address,
+        (decoded_log:amount::NUMBER / pow(10, decimals)) * price as amount_usd
+    from {{ source('POLYGON_FLIPSIDE', 'ez_decoded_event_logs') }}
+    left join {{ source('POLYGON_FLIPSIDE_PRICE', 'ez_prices_hourly') }} 
+        on lower('0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3') = token_address -- BAL token
+        and date_trunc('hour', block_timestamp) = hour
+    where contract_address = lower('0x0f3e0c4218b7b0108a3643cfe9d3ec0d4f57c54e')
+    and event_name = 'DistributionClaimed'
+    and decoded_log:token::STRING = lower('0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3')
+)
+, emissions as (
+    select
+        date(block_timestamp) as date,
+        'ethereum' as chain,
+        'BAL' as token,
+        to_address as emission_contract,
+        sum(amount) as amount,
+        sum(amount_usd) as amount_usd
+    from {{ source('ETHEREUM_FLIPSIDE', 'ez_token_transfers') }}
+    where 
+        contract_address = lower('0xba100000625a3754423978a60c9317c58a424e3d') -- BAL token
+        AND from_address = '0x0000000000000000000000000000000000000000' -- Zero address (minting)
+        AND block_timestamp >= '2022-04-01'
+    group by 1, 2, 3, 4
+)
+select
+    date,
+    'ethereum' as chain,
+    sum(amount) as amount,
+    sum(amount_usd) as amount_usd
+from merkle_orchard
+group by date, chain
+union all
+select
+    date,
+    'ethereum' as chain,
+    sum(amount) as amount,
+    sum(amount_usd) as amount_usd
+from merkle_redeem
+group by date, chain
+union all
+select
+    date,
+    'arbitrum' as chain,
+    sum(amount) as amount,
+    sum(amount_usd) as amount_usd
+from merkle_orchard_arbitrum
+group by date, chain
+union all
+select
+    date,
+    'polygon' as chain,
+    sum(amount) as amount,
+    sum(amount_usd) as amount_usd
+from merkle_orchard_polygon
+group by date, chain
+union all
+select
+    date,
+    'ethereum_emissions' as chain,
+    sum(amount) as amount,
+    sum(amount_usd) as amount_usd
+from emissions
+group by date, chain


### PR DESCRIPTION
Added:
- Data Models for BAL token incentives to ez_metrics & ez_metrics_by_chain tables

CAD: In-Progress

**Key Notes:**
- balancer ez_metrics table data starts flowing 3-01-2020 but token incentives start 10-01-2020 when the first BAL were minted
- balancer is deployed on 7 chains but TokenTerminal token incentives are only calculated from three (ethereum, arbitrum, polygon) and we do the same. Not even sure yet if the other 4 chains with balancer distribute BAL token incentives.
- balancer token incentives were already partially calculated, I think by @alexwes . I made updates to get a more identical match with TT and ensure our data is current in these models, but I kept the original token incentives models. Eventually those can be deleted
- Balancer code structure can be re-organized imo since a lot of the tables are currently in projects folder and should be in staging. Do we want to do this as part of this PR?

Validation:
![Screenshot 2025-05-14 at 12 27 03 PM](https://github.com/user-attachments/assets/f659df36-39b3-429a-9b04-875930be1246)


