### PR TITLE
feature/eigenlayer avs rewards & token incentives

### DIFF
--- a/models/projects/eigenlayer/core/ez_eigenlayer_metrics.sql
+++ b/models/projects/eigenlayer/core/ez_eigenlayer_metrics.sql
@@ -9,18 +9,25 @@
 }}
 
 -- Simplified ez metrics table that aggregates data for eigenlayer
-WITH 
-    eigenlayer_aggregated AS (
-        SELECT 
+WITH date_spine AS (
+        SELECT
             date
-            , protocol as app
-            , category
-            , SUM(num_restaked_eth) AS num_restaked_eth
-            , SUM(amount_restaked_usd) AS amount_restaked_usd
-        FROM {{ref('fact_eigenlayer_restaked_assets')}}
-        GROUP BY date, protocol, category
-    )
-    , eigenlayer_supply_data AS (
+        FROM {{ ref('dim_date_spine') }}
+        WHERE date BETWEEN 
+            (SELECT MIN(date) FROM {{ ref('fact_eigenlayer_restaked_assets') }}) 
+            AND (SELECT MAX(date) FROM {{ ref('fact_eigenlayer_restaked_assets') }})
+)
+, eigenlayer_aggregated AS (
+    SELECT 
+        date
+        , protocol as app
+        , category
+        , SUM(num_restaked_eth) AS num_restaked_eth
+        , SUM(amount_restaked_usd) AS amount_restaked_usd
+    FROM {{ref('fact_eigenlayer_restaked_assets')}}
+    GROUP BY date, protocol, category
+)
+, eigenlayer_supply_data AS (
         SELECT
             date
             , emissions_native
@@ -28,13 +35,45 @@ WITH
             , net_supply_change_native
             , circulating_supply
         FROM {{ ref('fact_eigenlayer_supply_data') }}
-    )
-    , market_data as (
-        {{ get_coingecko_metrics('eigenlayer') }}
-    )
+)
+, avs_rewards_submitted AS (
+    SELECT 
+        date
+        , SUM(amount_usd) AS avs_rewards_submitted
+    FROM {{ ref('fact_eigenlayer_avs_rewards_submitted') }}
+    WHERE event_name ilike '%AVS%'
+    GROUP BY date
+)
+, avs_rewards_claimed AS (
+    SELECT 
+        date
+        , SUM(amount_usd) AS avs_rewards_claimed
+    FROM {{ ref('fact_eigenlayer_avs_rewards_claimed') }}
+    GROUP BY date
+)
+, avs_and_operator_counts AS (
+    SELECT
+        date
+        , SUM(active_operators) AS active_operators
+        , SUM(active_avs) AS active_avs
+    FROM {{ ref('fact_eigenlayer_avs_and_operator_counts') }}
+    GROUP BY date
+)
+, market_data as (
+    {{ get_coingecko_metrics('eigenlayer') }}
+)
+, token_incentives as (
+    SELECT
+        date
+        , SUM(amount_aduj) AS token_incentives_native
+        , SUM(amount_usd) AS token_incentives
+    FROM {{ ref('fact_eigenlayer_avs_rewards_submitted') }}
+    WHERE event_name not ilike '%AVS%'
+    GROUP BY date
+)
 
 SELECT 
-    date
+    d.date
     , app
     , category
 
@@ -47,6 +86,12 @@ SELECT
     , coalesce(market_data.token_turnover_circulating, 0) as token_turnover_circulating
 
     -- Crypto Metrics
+    , coalesce(avs_rewards_submitted.avs_rewards_submitted, 0) as avs_rewards_submitted
+    , coalesce(avs_rewards_claimed.avs_rewards_claimed, 0) as avs_rewards_claimed
+    , coalesce(avs_and_operator_counts.active_operators, 0) as active_operators
+    , coalesce(avs_and_operator_counts.active_avs, 0) as active_avs
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
+    , coalesce(token_incentives.token_incentives_native, 0) as token_incentives_native
     , amount_restaked_usd as tvl
     , amount_restaked_usd - LAG(amount_restaked_usd) 
         OVER (ORDER BY date) AS tvl_net_change
