### PR TITLE
feature/compound token incentives

### DIFF
--- a/models/projects/compound/core/ez_compound_metrics.sql
+++ b/models/projects/compound/core/ez_compound_metrics.sql
@@ -30,6 +30,12 @@ with
         group by 1
     )
     , price_data as ({{ get_coingecko_metrics("compound-governance-token") }})
+    , token_incentives as (
+        select
+            day as date,
+            total_usd_value as token_incentives
+        from {{ref('fact_compound_token_incentives')}}
+    )
 
 select
     compound_metrics.date
@@ -41,7 +47,10 @@ select
     , price_data.price
     , price_data.market_cap
     , price_data.fdmc
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
 from compound_metrics
 left join price_data
     on compound_metrics.date = price_data.date
+left join token_incentives
+    on compound_metrics.date = token_incentives.date
 where compound_metrics.date < to_date(sysdate())

--- a/models/staging/compound/fact_compound_token_incentives.sql
+++ b/models/staging/compound/fact_compound_token_incentives.sql
@@ -1,0 +1,123 @@
+{{
+    config(
+        materialized = 'table',
+    )
+}}
+
+WITH v2_rewards_raw AS (
+  SELECT
+    DATE_TRUNC('day', block_timestamp) AS day,
+    SUM(TRY_CAST(decoded_log:"compDelta"::string AS FLOAT)) / 1e18 AS total_comp
+  FROM ethereum_flipside.core.ez_decoded_event_logs
+  WHERE
+    contract_address = LOWER('0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b')
+    AND event_name IN ('DistributedSupplierComp', 'DistributedBorrowerComp')
+  GROUP BY 1
+),
+
+v2_prices AS (
+  SELECT
+    DATE_TRUNC('day', hour) AS day,
+    AVG(price) AS comp_price
+  FROM ethereum_flipside.price.ez_prices_hourly
+  WHERE token_address = LOWER('0xc00e94cb662c3520282e6f5717214004a7f26888')
+  GROUP BY 1
+),
+
+v2_usd AS (
+  SELECT
+    r.day,
+    r.total_comp,
+    p.comp_price,
+    r.total_comp * p.comp_price AS usd_value
+  FROM v2_rewards_raw r
+  JOIN v2_prices p ON r.day = p.day
+),
+
+v2_with_median AS (
+  SELECT
+    day,
+    usd_value,
+    DATE_TRUNC('month', day) AS month,
+    MEDIAN(usd_value) OVER (PARTITION BY DATE_TRUNC('month', day)) AS monthly_median
+  FROM v2_usd
+),
+
+v2_final AS (
+  SELECT
+    day,
+    CASE 
+      WHEN usd_value > 5000000 THEN monthly_median
+      ELSE usd_value
+    END AS corrected_usd_value
+  FROM v2_with_median
+),
+
+v3_rewards_transfers AS (
+  SELECT
+    DATE_TRUNC('day', block_timestamp) AS day,
+    SUM(TRY_CAST(decoded_log:"amount"::string AS FLOAT)) / 1e18 AS total_comp
+  FROM ethereum_flipside.core.ez_decoded_event_logs
+  WHERE
+    ORIGIN_TO_ADDRESS = LOWER('0x1b0e765f6224c21223aea2af16c1c46e38885a40')
+    AND CONTRACT_ADDRESS = LOWER('0xc00e94cb662c3520282e6f5717214004a7f26888')
+    AND event_name = 'Transfer'
+    AND decoded_log:"from" = LOWER('0x1b0e765f6224c21223aea2af16c1c46e38885a40')
+  GROUP BY 1
+),
+
+v3_rewards_claimed AS (
+  SELECT
+    DATE_TRUNC('day', block_timestamp) AS day,
+    SUM(TRY_CAST(decoded_log:"amount"::string AS FLOAT)) / 1e18 AS total_comp
+  FROM ethereum_flipside.core.ez_decoded_event_logs
+  WHERE
+    contract_address = LOWER('0x1b0e765f6224c21223aea2af16c1c46e38885a40')
+    AND event_name = 'RewardClaimed'
+    AND decoded_log:"token" = LOWER('0xc00e94cb662c3520282e6f5717214004a7f26888')
+  GROUP BY 1
+),
+
+v3_combined AS (
+  SELECT * FROM v3_rewards_transfers
+  UNION ALL
+  SELECT * FROM v3_rewards_claimed
+),
+
+v3_daily_rewards AS (
+  SELECT
+    day,
+    SUM(total_comp) AS total_comp
+  FROM v3_combined
+  GROUP BY 1
+),
+
+v3_prices AS (
+  SELECT
+    DATE_TRUNC('day', hour) AS day,
+    AVG(price) AS comp_price
+  FROM ethereum_flipside.price.ez_prices_hourly
+  WHERE token_address = LOWER('0xc00e94cb662c3520282e6f5717214004a7f26888')
+  GROUP BY 1
+),
+
+v3_final AS (
+  SELECT
+    r.day,
+    r.total_comp * p.comp_price AS corrected_usd_value
+  FROM v3_daily_rewards r
+  JOIN v3_prices p ON r.day = p.day
+),
+
+combined_final AS (
+  SELECT * FROM v2_final
+  UNION ALL
+  SELECT * FROM v3_final
+)
+
+SELECT
+  day,
+  SUM(corrected_usd_value) AS total_usd_value
+FROM combined_final
+GROUP BY 1
+ORDER BY 1


### PR DESCRIPTION
Added:
Data model for compound token incentives to ez_metrics and ez_metrics_by_chain

CAD: In Progress

Key Notes:
All the token incentives are taken from the ethereum contract so in the by_chain table token incentives are only under eth

Validation:
<img width="672" alt="Screenshot 2025-05-20 at 10 24 34 PM" src="https://github.com/user-attachments/assets/fa1572d6-7cce-4f54-8baa-6f4b5ab03e81" />
