### PR TITLE
Switch fact_token_transfers -> ez_token_transfers for Ethereum and Gnosis

### DIFF
--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -45,14 +45,14 @@ sources:
       - name: fact_decoded_instructions
       - name: fact_events_inner
       - name: fact_token_account_owners
-  
+
   - name: SOLANA_FLIPSIDE_PRICE
     schema: PRICE
     database: SOLANA_FLIPSIDE
     tables:
       - name: ez_prices_hourly
       - name: ez_asset_metadata
-    
+
   - name: SOLANA_FLIPSIDE_DEFI
     schema: DEFI
     database: SOLANA_FLIPSIDE
@@ -65,7 +65,6 @@ sources:
     database: ethereum_flipside
     tables:
       - name: ez_native_transfers
-      - name: ez_token_transfers
       - name: fact_transactions
       - name: ez_decoded_event_logs
       - name: fact_event_logs
@@ -75,7 +74,7 @@ sources:
       - name: ez_decoded_traces
       - name: dim_contracts
       - name: fact_traces
-  
+
 
   - name: ETHEREUM_FLIPSIDE_PRICE
     schema: price
@@ -89,12 +88,12 @@ sources:
     database: ethereum_flipside
     tables:
       - name: fact_validators
-  
+
 # DUNE
   - name: DUNE_DEX_VOLUMES
     schema: dex
     database: zksync_dune
-    tables: 
+    tables:
       - name: trades
 
 # ARBITRUM
@@ -104,7 +103,7 @@ sources:
     database: arbitrum_flipside
     tables:
       - name: ez_prices_hourly
-  
+
   - name: ARBITRUM_FLIPSIDE
     schema: core
     database: arbitrum_flipside
@@ -116,7 +115,7 @@ sources:
       - name: ez_native_transfers
       - name: fact_traces
       - name: dim_contracts
-  
+
 
 # POLYGON
 

--- a/models/__global__sources.yml
+++ b/models/__global__sources.yml
@@ -65,7 +65,7 @@ sources:
     database: ethereum_flipside
     tables:
       - name: ez_native_transfers
-      - name: fact_token_transfers
+      - name: ez_token_transfers
       - name: fact_transactions
       - name: ez_decoded_event_logs
       - name: fact_event_logs

