### PR TITLE
Modify order_by for balancer and maple iceberg

### DIFF
--- a/iceberg/models/ez_metrics/balancer/ez_balancer_metrics_by_pool_iceberg.sql
+++ b/iceberg/models/ez_metrics/balancer/ez_balancer_metrics_by_pool_iceberg.sql
@@ -8,7 +8,7 @@
         alias="EZ_METRICS_BY_POOL",
         post_hook = "{{ merge_tags_dict({
             'duckdb': 'true',
-            'order_by': 'date, pool'
+            'order_by': 'date, pool_address'
         }) }}"
     )
 }}

--- a/iceberg/models/ez_metrics/maple/ez_maple_metrics_by_pool_iceberg.sql
+++ b/iceberg/models/ez_metrics/maple/ez_maple_metrics_by_pool_iceberg.sql
@@ -8,7 +8,7 @@
         alias="EZ_METRICS_BY_POOL",
         post_hook = "{{ merge_tags_dict({
             'duckdb': 'true',
-            'order_by': 'date, pool'
+            'order_by': 'date, pool_name'
         }) }}"
     )
 }}


### PR DESCRIPTION
# Description

Balancer and Maple `ez_metrics_by_pool` had different columns, so we need to modify the columns that they're ordering by.

# Tests

Ran locally