@@ -58,12 +103,18 @@ SELECT
     , circulating_supply
     , emissions_native as emissions_native
     , net_supply_change_native
-    , premine_unlocks_native as premine_unlocks_native
+    , premine_unlocks_native as premine_unlocks_native_native
 
     -- Turnover Metrics
     , coalesce(market_data.token_turnover_fdv, 0) as token_turnover_fdv
     , coalesce(market_data.token_volume, 0) as token_volume
-FROM eigenlayer_aggregated
+FROM date_spine d
+LEFT JOIN eigenlayer_aggregated using (date)
 LEFT JOIN eigenlayer_supply_data using (date)
+LEFT JOIN token_incentives using (date)
+LEFT JOIN avs_rewards_claimed using (date)
+LEFT JOIN avs_and_operator_counts using (date)
+LEFT JOIN avs_rewards_submitted using (date)
 LEFT JOIN market_data using (date)
-ORDER BY date
+WHERE d.date < CURRENT_DATE()
+ORDER BY d.date

--- a/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_chain.sql
+++ b/models/projects/eigenlayer/core/ez_eigenlayer_metrics_by_chain.sql
@@ -20,6 +20,38 @@ WITH chain_aggregates AS (
     FROM {{ref('fact_eigenlayer_restaked_assets')}}
     GROUP BY date, chain, protocol, category
 )
+, avs_rewards_submitted AS (
+    SELECT 
+        date
+        , SUM(amount_usd) AS avs_rewards_submitted
+    FROM {{ ref('fact_eigenlayer_avs_rewards_submitted') }}
+    WHERE event_name ilike '%AVS%'
+    GROUP BY date
+)
+, avs_rewards_claimed AS (
+    SELECT 
+        date
+        , SUM(amount_usd) AS avs_rewards_claimed
+    FROM {{ ref('fact_eigenlayer_avs_rewards_claimed') }}
+    GROUP BY date
+)
+, avs_and_operator_counts AS (
+    SELECT
+        date
+        , SUM(active_operators) AS active_operators
+        , SUM(active_avs) AS active_avs
+    FROM {{ ref('fact_eigenlayer_avs_and_operator_counts') }}
+    GROUP BY date
+)
+, token_incentives as (
+    SELECT
+        date
+        , SUM(amount_aduj) AS token_incentives_native
+        , SUM(amount_usd) AS token_incentives
+    FROM {{ ref('fact_eigenlayer_avs_rewards_submitted') }}
+    WHERE event_name not ilike '%AVS%'
+    GROUP BY date
+)
 
 SELECT 
     date
@@ -34,6 +66,12 @@ SELECT
         OVER (ORDER BY date) AS amount_restaked_usd_net_change
 
     -- Crypto Metrics
+    , avs_rewards_submitted.avs_rewards_submitted as avs_rewards_submitted
+    , avs_rewards_claimed.avs_rewards_claimed as avs_rewards_claimed
+    , coalesce(avs_and_operator_counts.active_operators, 0) as active_operators
+    , coalesce(avs_and_operator_counts.active_avs, 0) as active_avs
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
+    , coalesce(token_incentives.token_incentives_native, 0) as token_incentives_native
     , amount_restaked_usd as tvl
     , amount_restaked_usd - LAG(amount_restaked_usd) 
         OVER (ORDER BY date) AS tvl_net_change
@@ -41,4 +79,9 @@ SELECT
     , num_restaked_eth - LAG(num_restaked_eth) 
         OVER (ORDER BY date) AS tvl_native_net_change
 FROM chain_aggregates
+LEFT JOIN avs_rewards_submitted using (date)
+LEFT JOIN avs_rewards_claimed using (date)
+LEFT JOIN avs_and_operator_counts using (date)
+LEFT JOIN token_incentives using (date)
+WHERE date < CURRENT_DATE()
 ORDER BY date