--- a/models/_complete_asset_models/maker/ez_maker_metrics__complete__.sql
+++ b/models/_complete_asset_models/maker/ez_maker_metrics__complete__.sql
@@ -64,7 +64,7 @@ SELECT
     block_timestamp,
     tx_hash,
     from_address as usr
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where to_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__dim_dao_wallet as (
@@ -695,7 +695,7 @@ SELECT
     tx_hash,
     to_address as usr,
     raw_amount_precise as wad
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where from_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__fact_opex_suck_hashes as (
@@ -893,7 +893,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -906,7 +906,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         -SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -1227,7 +1227,7 @@ SELECT
     tx_hash AS hash,
     CAST(raw_amount_precise AS DOUBLE) AS expense,
     to_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
   AND to_address != '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- excluding transfers to itself
@@ -1239,7 +1239,7 @@ SELECT
     tx_hash AS hash,
     -CAST(raw_amount_precise AS DOUBLE) AS expense,
     from_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
     AND from_address NOT IN ('0x8ee7d9235e01e6b42345120b5d270bdb763624c7', '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb') -- excluding initial transfers in and transfers from itself
@@ -1723,7 +1723,7 @@ WITH token_transfers AS (
         from_address,
         to_address,
         raw_amount_precise::number / 1e18 AS amount
-    FROM ethereum_flipside.core.fact_token_transfers
+    FROM ethereum_flipside.core.ez_token_transfers
     WHERE contract_address = LOWER('0x517F9dD285e75b599234F7221227339478d0FcC8')
 ),
 daily_mints AS (

--- a/models/_complete_asset_models/maker/ez_maker_metrics_by_chain__complete__.sql
+++ b/models/_complete_asset_models/maker/ez_maker_metrics_by_chain__complete__.sql
@@ -64,7 +64,7 @@ SELECT
     block_timestamp,
     tx_hash,
     from_address as usr
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where to_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__dim_dao_wallet as (
@@ -695,7 +695,7 @@ SELECT
     tx_hash,
     to_address as usr,
     raw_amount_precise as wad
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where from_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__fact_opex_suck_hashes as (
@@ -893,7 +893,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -906,7 +906,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         -SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -1227,7 +1227,7 @@ SELECT
     tx_hash AS hash,
     CAST(raw_amount_precise AS DOUBLE) AS expense,
     to_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
   AND to_address != '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- excluding transfers to itself
@@ -1239,7 +1239,7 @@ SELECT
     tx_hash AS hash,
     -CAST(raw_amount_precise AS DOUBLE) AS expense,
     from_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
     AND from_address NOT IN ('0x8ee7d9235e01e6b42345120b5d270bdb763624c7', '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb') -- excluding initial transfers in and transfers from itself
@@ -1723,7 +1723,7 @@ WITH token_transfers AS (
         from_address,
         to_address,
         raw_amount_precise::number / 1e18 AS amount
-    FROM ethereum_flipside.core.fact_token_transfers
+    FROM ethereum_flipside.core.ez_token_transfers
     WHERE contract_address = LOWER('0x517F9dD285e75b599234F7221227339478d0FcC8')
 ),
 daily_mints AS (

--- a/models/_complete_asset_models/maker/ez_maker_metrics_by_token__complete__.sql
+++ b/models/_complete_asset_models/maker/ez_maker_metrics_by_token__complete__.sql
@@ -64,7 +64,7 @@ SELECT
     block_timestamp,
     tx_hash,
     from_address as usr
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where to_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__dim_dao_wallet as (
@@ -695,7 +695,7 @@ SELECT
     tx_hash,
     to_address as usr,
     raw_amount_precise as wad
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where from_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 ),  __dbt__cte__fact_opex_suck_hashes as (
@@ -893,7 +893,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -906,7 +906,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         -SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN __dbt__cte__dim_treasury_erc20s t
         ON evt.contract_address = t.contract_address
     WHERE evt.from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -1227,7 +1227,7 @@ SELECT
     tx_hash AS hash,
     CAST(raw_amount_precise AS DOUBLE) AS expense,
     to_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
   AND to_address != '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- excluding transfers to itself
@@ -1239,7 +1239,7 @@ SELECT
     tx_hash AS hash,
     -CAST(raw_amount_precise AS DOUBLE) AS expense,
     from_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
     AND from_address NOT IN ('0x8ee7d9235e01e6b42345120b5d270bdb763624c7', '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb') -- excluding initial transfers in and transfers from itself
@@ -1724,7 +1724,7 @@ WITH token_transfers AS (
         from_address,
         to_address,
         raw_amount_precise::number / 1e18 AS amount
-    FROM ethereum_flipside.core.fact_token_transfers
+    FROM ethereum_flipside.core.ez_token_transfers
     WHERE contract_address = LOWER('0x517F9dD285e75b599234F7221227339478d0FcC8')
 ),
 daily_mints AS (

--- a/models/projects/balancer/raw/fact_balancer_ethereum_revenue_by_token.sql
+++ b/models/projects/balancer/raw/fact_balancer_ethereum_revenue_by_token.sql
@@ -17,7 +17,7 @@ select
     sum(raw_amount_precise::number / 1e18) as amount_native,
     sum(raw_amount_precise::number / 1e18 * p.price) as amount_usd
 from
-    ethereum_flipside.core.fact_token_transfers t
+    ethereum_flipside.core.ez_token_transfers t
     left join ethereum_flipside.price.ez_prices_hourly p on p.token_address = t.contract_address
     and p.hour = t.block_timestamp::date
 where

--- a/models/projects/balancer/raw/fact_balancer_token_incentives.sql
+++ b/models/projects/balancer/raw/fact_balancer_token_incentives.sql
@@ -15,7 +15,7 @@ select
     sum(raw_amount_precise::number / 1e18) as amount_native,
     sum(raw_amount_precise::number / 1e18 * p.price) as amount_usd
 from
-    ethereum_flipside.core.fact_token_transfers t
+    ethereum_flipside.core.ez_token_transfers t
     left join ethereum_flipside.price.ez_prices_hourly p on p.token_address = t.contract_address
     and p.hour = t.block_timestamp::date
 where 1=1

--- a/models/projects/convex/raw/fact_convex_revenue.sql
+++ b/models/projects/convex/raw/fact_convex_revenue.sql
@@ -14,7 +14,7 @@ with transfers as (
         contract_address,
         sum(RAW_AMOUNT_PRECISE) as claimed
     from
-        {{ source('ETHEREUM_FLIPSIDE', 'fact_token_transfers') }}
+        {{ source('ETHEREUM_FLIPSIDE', 'ez_token_transfers') }}
     where
         contract_address = lower('0xD533a949740bb3306d119CC777fa900bA034cd52')
         and from_address = lower('0x0000000000000000000000000000000000000000')
@@ -28,7 +28,7 @@ with transfers as (
         contract_address,
         sum(RAW_AMOUNT_PRECISE) as claimed
     from
-        {{ source('ETHEREUM_FLIPSIDE', 'fact_token_transfers') }}
+        {{ source('ETHEREUM_FLIPSIDE', 'ez_token_transfers') }}
     where
         contract_address = lower('0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490')
         and to_address = lower('0x7091dbb7fcbA54569eF1387Ac89Eb2a5C9F6d2EA')

--- a/models/projects/lido/raw/fact_lido_fees_revs_expenses.sql
+++ b/models/projects/lido/raw/fact_lido_fees_revs_expenses.sql
@@ -24,7 +24,7 @@ with steth_prices as (
         , sum(raw_amount_precise::number / 1e18 * 20) as total_staking_yield_native
         , sum(raw_amount_precise::number / 1e18 * p.price * 20) as total_staking_yield_usd
     from
-        ethereum_flipside.core.fact_token_transfers t
+        ethereum_flipside.core.ez_token_transfers t
     left join steth_prices p on date_trunc('hour', t.block_timestamp) = p.hour
     where
         contract_address = lower('0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84')

--- a/models/projects/lido/raw/fact_lido_token_incentives.sql
+++ b/models/projects/lido/raw/fact_lido_token_incentives.sql
@@ -26,7 +26,7 @@ select
     , sum(coalesce(t.raw_amount_precise::number / 1e18,0)) as amount_native
     , sum(coalesce(t.raw_amount_precise::number / 1e18 * p.price,0)) as amount_usd
 from ldo_prices p
-LEFT JOIN ethereum_flipside.core.fact_token_transfers t 
+LEFT JOIN ethereum_flipside.core.ez_token_transfers t 
     ON p.hour = DATE_TRUNC('hour', t.block_timestamp)
     AND p.token_address = t.contract_address
     AND t.from_address IN (

--- a/models/projects/liquity/raw/fact_liquity_v1_outstanding_supply_ethereum.sql
+++ b/models/projects/liquity/raw/fact_liquity_v1_outstanding_supply_ethereum.sql
@@ -19,7 +19,7 @@ WITH c AS (
             END
         ) AS lusdSupplyChange
     FROM
-        ethereum_flipside.core.fact_token_transfers
+        ethereum_flipside.core.ez_token_transfers
     WHERE 1 = 1 
         AND contract_address = lower('0x5f98805a4e8be255a32880fdec7f6728c6568ba0')
         AND(

--- a/models/projects/maker/raw/fact_dai_burn.sql
+++ b/models/projects/maker/raw/fact_dai_burn.sql
@@ -12,6 +12,6 @@ SELECT
     block_timestamp,
     tx_hash,
     from_address as usr
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where to_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')

--- a/models/projects/maker/raw/fact_dai_mint.sql
+++ b/models/projects/maker/raw/fact_dai_mint.sql
@@ -13,6 +13,6 @@ SELECT
     tx_hash,
     to_address as usr,
     raw_amount_precise as wad
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 where from_address = '0x0000000000000000000000000000000000000000'
 and lower(contract_address) = lower('0x6B175474E89094C44Da98b954EedeAC495271d0F')

--- a/models/projects/maker/raw/fact_pause_proxy_mkr_trxns_raw.sql
+++ b/models/projects/maker/raw/fact_pause_proxy_mkr_trxns_raw.sql
@@ -13,7 +13,7 @@ SELECT
     tx_hash AS hash,
     CAST(raw_amount_precise AS DOUBLE) AS expense,
     to_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
   AND to_address != '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- excluding transfers to itself
@@ -25,7 +25,7 @@ SELECT
     tx_hash AS hash,
     -CAST(raw_amount_precise AS DOUBLE) AS expense,
     from_address AS address
-FROM ethereum_flipside.core.fact_token_transfers
+FROM ethereum_flipside.core.ez_token_transfers
 WHERE contract_address = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2' -- MKR token address
   AND to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb' -- pause proxy
     AND from_address NOT IN ('0x8ee7d9235e01e6b42345120b5d270bdb763624c7', '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb') -- excluding initial transfers in and transfers from itself

--- a/models/projects/maker/raw/fact_treasury_flows.sql
+++ b/models/projects/maker/raw/fact_treasury_flows.sql
@@ -14,7 +14,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN {{ ref('dim_treasury_erc20s') }} t
         ON evt.contract_address = t.contract_address
     WHERE evt.to_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'
@@ -27,7 +27,7 @@ WITH treasury_flows_preunioned AS (
         evt.tx_hash AS hash,
         t.token,
         -SUM(evt.RAW_AMOUNT_PRECISE / POW(10, t.decimals)) AS value
-    FROM ethereum_flipside.core.fact_token_transfers evt
+    FROM ethereum_flipside.core.ez_token_transfers evt
     JOIN {{ ref('dim_treasury_erc20s') }} t
         ON evt.contract_address = t.contract_address
     WHERE evt.from_address = '0xbe8e3e3618f7474f8cb1d074a26affef007e98fb'

--- a/models/projects/maker/raw/fact_uni_lp_supply.sql
+++ b/models/projects/maker/raw/fact_uni_lp_supply.sql
@@ -14,7 +14,7 @@ WITH token_transfers AS (
         from_address,
         to_address,
         raw_amount_precise::number / 1e18 AS amount
-    FROM ethereum_flipside.core.fact_token_transfers
+    FROM ethereum_flipside.core.ez_token_transfers
     WHERE contract_address = LOWER('0x517F9dD285e75b599234F7221227339478d0FcC8')
 ),
 daily_mints AS (

--- a/models/staging/bananagun/fact_bananagun_coin_metrics.sql
+++ b/models/staging/bananagun/fact_bananagun_coin_metrics.sql
@@ -26,7 +26,7 @@ transfers AS (
             WHEN lower(FROM_ADDRESS) = lower('0xECC6c8C7EdA9C600773F0D133549d9933a91dBFB') THEN 'reward'
             ELSE 'other'
         END as transfer_type
-    FROM ETHEREUM_FLIPSIDE.CORE.FACT_TOKEN_TRANSFERS
+    FROM ethereum_flipside.core.ez_token_transfers
     WHERE lower(CONTRACT_ADDRESS) = lower('0x38E68A37E401F7271568CecaAc63c6B1e19130B4') -- BANANA V2
         AND BLOCK_NUMBER >= 18135851
 ),

--- a/models/staging/gnosispay/fact_gnosispay_transfers.sql
+++ b/models/staging/gnosispay/fact_gnosispay_transfers.sql
@@ -10,7 +10,7 @@ select
     from_address,
     'EURe' as token,
     to_decimal(RAW_AMOUNT_PRECISE, 38, 0) / 1e18 AS transfer_volume
-from gnosis_flipside.core.fact_token_transfers
+from gnosis_flipside.core.ez_token_transfers
 where lower(contract_address) in (
     lower('0x420CA0f9B9b604cE0fd9C18EF134C705e5Fa3430')
 )
@@ -25,7 +25,7 @@ select
     from_address,
     'EURe' as token,
     to_decimal(RAW_AMOUNT_PRECISE, 38, 0) / 1e18 AS transfer_volume
-from gnosis_flipside.core.fact_token_transfers
+from gnosis_flipside.core.ez_token_transfers
 where lower(contract_address) in (
     lower('0xcB444e90D8198415266c6a2724b7900fb12FC56E')
 )
@@ -40,7 +40,7 @@ select
     from_address,
     'GBPe' as token,
     to_decimal(RAW_AMOUNT_PRECISE, 38, 0) / 1e18 AS transfer_volume
-from gnosis_flipside.core.fact_token_transfers
+from gnosis_flipside.core.ez_token_transfers
 where lower(contract_address) in (
     lower('0x5Cb9073902F2035222B9749F8fB0c9BFe5527108')
 )

--- a/models/staging/pendle/fact_pendle_token_incentives_by_chain_silver.sql
+++ b/models/staging/pendle/fact_pendle_token_incentives_by_chain_silver.sql
@@ -12,7 +12,7 @@ with agg as(
         , sum(raw_amount_precise::number / 1e18) as amt_pendle
         , SUM(raw_amount_precise::number / 1e18 * p.price) as amt_usd
     from
-        ethereum_flipside.core.fact_token_transfers
+        ethereum_flipside.core.ez_token_transfers
         left join ethereum_flipside.price.ez_prices_hourly p ON p.hour = date_trunc('hour', block_timestamp)
         AND p.token_address = lower('0x808507121B80c02388fAd14726482e061B8da827')
     where


### PR DESCRIPTION
## Summary
- Updating references to `fact_token_transfers` in advance of Flipside Ethereum Standarization later this month

## Test Plan
<img width="876" alt="image" src="https://github.com/user-attachments/assets/484a8819-405f-484c-bdba-f285ffe024e0" />
<img width="893" alt="image" src="https://github.com/user-attachments/assets/d2a84aa0-e513-4e46-be7c-c5fa45adb1dd" />

columns in fact_token_transfers are a subset of those in ez_token_transfers
<img width="441" alt="image" src="https://github.com/user-attachments/assets/445c99e4-2625-4dab-8511-0a4159284d01" />
