### PR TITLE
Add Ton token incentives

### DIFF
--- a/models/projects/ton/core/ez_ton_metrics_by_chain.sql
+++ b/models/projects/ton/core/ez_ton_metrics_by_chain.sql
@@ -4,7 +4,7 @@
         snowflake_warehouse="TON",
         database="ton",
         schema="core",
-        alias="ez_metrics",
+        alias="ez_metrics_by_chain",
         unique_key="date"
     )
 }}
@@ -46,6 +46,7 @@ with
     )
 select
     ton.date
+    , 'ton' as chain
     , dau
     , wau
     , mau


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [ ] Added new `fact` tables if necessary
- [ ] Added a database and warehouse
- [x] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [x] `ez_metrics_by_chain` column names adhere to naming convention
Add ton token incentives to ez_metrics_by_chain table
<img width="1038" alt="image" src="https://github.com/user-attachments/assets/f9291012-2cb3-43fb-8df8-4ef7c8a6e759" />

## 🧮 Final Checklist

- [x] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [ ] Add any relevant data screenshots below

## Other

- [x] Any other relevant information that may be helpful

Ton is an L1 blockchain hence token_incentives goes to rewards to validators.
Ton distributes their fees in 2 ways:
1. Burned – 50% of the fees are permanently destroyed.
**2. Validators – 50% is distributed to the validators who process and validate blocks, which what we see as token incentives.**