### PR TITLE
use ez decoed traces

### DIFF
--- a/models/projects/convex/raw/fact_convex_pools.sql
+++ b/models/projects/convex/raw/fact_convex_pools.sql
@@ -16,8 +16,8 @@
     decoded_input_data:_gauge::string as gauge,
     decoded_input_data:_stashVersion::number as stash_version,
     ROW_NUMBER() OVER (ORDER BY block_number) - 1 as pid
-  FROM {{ source('ETHEREUM_FLIPSIDE', 'fact_decoded_traces') }}
+  FROM {{ source('ETHEREUM_FLIPSIDE', 'ez_decoded_traces') }}
   WHERE to_address = lower('0xF403C135812408BFbE8713b5A23a04b3D48AAE31')
     AND function_name = 'addPool'
     -- Will be replaced by trace_succeeded = TRUE on 2025-05-05
-    AND trace_status = 'SUCCESS'
+    AND trace_succeeded = TRUE


### PR DESCRIPTION
Flipside removed the fact decoded traces table. This works just as well.

![CleanShot 2025-05-20 at 22 11 11@2x](https://github.com/user-attachments/assets/2ecd4313-688e-41bd-8061-fa215e8105db)

