### PR TITLE
Change ez pool tables to iceberg tables

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -179,3 +179,6 @@ models:
 
 vars:
   dbt_date:time_zone: "Etc/UTC"
+
+flags:
+  enable_iceberg_materializations: True

--- a/models/projects/balancer/core/ez_balancer_metrics_by_pool.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized='table',
         snowflake_warehouse='BALANCER',
+        table_format="iceberg",
         database='BALANCER',
         schema='core',
-        alias='ez_metrics_by_pool'
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias='ez_metrics_by_pool',
+        base_location_root="balancer"
     )
 }}
 
@@ -43,7 +46,7 @@ with swap_metrics as (
 )
 
 select
-    date_pool_spine.date
+    date_pool_spine.date::TIMESTAMP_NTZ(6) AS date
     , date_pool_spine.pool_address
     , swap_metrics.number_of_swaps
     , swap_metrics.unique_traders

--- a/models/projects/curve/core/ez_curve_metrics_by_pool.sql
+++ b/models/projects/curve/core/ez_curve_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="CURVE",
+        table_format="iceberg",
         database="curve",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="curve"
     )
 }}
 
@@ -37,7 +40,7 @@ with
     )
 
 select
-    tvl_by_pool.date
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date
     , 'curve' as app
     , 'DeFi' as category
     , tvl_by_pool.chain

--- a/models/projects/frax/core/ez_frax_metrics_by_pool.sql
+++ b/models/projects/frax/core/ez_frax_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="FRAX",
+        table_format="iceberg",
         database="frax",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="frax"
     )
 }}
 
@@ -18,7 +21,7 @@ with
        from {{ ref("fact_fraxswap_ethereum_tvl_by_pool") }}
     )
 select
-    tvl_by_pool.date,
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date,
     'frax' as app,
     'DeFi' as category,
     tvl_by_pool.chain,

--- a/models/projects/maple/core/ez_maple_metrics_by_pool.sql
+++ b/models/projects/maple/core/ez_maple_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized='table',
         snowflake_warehouse='MAPLE',
+        table_format="iceberg",
         database='MAPLE',
         schema='core',
-        alias='ez_metrics_by_pool'
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias='ez_metrics_by_pool',
+        base_location_root="maple"
     )
 }}
 
@@ -29,7 +32,7 @@ with fees as (
     GROUP BY 1, 2
 )
 SELECT
-    coalesce(fees.date, tvl.date) as date,
+    coalesce(fees.date, tvl.date)::TIMESTAMP_NTZ(6) AS date,
     coalesce(fees.pool_name, tvl.pool_name) as pool_name,
     fees.fees,
     fees.platform_fees,

--- a/models/projects/pancakeswap/core/ez_pancakeswap_metrics_by_pool.sql
+++ b/models/projects/pancakeswap/core/ez_pancakeswap_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="PANCAKESWAP_SM",
+        table_format="iceberg",
         database="pancakeswap",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="pancakeswap"
     )
 }}
 
@@ -42,7 +45,7 @@ with
         }}
     )
 select
-    tvl_by_pool.date
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date
     , 'pancakeswap' as app
     , 'DeFi' as category
     , tvl_by_pool.chain

--- a/models/projects/quickswap/core/ez_quickswap_metrics_by_pool.sql
+++ b/models/projects/quickswap/core/ez_quickswap_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="QUICKSWAP",
+        table_format="iceberg",
         database="quickswap",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="quickswap"
     )
 }}
 
@@ -18,7 +21,7 @@ with
        from {{ ref("fact_quickswap_polygon_tvl_by_pool") }}
     )
 select
-    tvl_by_pool.date
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date
     , 'quickswap' as app
     , 'DeFi' as category
     , tvl_by_pool.chain

--- a/models/projects/sushiswap/core/ez_sushiswap_metrics_by_pool.sql
+++ b/models/projects/sushiswap/core/ez_sushiswap_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="SUSHISWAP_SM",
+        table_format="iceberg",
         database="sushiswap",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="sushiswap"
     )
 }}
 
@@ -37,7 +40,7 @@ with
         }}
     )
 select
-    tvl_by_pool.date
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date
     , 'sushiswap' as app
     , 'DeFi' as category
     , tvl_by_pool.chain

--- a/models/projects/trader_joe/core/ez_trader_joe_metrics_by_pool.sql
+++ b/models/projects/trader_joe/core/ez_trader_joe_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="TRADER_JOE",
+        table_format="iceberg",
         database="trader_joe",
         schema="core",
-        alias="ez_metrics_by_pool",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="ez_metrics_by_pool_2",
+        base_location_root="trader_joe"
     )
 }}
 
@@ -30,7 +33,7 @@ with
         }}
     )
 select
-    tvl_by_pool.date,
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date,
     'trader_joe' as app,
     'DeFi' as category,
     tvl_by_pool.chain,

--- a/models/projects/uniswap/core/ez_uniswap_metrics_by_pool.sql
+++ b/models/projects/uniswap/core/ez_uniswap_metrics_by_pool.sql
@@ -2,9 +2,12 @@
     config(
         materialized="table",
         snowflake_warehouse="UNISWAP_SM",
+        table_format="iceberg",
         database="uniswap",
         schema="core",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="ez_metrics_by_pool",
+        base_location_root="uniswap"
     )
 }}
 
@@ -48,7 +51,7 @@ with
         SELECT * FROM {{ ref('fact_uniswap_v3_polygon_tvl_by_pool') }}
     )
 select
-    tvl_by_pool.date,
+    tvl_by_pool.date::TIMESTAMP_NTZ(6) AS date,
     'uniswap' as app,
     'DeFi' as category,
     tvl_by_pool.chain,


### PR DESCRIPTION
# Description

We are changing `ez_metrics_by_pool` tables from Snowflake tables to iceberg tables. Few reasons for this:
1. Gives us more flexibility to do whatever we want with the tables
2. Allows us to integrate it into DuckDB easily

# Tests

Made sure iceberg tables still work when querying from a secure view in ART_SHARE across different regions