### PR TITLE
modify pendle fees and add volume from markets

### DIFF
--- a/macros/pendle/get_pendle_swap_fees_for_chain_by_token.sql
+++ b/macros/pendle/get_pendle_swap_fees_for_chain_by_token.sql
@@ -8,10 +8,10 @@
                 DECODED_LOG:caller::STRING AS caller,
                 TRY_TO_NUMBER(DECODED_LOG:netPtOut::STRING) / 1e18 AS netPtOut,
                 TRY_TO_NUMBER(DECODED_LOG:netSyFee::STRING) / 1e18 AS netSyFee,
-                TRY_TO_NUMBER(DECODED_LOG:netSyOut::STRING) / 1e18 AS netSyOut,
+                ABS(TRY_TO_NUMBER(DECODED_LOG:netSyOut::STRING) / 1e18) AS netSyOut,
                 TRY_TO_NUMBER(DECODED_LOG:netSyToReserve::STRING) / 1e18 AS netSyToReserve,
-                DECODED_LOG:receiver::STRING AS receiver
-                , contract_address as market_address
+                DECODED_LOG:receiver::STRING AS receiver,
+                contract_address as market_address
             FROM {{ chain }}_flipside.core.ez_decoded_event_logs
             WHERE event_name = 'Swap'
             AND DECODED_LOG:netSyFee IS NOT NULL
@@ -22,46 +22,120 @@
             {% if blacklist is string %} AND lower(contract_address) != '{{ blacklist }}'
             {% elif blacklist | length > 1 %} AND lower(contract_address) not in {{ blacklist }}
             {% endif %}
-        )
-        , market_metadata as (
+        ),
+        
+        -- Get SY tokens with their metadata and exchange rates
+        sy_tokens as (
+            SELECT 
+                date(s.date) as date,
+                s.sy_address,
+                s.assetinfo_type,
+                s.assetinfo_address as underlying_address,
+                s.exchange_rate / pow(10, decimals) as exchange_rate  -- Normalize the exchange rate 
+            FROM {{ ref("fact_pendle_sy_info") }} s
+            WHERE s.chain = '{{ chain }}'
+            {% if is_incremental() %}
+                AND s.date > (select max(date)-1 from {{ this }})
+            {% endif %}
+        ),
+        
+        -- Map markets to their SY tokens
+        market_metadata as (
+            SELECT 
+                m.market_address,
+                m.sy_address
+            FROM {{ ref("dim_pendle_" ~ chain ~ "_market_metadata") }} m
+        ),
+        
+        -- Calculate daily swap fees and apply exchange rate conversion
+        daily_fees as (
             SELECT
-                market_address,
-                pt_address,
+                date(l.block_timestamp) as date,
+                m.sy_address,
+                s.assetinfo_type,
+                s.underlying_address,
+                s.exchange_rate,
+                -- Calculate supply side fees (excluding revenue fee, similar to TypeScript code)
+                SUM(l.netSyFee - l.netSyToReserve) as supply_side_fees_raw,
+                -- Revenue is tracked by netSyToReserve
+                SUM(l.netSyToReserve) as revenue_raw,
+                -- Total fees
+                SUM(l.netSyFee) as total_fees_raw,
+                -- Net Sy Out
+                SUM(l.netSyOut) as net_sy_out_raw
+            FROM swap_logs l
+            JOIN market_metadata m ON m.market_address = l.market_address
+            JOIN sy_tokens s ON s.sy_address = m.sy_address AND date(l.block_timestamp) = s.date
+            GROUP BY 1, 2, 3, 4, 5
+        ),
+        
+        -- Apply exchange rate conversion for asset type 0, similar to the TypeScript code
+        converted_fees as (
+            SELECT
+                date,
                 sy_address,
-                underlying_address
-            FROM
-                {{ ref("dim_pendle_" ~ chain ~ "_market_metadata") }}
-        )
-        , swaps_with_meta_data as (
+                underlying_address,
+                CASE 
+                    WHEN assetinfo_type = '0' THEN supply_side_fees_raw * exchange_rate
+                    ELSE supply_side_fees_raw
+                END as supply_side_fees,
+                CASE 
+                    WHEN assetinfo_type = '0' THEN revenue_raw * exchange_rate
+                    ELSE revenue_raw
+                END as revenue,
+                CASE 
+                    WHEN assetinfo_type = '0' THEN total_fees_raw * exchange_rate
+                    ELSE total_fees_raw
+                END as total_fees,
+                CASE 
+                    WHEN assetinfo_type = '0' THEN net_sy_out_raw * exchange_rate
+                    ELSE net_sy_out_raw
+                END as net_sy_out
+            FROM daily_fees
+        ),
+        
+        -- Add price data to convert to USD
+        fees_with_prices as (
             SELECT
-                l.block_timestamp
-                , p.symbol
-                , p.price
-                , l.netSyFee * p.price as fee_usd
-                , l.netSyFee as fee_native
-                , l.netSyOut * p.price as volume_usd
-                , l.netSyOut as volume_native
-                , l.netSyToReserve * p.price as revenue_usd
-                , l.netSyToReserve as revenue_native
-                , m.market_address
-                , m.underlying_address
-            FROM
-                swap_logs l
-            LEFT JOIN market_metadata m on m.market_address = l.market_address
-            LEFT JOIN {{ chain }}_flipside.price.ez_prices_hourly p on p.hour = date_trunc('hour', l.block_timestamp) AND lower(p.token_address) = lower(m.underlying_address)
+                f.date,
+                '{{ chain }}' as chain,
+                p.symbol,
+                f.underlying_address,
+                f.supply_side_fees,
+                f.revenue,
+                f.total_fees,
+                f.net_sy_out,
+                p.price,
+                f.supply_side_fees * p.price as supply_side_fees_usd,
+                f.revenue * p.price as revenue_usd,
+                f.total_fees * p.price as total_fees_usd,
+                f.net_sy_out * p.price as net_sy_out_usd
+            FROM converted_fees f
+            LEFT JOIN (
+                SELECT 
+                    date_trunc('day', hour) as day,
+                    token_address,
+                    symbol,
+                    AVG(price) as price
+                FROM {{ chain }}_flipside.price.ez_prices_hourly 
+                GROUP BY 1, 2, 3
+            ) p ON p.day = f.date AND lower(p.token_address) = lower(f.underlying_address)
         )
