### PR TITLE
Adding models to support risk_score

### DIFF
--- a/models/metrics/stablecoins/yield/ez_yield_table.sql
+++ b/models/metrics/stablecoins/yield/ez_yield_table.sql
@@ -10,6 +10,7 @@ select
     , type
     , chain
     , link
+    , tvl_score as risk score
 from {{ ref("fact_stablecoin_apy") }}
 union all
 select
@@ -22,5 +23,6 @@ select
     , type
     , chain
     , link
+    , null as tvl_score
 from {{ ref("fact_fedfunds_rates") }}
 qualify row_number() over (partition by name, protocol, link order by timestamp desc) = 1

--- a/models/metrics/stablecoins/yield/fact_stablecoin_apy.sql
+++ b/models/metrics/stablecoins/yield/fact_stablecoin_apy.sql
@@ -11,6 +11,7 @@ select
     , type
     , chain
     , link
+    , tvl_score
 from {{ ref("fact_raydium_stablecoin_apy") }}
 union all
 select
@@ -24,6 +25,7 @@ select
     , type
     , chain
     , link
+    , tvl_score
 from {{ ref("fact_kamino_stablecoin_apy") }}
 union all
 select
@@ -37,6 +39,7 @@ select
     , type
     , chain
     , link
+    , tvl_score
 from {{ ref("fact_save_stablecoin_apy") }}
 union all
 select
@@ -50,6 +53,7 @@ select
     , type
     , chain
     , link
+    , tvl_score
 from {{ ref("fact_orca_stablecoin_apy") }}
 union all
 select
@@ -63,6 +67,7 @@ select
     , type
     , chain
     , link
+    , tvl_score
 from {{ ref("fact_drift_stablecoin_apy") }}
 union all
 select

--- a/models/metrics/stablecoins/yield/fact_stablecoin_apy.sql
+++ b/models/metrics/stablecoins/yield/fact_stablecoin_apy.sql
@@ -81,4 +81,5 @@ select
     , type
     , chain
     , link
+    , null as tvl_score
 from {{ ref("fact_vaults_fyi_stablecoin_apy") }}

--- a/models/staging/drift/fact_drift_stablecoin_apy.sql
+++ b/models/staging/drift/fact_drift_stablecoin_apy.sql
@@ -1,61 +1,57 @@
 {{ config(materialized="table") }}
 
