### PR TITLE
Fix stargate ambiguous column name

### DIFF
--- a/models/staging/stargate/fact_stargate_v2_arbitrum_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_arbitrum_treasury_balance.sql
@@ -19,11 +19,11 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_base_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_base_treasury_balance.sql
@@ -19,11 +19,11 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_bsc_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_bsc_treasury_balance.sql
@@ -19,11 +19,11 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_ethereum_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_ethereum_treasury_balance.sql
@@ -19,7 +19,7 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             when lower(treasury_data.contract_address) in (
                 lower('0x72E95b8931767C79bA4EeE721354d6E99a61D004') -- variableDebtEthUSDC
                 , lower('0x6df1C1E379bC5a00a7b4C6e67A203333772f45A8') --variableDebtEthUSDT
@@ -31,7 +31,7 @@ treasury_data as (
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_mantle_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_mantle_treasury_balance.sql
@@ -19,7 +19,7 @@ treasury_data as (
         date
         , 'wallet' as protocol
         , treasury_data.contract_address
-        , symbol
+        , t1.symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_optimism_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_optimism_treasury_balance.sql
@@ -19,11 +19,11 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data

--- a/models/staging/stargate/fact_stargate_v2_polygon_treasury_balance.sql
+++ b/models/staging/stargate/fact_stargate_v2_polygon_treasury_balance.sql
@@ -19,11 +19,11 @@ treasury_data as (
     select
         date
         , case 
-            when substr(symbol, 0, 2) = 'S*' then 'stargate'
+            when substr(t1.symbol, 0, 2) = 'S*' then 'stargate'
             else 'wallet'
         end as protocol        
         , treasury_data.contract_address
-        , upper(replace(symbol, 'S*', '')) as symbol
+        , upper(replace(t1.symbol, 'S*', '')) as symbol
         , balance_native
         , balance
     from treasury_data


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [x] Any other relevant information that may be helpful
Added t1 to the symbols because there was a `SQL compilation error: ambiguous column name 'SYMBOL'`

reran all 6 fact table models
- fact_stargate_v2_arbitrum_treasury_balance.sql
- fact_stargate_v2_base_treasury_balance.sql
- fact_stargate_v2_bsc_treasury_balance.sql
- fact_stargate_v2_ethereum_treasury_balance.sql
- fact_stargate_v2_mantle_treasury_balance.sql
- fact_stargate_v2_optimism_treasury_balance.sql
- fact_stargate_v2_polygon_treasury_balance.sql

reran ez_stargate_metrics table as well (data is refreshed until `2025-05-13`)
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/cdd4b37d-9244-438d-b946-c2b923b7e9e0" />

reran RETL for backwards compatibility 
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/5195115e-0b9e-4e5d-ba1e-0bd2fb8cc843" />
