### PR TITLE
Switching liquity to use ez_token_transfers for Polygon

### DIFF
--- a/models/projects/liquity/raw/fact_liquity_v1_outstanding_supply_polygon.sql
+++ b/models/projects/liquity/raw/fact_liquity_v1_outstanding_supply_polygon.sql
@@ -19,7 +19,7 @@ WITH c AS (
             END
         ) AS lusdSupplyChange
     FROM
-        polygon_flipside.core.fact_token_transfers
+        polygon_flipside.core.ez_token_transfers
     WHERE 1 = 1 
         AND contract_address = lower('0x23001f892c0C82b79303EDC9B9033cD190BB21c7')
         AND(


### PR DESCRIPTION
## Summary
- `fact_token_transfers` has been renamed to `ez_token_transfers` by Elipside for Polygon

## Test Plan
<img width="894" alt="image" src="https://github.com/user-attachments/assets/b9081347-9308-41b9-92eb-b46102bad18a" />