-
+        
+    -- Final aggregation
     SELECT
-        date(block_timestamp) as date
-        , '{{ chain }}' as chain
-        , symbol
-        , SUM(fee_usd) as fee_usd
-        , SUM(fee_native) as fee_native
-        , SUM(volume_usd) as volume_usd
-        , SUM(volume_native) as volume_native
-        , SUM(revenue_usd) as revenue_usd
-        , SUM(revenue_native) as revenue_native
-    FROM swaps_with_meta_data
+        date,
+        chain,
+        symbol,
+        SUM(total_fees_usd) as fee_usd,
+        SUM(total_fees) as fee_native,
+        SUM(net_sy_out_usd) as volume_usd,
+        SUM(net_sy_out) as volume_native,
+        SUM(revenue_usd) as revenue_usd,
+        SUM(revenue) as revenue_native,
+        SUM(supply_side_fees_usd) as supply_side_fees_usd,
+        SUM(supply_side_fees) as supply_side_fees_native
+    FROM fees_with_prices
     GROUP BY 1, 2, 3
 
 {% endmacro %}

--- a/models/projects/pendle/core/ez_pendle_metrics.sql
+++ b/models/projects/pendle/core/ez_pendle_metrics.sql
@@ -13,8 +13,9 @@ with
         SELECT
             date
             , SUM(fees_usd) as swap_fees
-            , SUM(supply_side_fees) as supply_side_fees
-            , SUM(revenue) as swap_revenue
+            , SUM(supply_side_fees_usd) as supply_side_fees
+            , SUM(revenue_usd) as swap_revenue
+            , SUM(volume_usd) as swap_volume
         FROM
         {{ ref('fact_pendle_swap_fees') }}
         GROUP BY 1
@@ -120,6 +121,7 @@ SELECT
     --Usage/Sector Metrics
     , d.daus as spot_dau
     , d.daily_txns as spot_txns
+    , f.swap_volume as spot_volume
     , t.tvl as tvl
     , {{ daily_pct_change('t.tvl') }} as tvl_pct_change
 

--- a/models/projects/pendle/core/ez_pendle_metrics_by_chain.sql
+++ b/models/projects/pendle/core/ez_pendle_metrics_by_chain.sql
@@ -14,8 +14,8 @@ with
             date
             , chain
             , SUM(fees_usd) as swap_fees
-            , SUM(supply_side_fees) as supply_side_fees
-            , SUM(revenue) as swap_revenue
+            , SUM(supply_side_fees_usd) as supply_side_fees
+            , SUM(revenue_usd) as swap_revenue
         FROM
             {{ ref('fact_pendle_swap_fees') }}
         GROUP BY 1, 2

--- a/models/projects/pendle/core/ez_pendle_metrics_by_token.sql
+++ b/models/projects/pendle/core/ez_pendle_metrics_by_token.sql
@@ -33,8 +33,7 @@ with
         SELECT
             date
             , symbol as token
-            , sum(tvl_native) as tvl_native
-            , sum(tvl_usd) as tvl
+            , sum(amount_native) as tvl
         FROM
             {{ref('fact_pendle_tvl_by_token_and_chain')}}
         GROUP BY 1, 2
@@ -69,7 +68,6 @@ SELECT
     -- Standardized Metrics
     
     -- Usage/Sector Metrics
