### PR TITLE
Add chain gdp for ethereum and solana

### DIFF
--- a/macros/metrics/get_chain_gdp.sql
+++ b/macros/metrics/get_chain_gdp.sql
@@ -1,0 +1,109 @@
+{% macro get_chain_gdp(chain, granularity) %}
+
+WITH consumption_and_gov_expenditure AS (
+    WITH gas_blob_fees_and_nft_volume AS (
+        SELECT
+            date
+            , COALESCE(fees, 0) as gas
+            , COALESCE(nft_trading_volume, 0) AS nft_trading_volume -- consumption 
+            , COALESCE(blob_fees, 0) AS blob_fees
+            , COALESCE(gross_emissions, 0) AS gross_emissions -- gov expenditures
+        FROM ARTEMIS_ICEBERG.PROD_{{ chain }}.EZ_{{ chain }}_METRICS
+    )
+
+    -- need to add protocol revenue
+    , protocol_revenue AS (
+        SELECT 
+            DATE_TRUNC(DAY, date) AS date 
+            , SUM(gross_protocol_revenue) AS gross_protocol_revenue
+        FROM {{ ref("ez_protocol_datahub_by_chain") }}
+        WHERE chain = '{{ chain }}'
+        GROUP BY 1
+    )
+
+    SELECT 
+        g.date 
+        , g.gas
+        , g.nft_trading_volume
+        , g.blob_fees
+        , COALESCE(p.gross_protocol_revenue, 0) AS protocol_revenue
+        , g.gross_emissions
+        , g.gas + g.nft_trading_volume + g.blob_fees + protocol_revenue as consumption
+    FROM gas_blob_fees_and_nft_volume g 
+    LEFT JOIN protocol_revenue p
+        ON g.date = p.date
+)
+
+-- net flows
+, net_flows AS (
+    WITH inflows AS (
+        SELECT
+            date 
+            , SUM(amount_usd) AS inflows
+        FROM {{ ref("agg_daily_bridge_flows_metrics") }}
+        WHERE destination_chain = '{{ chain }}'
+        GROUP BY 1
+    )
+
+    , outflows AS (
+        SELECT
+            date 
+            , SUM(amount_usd) AS outflows
+        FROM {{ ref("agg_daily_bridge_flows_metrics") }}
+        WHERE source_chain = '{{ chain }}'
+        GROUP BY 1
+    )
+
+    SELECT
+        COALESCE(i.date, o.date) AS date 
+        , i.inflows - o.outflows AS net_flows
+    FROM inflows i 
+    FULL OUTER JOIN outflows o
+        ON i.date = o.date
+)
+
+, funding AS (
+    WITH cleaned_and_flattened_funding_data AS (
+        SELECT 
+            *
+            , STRTOK_TO_ARRAY(REPLACE(REPLACE(REPLACE(chains, '[', ''), ']', ''),  '''', ''), ',') AS cleaned_chains
+            , v.value::VARCHAR AS cleaned_single_chain
+        FROM PC_DBT_DB.PROD.DEFILLAMA_RAISES d,
+        LATERAL FLATTEN (input => cleaned_chains) v
+    )
+    
+    SELECT 
+        date 
+        , cleaned_single_chain
+        , SUM(amount * 1000000) AS funding_amount -- need to multiply by 1M
+    FROM  cleaned_and_flattened_funding_data
+    WHERE LOWER(cleaned_single_chain) LIKE '%{{ chain }}%'
+    GROUP BY 1, 2
+)
+
+, daily_gdp AS (
+    SELECT 
+        cg.date 
+        , COALESCE(cg.consumption, 0) AS consumption -- consumption
+        , COALESCE(cg.gross_emissions, 0) AS expenditures -- government expenditures
+        , COALESCE(nf.net_flows, 0) AS exports -- net exports
+        , COALESCE(f.funding_amount, 0) AS investment
+        , consumption + expenditures + exports + investment AS chain_gdp
+    FROM consumption_and_gov_expenditure cg
+    LEFT JOIN net_flows nf  
+        ON cg.date = nf.date
+    LEFT JOIN funding f
+        ON cg.date = f.date
+)
+
+SELECT 
+    DATE_TRUNC({{ granularity }}, date) AS date 
+    , SUM(consumption) AS consumption
+    , SUM(expenditures) AS expenditures
+    , SUM(exports) AS exports
+    , SUM(investment) AS investment
+    , SUM(chain_gdp) AS gdp 
+FROM daily_gdp 
+GROUP BY 1
+
+{% endmacro %}

--- a/macros/metrics/get_chain_gdp.sql
+++ b/macros/metrics/get_chain_gdp.sql
@@ -16,7 +16,7 @@ WITH consumption_and_gov_expenditure AS (
                 , COALESCE(nft_trading_volume, 0) AS nft_trading_volume -- consumption 
                 , COALESCE(gross_emissions, 0) AS gross_emissions -- gov expenditures
             {% endif %}
-        FROM ARTEMIS_ICEBERG.PROD_{{ chain }}.EZ_{{ chain }}_METRICS
+        FROM {{ ref('ez_' ~ chain ~ '_metrics') }}
     )
 
     -- need to add protocol revenue

--- a/models/projects/ethereum/raw/ez_ethereum_gdp.sql
+++ b/models/projects/ethereum/raw/ez_ethereum_gdp.sql
@@ -1,0 +1,10 @@
+{{ 
+    config(
+        materialized="table",
+        database="ethereum",
+        schema="raw",
+        alias="ez_ethereum_gdp",
+    )
+}}
+
+{{ get_chain_gdp("ethereum", "quarter") }}

--- a/models/projects/ethereum/raw/ez_ethereum_gdp.sql
+++ b/models/projects/ethereum/raw/ez_ethereum_gdp.sql
@@ -7,4 +7,4 @@
     )
 }}
 
-{{ get_chain_gdp("ethereum", "quarter") }}
+{{ get_chain_gdp("ethereum") }}

--- a/models/projects/solana/raw/ez_solana_gdp.sql
+++ b/models/projects/solana/raw/ez_solana_gdp.sql
@@ -1,0 +1,10 @@
+{{ 
+    config(
+        materialized="table",
+        database="solana",
+        schema="raw",
+        alias="ez_solana_gdp",
+    )
+}}
+
+{{ get_chain_gdp("solana") }}


### PR DESCRIPTION
## :pushpin: References

Adding chain GDP macro and metric starting with Ethereum and Solana. It looks like we need to add gross emissions to ez_metrics for the other L1's prior to adding. 

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [X] Running all new models, and all downstream models compiles
- [X] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

<img width="1079" alt="Screen Shot 2025-05-16 at 12 07 16 PM" src="https://github.com/user-attachments/assets/071018f3-0609-40a4-a11f-1fb5aaa1d434" />

<img width="1075" alt="Screen Shot 2025-05-16 at 12 07 56 PM" src="https://github.com/user-attachments/assets/b114c01d-b551-4ab5-a9b6-86006c711e81" />


- [ ] Any other relevant information that may be helpful