### PR TITLE
Disable Test Iceberg Model

### DIFF
--- a/iceberg/models/test_iceberg.sql
+++ b/iceberg/models/test_iceberg.sql
@@ -6,6 +6,7 @@
         schema="TEST",
         external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
         alias="EZ_TEST_METRICS",
+        enabled=false
     )
 }}
 


### PR DESCRIPTION
## Summary
- Model was being pulled in by the daily_iceberg_share_job because it writes to the `ARTEMIS_ICEBERG` database and is therefore part of that asset group
- Once we create a separate Dagster asset for models in this project we will be unblocked for running models with Iceberg materialization turned on 