### PR TITLE
Add Syrup ez tables

### DIFF
--- a/models/projects/syrup/core/ez_syrup_metrics.sql
+++ b/models/projects/syrup/core/ez_syrup_metrics.sql
@@ -1,0 +1,12 @@
+{{ 
+    config(
+        materialized='table',
+        snowflake_warehouse='SYRUP',
+        database='SYRUP',
+        schema='core',
+        alias='ez_metrics'
+    )
+}}
+SELECT
+    *
+FROM {{ ref('ez_maple_metrics') }}

--- a/models/projects/syrup/core/ez_syrup_metrics_by_chain.sql
+++ b/models/projects/syrup/core/ez_syrup_metrics_by_chain.sql
@@ -1,6 +1,6 @@
 {{
     config(
-        materialized = 'view',
+        materialized = 'table',
         snowflake_warehouse = 'SYRUP',
         database = 'SYRUP',
         schema = 'core',

--- a/models/projects/syrup/core/ez_syrup_metrics_by_chain.sql
+++ b/models/projects/syrup/core/ez_syrup_metrics_by_chain.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        materialized = 'view',
+        snowflake_warehouse = 'SYRUP',
+        database = 'SYRUP',
+        schema = 'core',
+        alias = 'ez_metrics_by_chain'
+    )
+}}
+SELECT 
+    *
+FROM {{ ref('ez_maple_metrics_by_chain') }}


### PR DESCRIPTION
## Summary
- Adding Syrup ez tables
- For now these are just copies of the tables for Maple 
- We need to materialize these into the `SYRUP` database for the FE to properly attribute them to `syrup` instead of `maple` for now

## Test Plan
- Materialized models, ran RETL locally, and metrics appear 
<img width="764" alt="image" src="https://github.com/user-attachments/assets/028cc586-29aa-450d-86ae-eb7105ade588" />
<img width="710" alt="image" src="https://github.com/user-attachments/assets/8f5e8892-1506-4173-a568-37adf8cc7793" />

## Next Steps
- Schedule DBT models and fix adapter