-with stableconin_lending as (
+with latest_stableconin_lending as (
   select
-    l.timestamp
-    , l.market as id
-    , concat(l.market, ' Main Pool') as name
-    , l.apy
-    , l.tvl
-    , array_construct(p.symbol) as symbol
-    , l.protocol
-    , l.type
-    , l.chain
-    , p.link
-  from {{ ref("fact_drift_lending_apy") }} l
-  join {{ ref("drift_stablecoin_pool_ids") }} p
-    on l.market = p.name
+    market
+    , extraction_timestamp
+  from {{ ref("fact_drift_lending_apy") }}
+  qualify row_number() over (partition by market order by extraction_timestamp desc) = 1
 ),
 
-stablecoin_iv as (
+latest_stablecoin_iv as (
   select
-    i.timestamp
-    , i.market as id
-    , concat(i.market, ' ', p.market) as name
-    , i.apy
-    , i.tvl
-    , array_construct(p.symbol) as symbol
-    , i.protocol
-    , i.type
-    , i.chain
-    , p.link
-  from {{ ref("fact_drift_insurance_vault_apy") }} i
-  join {{ ref("drift_stablecoin_pool_ids") }} p
-    on i.market = p.name
+    market
+    , extraction_timestamp
+  from {{ ref("fact_drift_insurance_vault_apy") }}
+  qualify row_number() over (partition by market order by extraction_timestamp desc) = 1
 )
 
 select
-  timestamp
-  , id
-  , name
-  , apy
-  , tvl
-  , symbol
-  , protocol
-  , type
-  , chain
-  , link
-from stableconin_lending
+  l.extraction_timestamp as timestamp
+  , l.market as id
+  , concat(l.market, ' Main Pool') as name
+  , l.apy
+  , l.tvl
+  , l.symbol
+  , l.protocol
+  , l.type
+  , l.chain
+  , l.link
+  , a.tvl_score
+from {{ ref("fact_drift_lending_apy") }} l
+join latest_stableconin_lending ll
+  on l.market = ll.market
+  and l.extraction_timestamp = ll.extraction_timestamp
+join {{ ref("agg_drift_stablecoin_apy") }} a
+  on l.market = a.market
+  and l.type = a.type
 union all
 select
-  timestamp
-  , id
-  , name
-  , apy
-  , tvl
-  , symbol
-  , protocol
-  , type
-  , chain
-  , link
-from stablecoin_iv
+  i.extraction_timestamp as timestamp
+  , i.market as id
+  , concat(i.market, ' Insurance Vault') as name
+  , i.apy
+  , i.tvl
+  , i.symbol
+  , i.protocol
+  , i.type
+  , i.chain
+  , i.link
+  , a.tvl_score
+from {{ ref("fact_drift_insurance_vault_apy") }} i
+join latest_stablecoin_iv li
+  on i.market = li.market
+  and i.extraction_timestamp = li.extraction_timestamp
+join {{ ref("agg_drift_stablecoin_apy") }} a
+  on i.market = a.market
+  and i.type = a.type

--- a/models/staging/kamino/agg_kamino_stablecoin_apy.sql
+++ b/models/staging/kamino/agg_kamino_stablecoin_apy.sql
@@ -27,6 +27,7 @@ vaults_score as (
         f.extraction_timestamp
     from {{ ref("fact_kamino_vaults_apy") }} f
     left join avg_vaults_tvl a on a.id = f.id
+    and f.extraction_timestamp = a.extraction_timestamp
     qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1
 ),
 
@@ -57,6 +58,7 @@ lending_score as (
         f.extraction_timestamp
     from {{ ref("fact_kamino_lending_apy") }} f
     left join avg_lending_tvl a on a.id = f.id
+    and f.extraction_timestamp = a.extraction_timestamp
     qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1
 )
 

--- a/models/staging/kamino/agg_kamino_stablecoin_apy.sql
+++ b/models/staging/kamino/agg_kamino_stablecoin_apy.sql
@@ -1,0 +1,75 @@
+{{ config(materialized="table") }}
+
+with avg_vaults_tvl as (
+    select
+        id,
+        avg(tvl) as avg_tvl_l7d
+    from {{ ref("fact_kamino_vaults_apy") }}
+    where extraction_timestamp >= dateadd(day, -7, current_date)
+    group by id
+),
+
+vaults_score as (
+    select
+        f.id,
+        f.name,
+        case 
+            when a.avg_tvl_l7d >= 1e9 then 5.0
+            when a.avg_tvl_l7d >= 5e8 then 4.5
+            when a.avg_tvl_l7d >= 1e8 then 4.0
+            when a.avg_tvl_l7d >= 5e7 then 3.5
+            when a.avg_tvl_l7d >= 1e7 then 3.0
+            when a.avg_tvl_l7d >= 5e6 then 2.5
+            when a.avg_tvl_l7d >= 1e6 then 2.0
+            when a.avg_tvl_l7d >= 5e5 then 1.5
+            else 1.0
+        end as tvl_score,
+        f.extraction_timestamp
+    from {{ ref("fact_kamino_vaults_apy") }} f
+    left join avg_vaults_tvl a on a.id = f.id
+    qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1
+),
+
+avg_lending_tvl as (
+    select
+        id,
+        avg(tvl) as avg_tvl_l7d
+    from {{ ref("fact_kamino_lending_apy") }}
+    where extraction_timestamp >= dateadd(day, -7, current_date)
+    group by id
+),
+
+lending_score as (
+    select
+        f.id,
+        f.name,
+        case 
+            when a.avg_tvl_l7d >= 1e9 then 5.0
+            when a.avg_tvl_l7d >= 5e8 then 4.5
+            when a.avg_tvl_l7d >= 1e8 then 4.0
+            when a.avg_tvl_l7d >= 5e7 then 3.5
+            when a.avg_tvl_l7d >= 1e7 then 3.0
+            when a.avg_tvl_l7d >= 5e6 then 2.5
+            when a.avg_tvl_l7d >= 1e6 then 2.0
+            when a.avg_tvl_l7d >= 5e5 then 1.5
+            else 1.0
+        end as tvl_score,
+        f.extraction_timestamp
+    from {{ ref("fact_kamino_lending_apy") }} f
+    left join avg_lending_tvl a on a.id = f.id
+    qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1
+)
+
+select
+    v.id,
+    v.name,
+    v.tvl_score,
+    v.extraction_timestamp
+from vaults_score v
+union all
+select
+    l.id,
+    l.name,
+    l.tvl_score,
+    l.extraction_timestamp
+from lending_score l

--- a/models/staging/kamino/fact_kamino_lending_apy.sql
+++ b/models/staging/kamino/fact_kamino_lending_apy.sql
@@ -1,5 +1,9 @@
 {{ config(
-    materialized="table"
+    materialized="incremental",
+    unique_key=[
+        'id',
+        'extraction_timestamp',
+    ],
 ) }}
 
 with base as (
@@ -7,58 +11,66 @@ with base as (
     parse_json(source_json) as json,
     extraction_date
   from {{ source("PROD_LANDING", "raw_kamino_lending") }}
+  {% if is_incremental() %}
+    where extraction_date > (
+      select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
+    )
+  {% endif %}
 ),
 
-outer_flatten as (
+historical as (
   select
-    value:reserve_id::string as reserve_id,
-    value:market_id::string as market_id,
-    value:response:history as history_array,
-    extraction_date
-  from base,
-  lateral flatten(input => json)
+    outer_item.value:market_id::string as market_id,
+    outer_item.value:reserve_id::string as reserve_id,
+    history_item.value:timestamp::timestamp_ntz as timestamp,
+    history_item.value:metrics:symbol::string as symbol,
+    history_item.value:metrics:supplyInterestAPY::float as supply_interest_apy,
+    history_item.value:metrics:depositTvl::float as deposit_tvl,
+    history_item.value:metrics:borrowTvl::float as borrow_tvl,
+    b.extraction_date as extraction_date
+  from base b,
+  lateral flatten(input => b.json) as outer_item,
+  lateral flatten(input => outer_item.value:response:history) as history_item
+  qualify row_number() over (
+    partition by
+      market_id,
+      reserve_id,
+      b.extraction_date
+    order by timestamp desc
+  ) = 1
 ),
 
-history_flattened as (
+extracted as (
   select
-    market_id,
-    reserve_id,
-    value:timestamp::timestamp_ntz as timestamp,
-    value:metrics:symbol::string as symbol,
-    value:metrics:supplyInterestAPY::float as supply_interest_apy,
-    value:metrics:depositTvl::float as deposit_tvl,
-    value:metrics:borrowTvl::float as borrow_tvl,
-    extraction_date
-  from outer_flatten,
-  lateral flatten(input => history_array)
-),
+    h.market_id,
+    h.reserve_id,
+    h.symbol,
+    h.supply_interest_apy,
+    h.deposit_tvl,
+    h.borrow_tvl,
+    h.extraction_date,
+    l.link
+  from historical h
+  inner join {{ ref("kamino_stablecoin_lending_ids") }} l
+  on h.market_id = l.market_id
+    and h.reserve_id = l.id
 
-latest_timestamp_per_reserve as (
-  select
-    market_id,
-    reserve_id,
-    max(timestamp) as max_timestamp
-  from history_flattened
-  group by market_id, reserve_id
 )
 
 select
-    h.market_id,
-    h.reserve_id as id,
-    h.supply_interest_apy as apy,
-    h.deposit_tvl - h.borrow_tvl as tvl,
-    h.extraction_date as extraction_timestamp,
+    market_id,
+    reserve_id as id,
     case
-    when h.market_id = '7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF' then concat(h.symbol, ' Main Market')
-    when h.market_id = 'DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npfDMjjMek' then concat(h.symbol, ' JLP Market')
-    else h.symbol
+      when market_id = '7u3HeHxYDLhnCoErrtycNokbQYbWGzLs6JSDqGAv5PfF' then concat(symbol, ' Main Market')
+      when market_id = 'DxXdAyU3kCjnyggvHmY5nAwg5cRbbmdyX3npfDMjjMek' then concat(symbol, ' JLP Market')
+      else symbol
     end as name,
-    'Lending' as type,
+    supply_interest_apy as apy,
+    deposit_tvl - borrow_tvl as tvl,
+    array_construct(symbol) as symbol,
     'kamino' as protocol,
+    'Lending' as type,
     'solana' as chain,
-    array_construct(h.symbol) as symbol
-from history_flattened h
-join latest_timestamp_per_reserve l
-    on h.market_id = l.market_id
-    and h.reserve_id = l.reserve_id
-    and h.timestamp = l.max_timestamp
+    link,
+    extraction_date as extraction_timestamp
+from extracted

--- a/models/staging/kamino/fact_kamino_stablecoin_apy.sql
+++ b/models/staging/kamino/fact_kamino_stablecoin_apy.sql
@@ -4,50 +4,53 @@
 
 with latest_vaults as (
   select
-    id,
-    max(extraction_timestamp) as max_timestamp
+    id
+    , extraction_timestamp
   from {{ ref("fact_kamino_vaults_apy") }}
-  group by id
+  qualify row_number() over (partition by id order by extraction_timestamp desc) = 1
 ),
+
 latest_lending as (
   select
-    id,
-    max(extraction_timestamp) as max_timestamp
+    id
+    , extraction_timestamp
   from {{ ref("fact_kamino_lending_apy") }}
-  group by id
+  qualify row_number() over (partition by id order by extraction_timestamp desc) = 1
 )
+
 select
-    v.extraction_timestamp as timestamp,
-    v.id,
-    v.name,
-    v.apy,
-    v.tvl,
-    v.symbol,
-    v.protocol,
-    v.type,
-    v.chain,
-    s.link
+    v.extraction_timestamp as timestamp
+    , v.id
+    , v.name
+    , v.apy
+    , v.tvl
+    , v.symbol
+    , v.protocol
+    , v.type
+    , v.chain
+    , v.link
+    , a.tvl_score
 from {{ ref("fact_kamino_vaults_apy") }} v
 join latest_vaults lv
 on v.id = lv.id
-    and v.extraction_timestamp = lv.max_timestamp
-join {{ ref("kamino_stablecoin_vault_ids") }} s
-on v.id = s.id
+    and v.extraction_timestamp = lv.extraction_timestamp
+join {{ ref("agg_kamino_stablecoin_apy") }} a
+on v.id = a.id
 union all
 select
-    extraction_timestamp,
-    l.id,
-    name,
-    apy,
-    tvl,
-    symbol,
-    protocol,
-    type,
-    chain,
-    link,
+    extraction_timestamp
+    , l.id
+    , name
+    , apy
+    , tvl
+    , symbol
+    , protocol
+    , type
+    , chain
+    , link
 from {{ ref("fact_kamino_lending_apy") }} l
 join latest_lending ll
 on l.id = ll.id
-   and l.extraction_timestamp = ll.max_timestamp
-join {{ ref("kamino_stablecoin_lending_ids") }} s
-on l.id = s.id
+   and l.extraction_timestamp = ll.extraction_timestamp
+join {{ ref("agg_kamino_stablecoin_apy") }} a
+on l.id = a.id

--- a/models/staging/kamino/fact_kamino_vaults_apy.sql
+++ b/models/staging/kamino/fact_kamino_vaults_apy.sql
@@ -1,21 +1,10 @@
-{{ config(
-    materialized="incremental",
-    unique_key=[
-        'id',
-        'extraction_timestamp',
-    ],
-) }}
+{{ config(materialized="table") }}
 
 with base as (
   select
     source_json,
     extraction_date
   from {{ source("PROD_LANDING", "raw_kamino_vaults") }}
-  {% if is_incremental() %}
-    where extraction_date > (
-      select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
-    )
-  {% endif %}
 ),
 
 flattened as (

--- a/models/staging/orca/agg_orca_stablecoin_apy.sql
+++ b/models/staging/orca/agg_orca_stablecoin_apy.sql
@@ -1,0 +1,29 @@
+{{ config(materialized="table") }}
+
+with avg_tvl as (
+    select
+        id,
+        avg(tvl) as avg_tvl_l7d
+    from {{ ref("fact_orca_apy") }}
+    where extraction_timestamp >= dateadd(day, -7, current_date)
+    group by id
+)
+
+select
+    f.id,
+    f.name,
+    case 
+        when a.avg_tvl_l7d >= 1e9 then 5.0
+        when a.avg_tvl_l7d >= 5e8 then 4.5
+        when a.avg_tvl_l7d >= 1e8 then 4.0
+        when a.avg_tvl_l7d >= 5e7 then 3.5
+        when a.avg_tvl_l7d >= 1e7 then 3.0
+        when a.avg_tvl_l7d >= 5e6 then 2.5
+        when a.avg_tvl_l7d >= 1e6 then 2.0
+        when a.avg_tvl_l7d >= 5e5 then 1.5
+        else 1.0
+    end as tvl_score,
+    f.extraction_timestamp
+from {{ ref("fact_orca_apy") }} f
+left join avg_tvl a on a.id = f.id
+qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1

--- a/models/staging/orca/fact_orca_apy.sql
+++ b/models/staging/orca/fact_orca_apy.sql
@@ -1,10 +1,4 @@
-{{ config(
-    materialized="incremental",
-    unique_key=[
-        'id',
-        'extraction_timestamp',
-    ],
-) }}
+{{ config(materialized="table") }}
 
 with base as (
   select
@@ -12,11 +6,6 @@ with base as (
     extraction_date,
     source_url
   from {{ source("PROD_LANDING", "raw_orca_pools") }}
-  {% if is_incremental() %}
-      where extraction_date > (
-        select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
-      )
-  {% endif %}
 ),
 
 flattened as (

--- a/models/staging/orca/fact_orca_stablecoin_apy.sql
+++ b/models/staging/orca/fact_orca_stablecoin_apy.sql
@@ -2,41 +2,29 @@
 
 with latest_per_group as (
   select
-    name,
-    fees,
-    max(extraction_timestamp) as max_timestamp
+    name
+    , fees
+    , extraction_timestamp
   from {{ ref("fact_orca_apy") }}
-  group by name, fees
-),
-latest_apy as (
-  select
-    f.extraction_timestamp as timestamp,
-    f.id,
-    concat(f.name, ' (', f.fees, '%)') as name,
-    f.apy,
-    f.tvl,
-    f.symbol,
-    f.protocol,
-    f.type,
-    f.chain
-  from {{ ref("fact_orca_apy") }} f
-  join latest_per_group l
-    on f.name = l.name
-   and f.fees = l.fees
-   and f.extraction_timestamp = l.max_timestamp
+  qualify row_number() over (partition by id order by extraction_timestamp desc) = 1
 )
 
 select
-  l.timestamp
-  , l.id
-  , l.name
-  , l.apy
-  , l.tvl
-  , l.symbol
-  , l.protocol
-  , l.type
-  , l.chain
-  , p.link
-from latest_apy l
-join {{ ref("orca_stablecoin_pool_ids") }} p
-  on l.id = p.id
+  f.extraction_timestamp as timestamp
+  , f.id
+  , concat(f.name, ' (', f.fees, '%)') as name
+  , f.apy
+  , f.tvl
+  , f.symbol
+  , f.protocol
+  , f.type
+  , f.chain
+  , f.link
+  , a.tvl_score
+from {{ ref("fact_orca_apy") }} f
+join latest_per_group l
+  on f.name = l.name
+  and f.fees = l.fees
+  and f.extraction_timestamp = l.extraction_timestamp
+join {{ ref("agg_orca_stablecoin_apy") }} a
+  on f.id = a.id

--- a/models/staging/raydium/agg_raydium_stablecoin_apy.sql
+++ b/models/staging/raydium/agg_raydium_stablecoin_apy.sql
@@ -1,0 +1,29 @@
+{{ config(materialized="table") }}
+
+with avg_tvl as (
+    select
+        id,
+        avg(tvl) as avg_tvl_l7d
+    from {{ ref("fact_raydium_apy") }}
+    where extraction_timestamp >= dateadd(day, -7, current_date)
+    group by id
+)
+
+select
+    f.id,
+    f.name,
+    case 
+        when a.avg_tvl_l7d >= 1e9 then 5.0
+        when a.avg_tvl_l7d >= 5e8 then 4.5
+        when a.avg_tvl_l7d >= 1e8 then 4.0
+        when a.avg_tvl_l7d >= 5e7 then 3.5
+        when a.avg_tvl_l7d >= 1e7 then 3.0
+        when a.avg_tvl_l7d >= 5e6 then 2.5
+        when a.avg_tvl_l7d >= 1e6 then 2.0
+        when a.avg_tvl_l7d >= 5e5 then 1.5
+        else 1.0
+    end as tvl_score,
+    f.extraction_timestamp
+from {{ ref("fact_raydium_apy") }} f
+left join avg_tvl a on a.id = f.id
+qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1

--- a/models/staging/raydium/fact_raydium_apy.sql
+++ b/models/staging/raydium/fact_raydium_apy.sql
@@ -1,10 +1,4 @@
-{{ config(
-    materialized="incremental",
-    unique_key=[
-      'id',
-      'extraction_timestamp',
-    ],
-) }}
+{{ config(materialized="table") }}
 
 with base as (
   select
@@ -12,11 +6,6 @@ with base as (
     extraction_date,
     source_url
   from {{ source("PROD_LANDING", "raw_raydium_pools") }}
-  {% if is_incremental() %}
-    where extraction_date > (
-      select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
-    )
-  {% endif %}
 ),
 
 flattened as (

--- a/models/staging/raydium/fact_raydium_apy.sql
+++ b/models/staging/raydium/fact_raydium_apy.sql
@@ -1,57 +1,57 @@
 {{ config(
     materialized="incremental",
     unique_key=[
-        'id',
-        'extraction_timestamp',
+      'id',
+      'extraction_timestamp',
     ],
 ) }}
 
 with base as (
-    select
-        source_json,
-        extraction_date,
-        source_url
-    from {{ source("PROD_LANDING", "raw_raydium_pools") }}
-    {% if is_incremental() %}
-        where extraction_date > (
-          select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
-        )
-    {% endif %}
+  select
+    source_json,
+    extraction_date,
+    source_url
+  from {{ source("PROD_LANDING", "raw_raydium_pools") }}
+  {% if is_incremental() %}
+    where extraction_date > (
+      select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
+    )
+  {% endif %}
 ),
 
 flattened as (
-    select
-        value as pool,
-        base.extraction_date
-        from base,
-    lateral flatten(input => parse_json(base.source_json))
+  select
+    value as pool,
+    base.extraction_date
+    from base,
+  lateral flatten(input => parse_json(base.source_json))
 ),
 
 extracted as (
-    select
-        pool:id::string as id,
-        pool:mintA:symbol::string as mintA_symbol,
-        pool:mintB:symbol::string as mintB_symbol,
-        pool:feeRate::float as fees,
-        pool:day:apr::float as apr,
-        pool:tvl::float as tvl,
-        p.link as link,
-        extraction_date
-    from flattened
-    inner join {{ ref("raydium_stablecoin_pool_ids") }} p
-    on pool:id::string = p.id
+  select
+    pool:id::string as id,
+    pool:mintA:symbol::string as mintA_symbol,
+    pool:mintB:symbol::string as mintB_symbol,
+    pool:feeRate::float as fees,
+    pool:day:apr::float as apr,
+    pool:tvl::float as tvl,
+    p.link,
+    extraction_date
+  from flattened
+  inner join {{ ref("raydium_stablecoin_pool_ids") }} p
+  on pool:id::string = p.id
 )
 
 select
-    id,
-    iff(mintB_symbol is null, mintA_symbol, concat(mintA_symbol, '-', mintB_symbol)) as name,
-    (power(1 + ((apr / 100) / 365), 365) - 1) as apy,
-    tvl,
-    fees,
-    array_construct( mintA_symbol, mintB_symbol ) as symbol,
-    'raydium' as protocol,
-    'Pool' as type,
-    'solana' as chain,
-    link,
-    extraction_date as extraction_timestamp
+  id,
+  iff(mintB_symbol is null, mintA_symbol, concat(mintA_symbol, '-', mintB_symbol)) as name,
+  (power(1 + ((apr / 100) / 365), 365) - 1) as apy,
+  tvl,
+  fees,
+  array_construct( mintA_symbol, mintB_symbol ) as symbol,
+  'raydium' as protocol,
+  'Pool' as type,
+  'solana' as chain,
+  link,
+  extraction_date as extraction_timestamp
 from extracted

--- a/models/staging/raydium/fact_raydium_apy.sql
+++ b/models/staging/raydium/fact_raydium_apy.sql
@@ -1,51 +1,57 @@
 {{ config(
-    materialized="table"
+    materialized="incremental",
+    unique_key=[
+        'id',
+        'extraction_timestamp',
+    ],
 ) }}
 
 with base as (
-  select
-    source_json,
-    extraction_date,
-    source_url
-  from {{ source("PROD_LANDING", "raw_raydium_pools") }}
-  where extraction_date = (
-    select max(extraction_date)
+    select
+        source_json,
+        extraction_date,
+        source_url
     from {{ source("PROD_LANDING", "raw_raydium_pools") }}
-  )
+    {% if is_incremental() %}
+        where extraction_date > (
+          select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
+        )
+    {% endif %}
 ),
 
 flattened as (
-  select
-    value as pool,
-    base.extraction_date
-  from base,
-  lateral flatten(input => parse_json(base.source_json))
+    select
+        value as pool,
+        base.extraction_date
+        from base,
+    lateral flatten(input => parse_json(base.source_json))
 ),
 
 extracted as (
-  select
-    pool:id::string as id,
-    pool:mintA:symbol::string as mintA_symbol,
-    pool:mintB:symbol::string as mintB_symbol,
-    pool:feeRate::float as fees,
-    pool:day:apr::float as apr,
-    pool:tvl::float as tvl,
-    extraction_date
-  from flattened
+    select
+        pool:id::string as id,
+        pool:mintA:symbol::string as mintA_symbol,
+        pool:mintB:symbol::string as mintB_symbol,
+        pool:feeRate::float as fees,
+        pool:day:apr::float as apr,
+        pool:tvl::float as tvl,
+        p.link as link,
+        extraction_date
+    from flattened
+    inner join {{ ref("raydium_stablecoin_pool_ids") }} p
+    on pool:id::string = p.id
 )
 
 select
-  id,
-  iff(mintB_symbol is null, mintA_symbol, concat(mintA_symbol, '-', mintB_symbol)) as name,
-  (power(1 + ((apr / 100) / 365), 365) - 1) as apy,
-  tvl,
-  fees,
-  array_construct(
-    case when mintA_symbol = 'WSOL' then 'SOL' else mintA_symbol end,
-    case when mintB_symbol = 'WSOL' then 'SOL' else mintB_symbol end
-  ) as symbol,
-  'raydium' as protocol,
-  'Pool' as type,
-  'solana' as chain,
-  extraction_date as extraction_timestamp
+    id,
+    iff(mintB_symbol is null, mintA_symbol, concat(mintA_symbol, '-', mintB_symbol)) as name,
+    (power(1 + ((apr / 100) / 365), 365) - 1) as apy,
+    tvl,
+    fees,
+    array_construct( mintA_symbol, mintB_symbol ) as symbol,
+    'raydium' as protocol,
+    'Pool' as type,
+    'solana' as chain,
+    link,
+    extraction_date as extraction_timestamp
 from extracted

--- a/models/staging/raydium/fact_raydium_stablecoin_apy.sql
+++ b/models/staging/raydium/fact_raydium_stablecoin_apy.sql
@@ -2,42 +2,30 @@
 
 with latest_per_group as (
   select
-    name,
-    fees,
-    max(extraction_timestamp) as max_timestamp
+    name
+    , fees
+    , extraction_timestamp
   from {{ ref("fact_raydium_apy") }}
-  group by name, fees
-),
-
-latest_apy as (
-  select
-    f.extraction_timestamp as timestamp,
-    f.id,
-    concat(f.name, ' (', round(f.fees * 100, 2), '%)') as name,
-    f.apy,
-    f.tvl,
-    f.symbol,
-    f.protocol,
-    f.type,
-    f.chain
-  from {{ ref("fact_raydium_apy") }} f
-  join latest_per_group l
-    on f.name = l.name
-   and f.fees = l.fees
-   and f.extraction_timestamp = l.max_timestamp
+  qualify row_number() over (partition by id order by extraction_timestamp desc) = 1
 )
 
 select
-  l.timestamp
-  , l.id
-  , l.name
-  , l.apy
-  , l.tvl
-  , l.symbol
-  , l.protocol
-  , l.type
-  , l.chain
-  , p.link
-from latest_apy l
-join {{ ref("raydium_stablecoin_pool_ids") }} p
-  on l.id = p.id
+  f.extraction_timestamp as timestamp
+  , f.id
+  , concat(f.name, ' (', round(f.fees * 100, 2), '%)') as name
+  , f.apy
+  , f.tvl
+  , f.symbol
+  , f.protocol
+  , f.type
+  , f.chain
+  , f.link
+  , a.tvl_score
+from {{ ref("fact_raydium_apy") }} f
+join latest_per_group l
+  on f.name = l.name
+  and f.fees = l.fees
+  and f.extraction_timestamp = l.extraction_timestamp
+join {{ ref("agg_raydium_stablecoin_apy") }} a
+  on f.id = a.id
+  and f.extraction_timestamp = a.extraction_timestamp

--- a/models/staging/save/agg_save_stablecoin_apy.sql
+++ b/models/staging/save/agg_save_stablecoin_apy.sql
@@ -1,0 +1,29 @@
+{{ config(materialized="table") }}
+
+with avg_tvl as (
+    select
+        id,
+        avg(tvl) as avg_tvl_l7d
+    from {{ ref("fact_save_apy") }}
+    where extraction_timestamp >= dateadd(day, -7, current_date)
+    group by id
+)
+
+select
+    f.id,
+    f.name,
+    case 
+        when a.avg_tvl_l7d >= 1e9 then 5.0
+        when a.avg_tvl_l7d >= 5e8 then 4.5
+        when a.avg_tvl_l7d >= 1e8 then 4.0
+        when a.avg_tvl_l7d >= 5e7 then 3.5
+        when a.avg_tvl_l7d >= 1e7 then 3.0
+        when a.avg_tvl_l7d >= 5e6 then 2.5
+        when a.avg_tvl_l7d >= 1e6 then 2.0
+        when a.avg_tvl_l7d >= 5e5 then 1.5
+        else 1.0
+    end as tvl_score,
+    f.extraction_timestamp
+from {{ ref("fact_save_apy") }} f
+left join avg_tvl a on a.id = f.id
+qualify row_number() over (partition by f.id order by extraction_timestamp desc) = 1

--- a/models/staging/save/fact_save_apy.sql
+++ b/models/staging/save/fact_save_apy.sql
@@ -1,21 +1,10 @@
-{{ config(
-    materialized="incremental",
-    unique_key=[
-        'id',
-        'extraction_timestamp',
-    ],
-) }}
+{{ config(materialized="table") }}
 
 with base as (
   select
     parse_json(source_json) as json,
     extraction_date
   from {{ source("PROD_LANDING", "raw_save_lending") }}
-  {% if is_incremental() %}
-      where extraction_date > (
-        select dateadd('day', -1, max(extraction_timestamp)) from {{ this }}
-      )
-  {% endif %}
 ),
 
 flattened as (


### PR DESCRIPTION
Adding risk score(tvl_score right now) to the yield tables
right now is for kamino and raydium, if the model looks good to go, will add the rest here as well.

Current build
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/b01f7159-665f-44c3-91dd-c3853384e978" />


![image](https://github.com/user-attachments/assets/01c04765-bddc-448b-9a14-52ef62ac6c0c)
![image](https://github.com/user-attachments/assets/73ca13bd-c905-4789-ba52-273f42ab3c80)
