### PR TITLE
Add Iceberg dbt Subproject

### DIFF
--- a/iceberg/dbt_project.yml
+++ b/iceberg/dbt_project.yml
@@ -1,0 +1,42 @@
+# Name your project! Project names should contain only lowercase characters
+# and underscores. A good package name should reflect your organization's
+# name or the intended use of these models
+name: "artemis_dbt_iceberg"
+version: "1.0.0"
+config-version: 2
+
+# This setting configures which "profile" dbt uses for this project.
+profile: "snowflake-dagster"
+
+# These configurations specify where dbt should look for different types of files.
+# The `source-paths` config, for example, states that models in this project can be
+# found in the "models/" directory. You probably won't need to change these!
+model-paths: ["./models"]
+analysis-paths: ["./analyses"]
+test-paths: ["./tests"]
+seed-paths: ["./seeds"]
+macro-paths: ["./macros"]
+snapshot-paths: ["./snapshots"]
+
+target-path: "target" # directory which will store compiled SQL files
+clean-targets: # directories to be removed by `dbt clean`
+  - "target"
+  - "dbt_packages"
+
+# Configuring models
+# Full documentation: https://docs.getdbt.com/docs/configuring-models
+
+# In this example config, we tell dbt to build all models in the example/ directory
+# as tables. These settings can be overridden in the individual model files
+# using the `{{ config(...) }}` macro.
+models:
+  +persist_docs:
+    relation: true
+    columns: true
+
+vars:
+  dbt_date:time_zone: "Etc/UTC"
+
+flags:
+  enable_iceberg_materializations: True
+

--- a/iceberg/models/test_iceberg.sql
+++ b/iceberg/models/test_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="TEST",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_TEST_METRICS",
+    )
+}}
+
+SELECT
+    *
+FROM (
+    VALUES (
+        ('a'),
+        ('b')
+    )
+) AS t(c1, c2)
+

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -3,6 +3,7 @@ packages:
     version: 1.1.0
   - package: metaplane/dbt_expectations
     version: 0.10.8
+  - local: iceberg/
   - package: godatadriven/dbt_date
-    version: 0.11.0
-sha1_hash: 9a79207ce50e41bd4bcda50d3a90be956a263c1e
+    version: 0.13.0
+sha1_hash: 855fe3f193d15725d23355830fa1e08937c2f32c

--- a/packages.yml
+++ b/packages.yml
@@ -3,3 +3,4 @@ packages:
     version: 1.1.0
   - package: metaplane/dbt_expectations
     version: 0.10.8
+  - local: iceberg/


### PR DESCRIPTION
## Summary
- Adding subproject for Iceberg tables
## Test Plan
- Ran model from iceberg project 
`dbt run -s models/test_iceberg.sql`
<img width="486" alt="image" src="https://github.com/user-attachments/assets/8a72c9cb-0889-4580-a7a5-39331d566d9b" />

- Compilation runs super fast (6s)

- Selecting models from primary package works
`dbt ls --select 'artemis_dbt_iceberg.*'`

<img width="658" alt="image" src="https://github.com/user-attachments/assets/7509226a-c27c-48aa-9ae5-a3f3bd8e4a93" />

- `dbt compile` from primary project still works in normal amount of time
<img width="302" alt="image" src="https://github.com/user-attachments/assets/ec031cb2-13b5-4aea-a41e-30926f5c8786" />


- Files written to S3 
<img width="419" alt="image" src="https://github.com/user-attachments/assets/1cd932eb-6b1c-451c-8e9c-130a35d4a00e" />

- Table available within `ARTEMIS_ICEBERG` in snowflake
<img width="780" alt="image" src="https://github.com/user-attachments/assets/449fb0b3-4ae7-41d0-a35b-fc0282b55700" />

## Next Steps
- Iron out Dagster Integration