--- a/models/projects/eigenlayer/raw/fact_eigenlayer_avs_and_operator_counts.sql
+++ b/models/projects/eigenlayer/raw/fact_eigenlayer_avs_and_operator_counts.sql
@@ -1,0 +1,95 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="raw",
+        alias="fact_eigenlayer_avs_and_operator_counts",
+    )
+}}
+
+WITH AVSEvents AS (
+    SELECT
+        block_timestamp,
+        DATE_TRUNC('day', block_timestamp) AS date,
+        decoded_log:avs::STRING AS avs,
+        decoded_log:operator::STRING AS operator,
+        decoded_log:status::STRING AS status
+    FROM {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    WHERE contract_address = '0x135dda560e946695d6f155dacafc6f1f25c1f5af'
+    AND event_name = 'OperatorAVSRegistrationStatusUpdated'
+),
+
+-- Create a complete date spine
+DateSpine AS (
+    SELECT DISTINCT
+        date
+    FROM {{ ref('dim_date_spine') }}
+    WHERE date > (SELECT MIN(date) FROM AVSEvents)
+    AND date < CURRENT_DATE()
+    ORDER BY date
+),
+
+-- Get all operator-AVS pairs
+OperatorAVSPairs AS (
+    SELECT DISTINCT operator, avs 
+    FROM AVSEvents
+),
+
+-- Create all combinations of dates and operator-AVS pairs
+DatePairCombinations AS (
+    SELECT 
+        d.date,
+        p.operator,
+        p.avs
+    FROM DateSpine d
+    CROSS JOIN OperatorAVSPairs p
+),
+
+-- Join with events and find the status as of each date
+HistoricalStatus AS (
+    SELECT
+        c.date,
+        c.operator,
+        c.avs,
+        e.block_timestamp,
+        e.status
+    FROM DatePairCombinations c
+    LEFT JOIN AVSEvents e
+        ON e.operator = c.operator
+        AND e.avs = c.avs
+        AND e.block_timestamp <= DATEADD('day', 1, c.date) - INTERVAL '1 second'
+),
+
+-- Get the latest status for each date and operator-AVS pair
+LatestStatus AS (
+    SELECT
+        date,
+        operator,
+        avs,
+        FIRST_VALUE(status) OVER (
+            PARTITION BY date, operator, avs
+            ORDER BY block_timestamp DESC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS current_status
+    FROM HistoricalStatus
+),
+
+-- Remove duplicates
+DeduplicatedStatus AS (
+    SELECT DISTINCT
+        date,
+        operator,
+        avs,
+        current_status
+    FROM LatestStatus
+)
+
+-- Count active relationships each day
+SELECT
+    date,
+    COUNT(DISTINCT CASE WHEN current_status = '1' THEN operator END) AS active_operators,
+    COUNT(DISTINCT CASE WHEN current_status = '1' THEN avs END) AS active_avs
+FROM DeduplicatedStatus
+GROUP BY date
+ORDER BY date

--- a/models/projects/eigenlayer/raw/fact_eigenlayer_avs_rewards_claimed.sql
+++ b/models/projects/eigenlayer/raw/fact_eigenlayer_avs_rewards_claimed.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="raw",
+        alias="fact_eigenlayer_avs_rewards_claimed",
+    )
+}}
+
+With AVSRewardsClaimedEvents AS (
+    select
+        date_trunc('day', block_timestamp) as date,
+        block_timestamp,
+        tx_hash,
+        decoded_log,
+        decoded_log:claimedAmount::FLOAT as amount,
+        decoded_log:claimer::STRING as claimer,
+        decoded_log:recipient::STRING as recipient,
+        decoded_log:token::STRING as token_address,
+    from {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    where contract_address = lower('0x7750d328b314EfFa365A0402CcfD489B80B0adda') --Eigenlayer Rewards Coordinator
+    and event_name = 'RewardsClaimed'
+), token_info AS (
+    SELECT
+        hour,
+        token_address,
+        price,
+        symbol,
+        decimals
+    FROM {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }}
+), AVSRewardsClaimedEvents_USD AS (
+    select
+        rce.*,
+        t.decimals,
+        rce.amount / pow(10,t.decimals) as amount_aduj,
+        t.symbol as token_symbol,
+        t.price as token_price,
+        (rce.amount / POW(10, t.decimals)) * t.price AS amount_usd
+    from AVSRewardsClaimedEvents rce
+    LEFT JOIN token_info t 
+        ON lower(t.token_address) = lower(rce.token_address) 
+        and t.hour = rce.date
+) select * from AVSRewardsClaimedEvents_USD WHERE token_symbol != 'EIGEN'

