### PR TITLE
Updating celo, kaia, and aptos

### DIFF
--- a/models/staging/standard_8d737a18/fact_aptos_stablecoin_transfers_standard_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_aptos_stablecoin_transfers_standard_8d737a18.sql
@@ -1,4 +1,29 @@
 {{config(materialized="incremental", snowflake_warehouse="STANDARD_8D737A18", unique_key=["transaction_hash", "transfer_index"])}}
 
+with
+    stablecoin_transfers as (
+        {{standard_8d737a18_stablecoin_transfers("aptos")}}
+    )
 
-{{standard_8d737a18_stablecoin_transfers("aptos")}}
+select 
+    stablecoin_transfers.transaction_timestamp,
+    stablecoin_transfers.date_day,
+    stablecoin_transfers.block_number,
+    stablecoin_transfers.transfer_index,
+    -- -1 if the transfer is an epoch rewards transfer
+    transactions.version as transaction_position,
+    stablecoin_transfers.transaction_hash,
+    stablecoin_transfers.sender_address,
+    stablecoin_transfers.receiver_address,
+    stablecoin_transfers.is_mint,
+    stablecoin_transfers.is_burn,
+    stablecoin_transfers.amount_asset,
+    stablecoin_transfers.inflow,
+    stablecoin_transfers.transfer_volume,
+    stablecoin_transfers.asset_id,
+    stablecoin_transfers.asset_symbol,
+    stablecoin_transfers.chain_name,
+    stablecoin_transfers.chain_id
+from stablecoin_transfers
+left join  aptos_flipside.core.fact_transactions transactions
+    on stablecoin_transfers.transaction_hash = transactions.tx_hash

--- a/models/staging/standard_8d737a18/fact_celo_stablecoin_transfers_standard_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_celo_stablecoin_transfers_standard_8d737a18.sql
@@ -9,7 +9,8 @@ select
     stablecoin_transfers.date_day,
     stablecoin_transfers.block_number,
     stablecoin_transfers.transfer_index,
-    transactions.transaction_index as transaction_position,
+    -- -1 if the transfer is an epoch rewards transfer
+    coalesce(transactions.transaction_index, -1) as transaction_position,
     stablecoin_transfers.transaction_hash,
     stablecoin_transfers.sender_address,
     stablecoin_transfers.receiver_address,

--- a/models/staging/standard_8d737a18/fact_kaia_stablecoin_transfers_standard_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_kaia_stablecoin_transfers_standard_8d737a18.sql
@@ -1,4 +1,29 @@
 {{config(materialized="incremental", snowflake_warehouse="STANDARD_8D737A18", unique_key=["transaction_hash", "transfer_index"])}}
 
+with
+    stablecoin_transfers as (
+        {{standard_8d737a18_stablecoin_transfers("kaia")}}
+    )
 
-{{standard_8d737a18_stablecoin_transfers("kaia")}}
+select 
+    stablecoin_transfers.transaction_timestamp,
+    stablecoin_transfers.date_day,
+    stablecoin_transfers.block_number,
+    stablecoin_transfers.transfer_index,
+    -- -1 if the transfer is an epoch rewards transfer
+    transactions.index as transaction_position,
+    stablecoin_transfers.transaction_hash,
+    stablecoin_transfers.sender_address,
+    stablecoin_transfers.receiver_address,
+    stablecoin_transfers.is_mint,
+    stablecoin_transfers.is_burn,
+    stablecoin_transfers.amount_asset,
+    stablecoin_transfers.inflow,
+    stablecoin_transfers.transfer_volume,
+    stablecoin_transfers.asset_id,
+    stablecoin_transfers.asset_symbol,
+    stablecoin_transfers.chain_name,
+    stablecoin_transfers.chain_id
+from stablecoin_transfers
+left join zksync_dune.kaia.transactions transactions
+    on stablecoin_transfers.transaction_hash = transactions.hash_hex


### PR DESCRIPTION
1. Adding transaction_position to stablecoin standard transfers