### PR TITLE
feature/vertex token_incentives

### DIFF
--- a/models/projects/vertex/core/ez_vertex_metrics.sql
+++ b/models/projects/vertex/core/ez_vertex_metrics.sql
@@ -8,33 +8,58 @@
     )
 }}
 
-with
-    trading_volume_data as (
-        select date, sum(trading_volume) as trading_volume
-        from {{ ref("fact_vertex_trading_volume") }}
-        group by date
-    )
-    , unique_traders_data as (
-        select date, sum(unique_traders) as unique_traders
-        from {{ ref("fact_vertex_unique_traders") }}
-        group by date
-    )
-    , price as ({{ get_coingecko_metrics("vertex-protocol") }})
+with trading_volume_data as (
+    select date, sum(trading_volume) as trading_volume
+    from {{ ref("fact_vertex_trading_volume") }}
+    group by date
+)
+, unique_traders_data as (
+    select date, sum(unique_traders) as unique_traders
+    from {{ ref("fact_vertex_unique_traders") }}
+    group by date
+)
+, token_incentives as (
+    select 
+        date,
+        sum(amount) as token_incentives_native,
+        sum(amount_usd) as token_incentives
+    from {{ ref("fact_vertex_token_incentives") }}
+    group by date
+)
+, date_spine as (
+    select date_spine.date
+    from {{ ref('dim_date_spine') }} date_spine
+    where date_spine.date between '2023-11-01' and to_date(sysdate())
+)
+, market_metrics as ({{ get_coingecko_metrics("vertex-protocol") }})
+
 select
-    date
+    date_spine.date
     , 'vertex' as app
     , 'DeFi' as category
-    -- standardize metrics
-    , trading_volume as perp_volume
-    , unique_traders as perp_dau
-    -- Market Data
-    , price
-    , market_cap
-    , fdmc
-    , token_turnover_circulating
-    , token_turnover_fdv
-    , token_volume
-from trading_volume_data
+
+    -- Standardized Metrics
+
+    -- Market Metrics
+    , market_metrics.price
+    , market_metrics.market_cap
+    , market_metrics.fdmc
+    , market_metrics.token_volume
+
+    --Usage Metrics
+    , trading_volume_data.trading_volume as perp_volume
+    , unique_traders_data.unique_traders as perp_dau
+
+    -- Cashflow Incentives
+    , token_incentives.token_incentives
+
+    -- Turnover Metrics
+    , market_metrics.token_turnover_circulating
+    , market_metrics.token_turnover_fdv
+
+from date_spine
+left join market_metrics using(date)
+left join trading_volume_data using(date)
 left join unique_traders_data using(date)
-left join price using(date)
-where date < to_date(sysdate())
+left join token_incentives using(date)
+where date_spine.date < to_date(sysdate())

--- a/models/staging/vertex/fact_vertex_token_incentives.sql
+++ b/models/staging/vertex/fact_vertex_token_incentives.sql
@@ -1,0 +1,50 @@
+{{ config(materialized="table") }}
+
+--Initial mint of 1,000,000,000 VRTX tokens
+with vertex_initial_mint as (
+    select
+        date(block_timestamp) as date,
+        'arbitrum' as chain,
+        'VRTX' as token,
+        to_address as emission_contract,
+        sum(amount) as minted_amount,
+    from arbitrum_flipside.core.ez_token_transfers
+    where 
+        contract_address = lower('0x95146881b86b3ee99e63705ec87afe29fcc044d9') -- VRTX token
+        AND from_address = '0x0000000000000000000000000000000000000000' -- Zero address (minting)
+        AND block_timestamp <= '2023-12-01' 
+    group by 1, 2, 3, 4
+)
+
+--Vrtx claim events
+, claim_events as (
+    select
+        block_timestamp,
+        date(block_timestamp) as date,
+        'arbitrum' as chain,
+        'VRTX' as token,
+        decoded_log:account::STRING as to_address,
+        decoded_log:amount::NUMBER as amount,
+    from arbitrum_flipside.core.ez_decoded_event_logs
+    where 
+        contract_address = lower('0xafe39cd8e17fa4172144ff95274bb665da411f80') -- VRTX token
+        AND event_name = 'ClaimVrtx' -- Zero address (minting)
+        AND block_timestamp <= '2024-07-01'
+)
+
+select
+    date,
+    sum(amount) as amount,
+    sum( (amount / pow(10, decimals)) * price ) as amount_usd
+from claim_events
+left join arbitrum_flipside.price.ez_prices_hourly
+    on token_address = lower('0x95146881b86b3ee99e63705ec87afe29fcc044d9')
+    and hour = date_trunc('hour', block_timestamp)
+group by date
+union all
+select
+    date,
+    sum(minted_amount) as amount,
+    sum(minted_amount * .019368) as amount_usd --Initial price of VRTX on mint
+from vertex_initial_mint
+group by date


### PR DESCRIPTION
Added:
- Vertex token incentives data model
- vertex token incentives to ez_metrics table

CAD: in-progress

**Key Notes:**
- VRTX token incentives is constructed using 'ClaimVRTX' events and initial mint to reach parity with TT
- Initial mint is multiplied by an assumed VTRX price @ launch of .01938, derived back back calculating based on the initial mint usd value on TT (Arbitrum_flipside prices for VRTX don't begin until 10 days after the mint date)
- Claim events only collected before July 2024 to match TT token incentives going to zero after July 2024
- Research to be expanded in the CAD in regards to what token incentives actually mean in this case

Validation:
![Screenshot 2025-05-15 at 3 35 42 PM](https://github.com/user-attachments/assets/33b725a7-eb04-4f52-ac87-0e063ca070c8)