--- a/models/projects/eigenlayer/raw/fact_eigenlayer_avs_rewards_submitted.sql
+++ b/models/projects/eigenlayer/raw/fact_eigenlayer_avs_rewards_submitted.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="EIGENLAYER",
+        database="EIGENLAYER",
+        schema="raw",
+        alias="fact_eigenlayer_avs_rewards_submitted",
+    )
+}}
+
+
+With AVSRewardsSubmittedEvents AS (
+    select
+        date_trunc('day', block_timestamp) as date,
+        block_timestamp,
+        tx_hash,
+        event_name,
+        decoded_log,
+        decoded_log:rewardsSubmission[1]::STRING as token_address,
+        decoded_log:rewardsSubmission[2]::STRING as amount,
+    from {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    where contract_address = lower('0x7750d328b314EfFa365A0402CcfD489B80B0adda') --Eigenlayer Rewards Coordinator
+    and event_name in ('RewardsSubmissionForAllEarnersCreated', 'AVSRewardsSubmissionCreated')
+), token_info AS (
+    SELECT
+        hour,
+        token_address,
+        price,
+        symbol,
+        decimals
+    FROM {{ source('ETHEREUM_FLIPSIDE_PRICE', 'ez_prices_hourly') }}
+), AVSRewardsSubmittedEvents_USD AS (
+    select
+        rse.*,
+        t.decimals,
+        rse.amount / pow(10,t.decimals) as amount_aduj,
+        t.symbol as token_symbol,
+        t.price as token_price,
+        (rse.amount / POW(10, t.decimals)) * t.price AS amount_usd
+    from AVSRewardsSubmittedEvents rse
+    LEFT JOIN token_info t 
+        ON lower(t.token_address) = lower(rse.token_address) 
+        and t.hour = rse.date
+) select * from AVSRewardsSubmittedEvents_USD


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [x] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [X] Running all new models, and all downstream models compiles
[screenshot]
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist: https://www.notion.so/artemisxyz/Eigenlayer-dec4b761d8a946fab818ce91ecffc2d2

- [x] Added clear asset and metric documentation to CAD
- [x] Added metric definitions to Terminal (if applicable)
- [x] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below
<img width="1134" alt="Screenshot 2025-05-20 at 7 52 38 PM" src="https://github.com/user-attachments/assets/9127b593-1ada-45cc-ab5e-3fdc0f7981f2" />
<img width="1134" alt="Screenshot 2025-05-20 at 7 54 53 PM" src="https://github.com/user-attachments/assets/d15b0d93-7cbb-40b8-9abe-3ccbb1fe44cc" />

*See how our modeled emissions follows very closely the trend of the actual $EIGEN emissions distributed through the rewards contract. Obviously the on-chain is the true rewards.

## Other
- [x] Any other relevant information that may be helpful: see below

**Key Note:**
- Previously we modeled emissions_native for $EIGEN token through our seed file, in line with the linear weekly emissions that amount to 4% annually. This 4% annual emissions is distributed via the RewardsCoordinator on-chain
- In this PR I programmatically calculated these emissions and titled this metric 'token_incentives'. Should we get rid of the seeded metrics? Should we keep the name 'token_incentives' or 'emissions_native' name in this case?
- fact_restaked_tokens is slow (model from the last EIGEN pr, takes >30 minutes to run on the EIGENLAYER warehouse so maybe we should change this to incremental. This would have to be a next week task since I'll be at Avalanche summit this week, but calling it out here.