### PR TITLE
Rename columns to deposits and borrows

### DIFF
--- a/models/projects/morpho/core/ez_morpho_metrics.sql
+++ b/models/projects/morpho/core/ez_morpho_metrics.sql
@@ -52,9 +52,9 @@ select
     date
     , dau
     , txns
-    , borrows as daily_borrows_usd
+    , borrows
     , supplies as total_available_supply
-    , deposits as daily_supply_usd
+    , deposits
     , fees
 
     -- Standardized metrics

--- a/models/projects/morpho/core/ez_morpho_metrics_by_chain.sql
+++ b/models/projects/morpho/core/ez_morpho_metrics_by_chain.sql
@@ -39,9 +39,9 @@ select
     , chain
     , dau
     , txns
-    , borrows as daily_borrows_usd
+    , borrows
     , supplies as total_available_supply
-    , deposits as daily_supply_usd
+    , deposits
     , fees
 
     -- Standardized metrics


### PR DESCRIPTION
- renamed columns to deposits and borrows so we don't have to depend on adapters support metrics `SupportsLending`

- ez_morpho_metrics_by_chain
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/c98a536e-7f11-4de1-a9a6-6c28ee22b1d8" />

- removed SupportsLending
<img width="1172" alt="image" src="https://github.com/user-attachments/assets/3ec3cc82-b75c-4b5a-a8fe-a0c5918b21ed" />