-    , COALESCE(t.tvl_native, 0) as tvl_native
     , COALESCE(t.tvl, 0) as tvl
 
     , f.swap_fees as spot_fees

--- a/models/projects/pendle/raw/fact_pendle_arbitrum_fees.sql
+++ b/models/projects/pendle/raw/fact_pendle_arbitrum_fees.sql
@@ -11,6 +11,13 @@
 SELECT
     date
     , chain
-    , fee_usd as fees
+    , fee_usd
+    , fee_native
+    , volume_usd
+    , volume_native
+    , revenue_usd
+    , revenue_native
+    , supply_side_fees_usd
+    , supply_side_fees_native
 FROM
     {{ ref('fact_pendle_arbitrum_fees_silver') }}

--- a/models/projects/pendle/raw/fact_pendle_ethereum_fees.sql
+++ b/models/projects/pendle/raw/fact_pendle_ethereum_fees.sql
@@ -11,6 +11,13 @@
 SELECT
     date
     , chain
-    , fee_usd as fees
+    , fee_usd
+    , fee_native
+    , volume_usd
+    , volume_native
+    , revenue_usd
+    , revenue_native
+    , supply_side_fees_usd
+    , supply_side_fees_native
 FROM
     {{ ref('fact_pendle_ethereum_fees_silver') }}

--- a/models/projects/pendle/raw/fact_pendle_optimism_fees.sql
+++ b/models/projects/pendle/raw/fact_pendle_optimism_fees.sql
@@ -9,8 +9,15 @@
 }}
 
 SELECT
-    date
-    , chain
-    , fee_usd as fees
+    date,
+    chain,
+    fee_usd,
+    fee_native,
+    volume_usd,
+    volume_native,
+    revenue_usd,
+    revenue_native,
+    supply_side_fees_usd,
+    supply_side_fees_native
 FROM
     {{ ref('fact_pendle_optimism_fees_silver') }}

--- a/models/projects/pendle/raw/fact_pendle_swap_fees.sql
+++ b/models/projects/pendle/raw/fact_pendle_swap_fees.sql
@@ -15,10 +15,12 @@ SELECT
     , symbol as token
     , fees_usd
     , fees_native
-    , fees_usd * 0.8 as revenue
-    , fees_native * 0.8 as revenue_native
-    , fees_usd * 0.2 as supply_side_fees
-    , fees_native * 0.2 as supply_side_fees_native
+    , revenue_usd
+    , revenue_native
+    , supply_side_fees_usd
+    , supply_side_fees_native
+    , volume_usd
+    , volume_native
 FROM {{ref('fact_pendle_swap_fees_by_chain_and_token_silver')}}
 WHERE fees_usd < 1e6
 AND date < current_date()

--- a/models/staging/pendle/fact_pendle_arbitrum_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_arbitrum_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_arbitrum_yield_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_arbitrum_yield_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_ethereum_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_ethereum_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_ethereum_yield_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_ethereum_yield_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_optimism_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_optimism_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_optimism_yield_fees_silver.sql
+++ b/models/staging/pendle/fact_pendle_optimism_yield_fees_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="incremental",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 

--- a/models/staging/pendle/fact_pendle_swap_fees_by_chain_and_token_silver.sql
+++ b/models/staging/pendle/fact_pendle_swap_fees_by_chain_and_token_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 
@@ -18,6 +18,12 @@ SELECT
     , symbol
     , sum(fee_usd) as fees_usd
     , sum(fee_native) as fees_native
+    , sum(volume_usd) as volume_usd
+    , sum(volume_native) as volume_native
+    , sum(revenue_usd) as revenue_usd
+    , sum(revenue_native) as revenue_native
+    , sum(supply_side_fees_usd) as supply_side_fees_usd
+    , sum(supply_side_fees_native) as supply_side_fees_native
 FROM agg
 where date < to_date(sysdate())
 GROUP BY 1, 2, 3

--- a/models/staging/pendle/fact_pendle_yield_fees_by_chain_and_token_silver.sql
+++ b/models/staging/pendle/fact_pendle_yield_fees_by_chain_and_token_silver.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="PENDLE"
+        snowflake_warehouse="PENDLE",
     )
 }}
 


### PR DESCRIPTION
Fixing Pendle fees data.

Pendle Swap fees on Ethereum before and after changes
![CleanShot 2025-05-21 at 01.11.19@2x.png](attachment:38266dd2-6921-4c35-af03-8176a7919c8a:CleanShot_2025-05-21_at_01.11.192x.png)

Pendle Yield fees on Ethereum before and after changes

![CleanShot 2025-05-21 at 01.18.47@2x.png](attachment:bdd89c38-5e3e-4cbf-bb25-1ed57e91c99c:CleanShot_2025-05-21_at_01.18.472x.png)
Here there is a much larger difference because the old fees calculation was over estimating the fees paid.