### PR TITLE
Disable PolygonZK and ZCash ez Metrics Models

### DIFF
--- a/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
+++ b/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
@@ -5,6 +5,7 @@
         database="polygon_zk",
         schema="core",
         alias="ez_metrics",
+        enabled=false,
     )
 }}
 

--- a/models/projects/zcash/core/ez_zcash_metrics.sql
+++ b/models/projects/zcash/core/ez_zcash_metrics.sql
@@ -4,7 +4,8 @@
         snowflake_warehouse="ZCASH",
         database="zcash",
         schema="core",
-        alias="ez_metrics"
+        alias="ez_metrics",
+        enabled=false,
     )
 }}
 
@@ -20,7 +21,7 @@ with
     , github_data as ({{ get_github_metrics("zcash") }})
     , price_data as ({{ get_coingecko_metrics('zcash') }})
 
-select 
+select
     f.date
 
     -- Standardized Metrics


### PR DESCRIPTION
## Summary
- Setting these models to disabled so they don't appear in the dbt manifest.json file and get pulled into various automated systems