### PR TITLE
feature/aerodrome token incentives

### DIFF
--- a/models/projects/aerodrome/core/ez_aerodrome_metrics.sql
+++ b/models/projects/aerodrome/core/ez_aerodrome_metrics.sql
@@ -46,6 +46,12 @@ with swap_metrics as (
         cumulative_count
     FROM {{ ref('fact_aerodrome_pools') }}
 )
+, token_incentives as (
+        select
+            day as date,
+            usd_value as token_incentives
+        from {{ref('fact_aerodrome_token_incentives')}}
+)
 , date_spine as (
     SELECT
         ds.date
@@ -108,10 +114,13 @@ SELECT
     , coalesce(mm.token_turnover_circulating, 0) as token_turnover_circulating
     , coalesce(mm.token_turnover_fdv, 0) as token_turnover_fdv
     , coalesce(pm.cumulative_count, 0) as total_pools
+    , coalesce(ti.token_incentives, 0) as token_incentives
+
 FROM date_spine ds
 LEFT JOIN swap_metrics sm using (date)
 LEFT JOIN tvl_metrics tm using (date)
 LEFT JOIN market_metrics mm using (date)
 LEFT JOIN supply_metrics sp using (date)
 LEFT JOIN pools_metrics pm using (date)
+LEFT JOIN token_incentives ti using (date)
 WHERE ds.date < to_date(sysdate())

--- a/models/projects/aerodrome/core/ez_aerodrome_metrics_by_chain.sql
+++ b/models/projects/aerodrome/core/ez_aerodrome_metrics_by_chain.sql
@@ -25,6 +25,12 @@ with swap_metrics as (
     FROM {{ ref('fact_aerodrome_tvl') }}
     GROUP BY date
 )
+, token_incentives as (
+        select
+            day as date,
+            usd_value as token_incentives
+        from {{ref('fact_aerodrome_token_incentives')}}
+)
 , date_spine as (
     SELECT
         ds.date
@@ -60,6 +66,8 @@ SELECT
     , sm.daily_fees_usd as spot_fees
     , sm.daily_fees_usd as ecosystem_revenue
     , sm.daily_fees_usd as fee_sharing_token_cash_flow
+    , coalesce(ti.token_incentives, 0) as token_incentives
 FROM date_spine ds
 LEFT JOIN swap_metrics sm using (date)
 LEFT JOIN tvl_metrics tm using (date)
+LEFT JOIN token_incentives ti using (date)

--- a/models/staging/aerodrome/fact_aerodrome_token_incentives.sql
+++ b/models/staging/aerodrome/fact_aerodrome_token_incentives.sql
@@ -1,0 +1,29 @@
+{{ config(materialized="table") }}
+
+
+WITH weekly_rewards AS (
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS day,
+        SUM(decoded_log:"amount"::FLOAT) / 1e18 AS total_reward
+    FROM base_flipside.core.ez_decoded_event_logs 
+    WHERE 
+        CONTRACT_ADDRESS = LOWER('0x16613524e02ad97eDfeF371bC883F2F5d6C480A5') 
+        AND EVENT_NAME = 'NotifyReward'
+    GROUP BY 1
+),
+aero_prices AS (
+    SELECT
+        DATE_TRUNC('day', hour) AS day,
+        AVG(price) AS aero_price
+    FROM base_flipside.price.ez_prices_hourly
+    WHERE token_address = LOWER('0x940181a94a35a4569e4529a3cdfb74e38fd98631')
+    GROUP BY 1
+)
+SELECT
+    r.day,
+    r.total_reward,
+    p.aero_price,
+    r.total_reward * p.aero_price AS usd_value
+FROM weekly_rewards r
+LEFT JOIN aero_prices p ON r.day = p.day
+ORDER BY r.day


### PR DESCRIPTION
Added:
Data model for aerodrome token incentives to ez_metrics and ez_metrics_by_chain

CAD: https://www.notion.so/artemisxyz/72f60456ca1d4942a8d5dcaa65f71b6a?v=6fefa7090768453ab7c72be16e586142&p=d09c1182189947e69a18ec6f1b639c0c&pm=s

Key Notes:
Aerodrome calculates and distributes rewards on an epoch basis (once per week) so token incentives only show up once a week. 

Validation:
<img width="494" alt="Screenshot 2025-05-21 at 2 02 57 AM" src="https://github.com/user-attachments/assets/f83a90c1-77e9-4f7d-bbf4-73cf813bdeaf" />
