### PR TITLE
Add partitioned order by for pancakeswap

### DIFF
--- a/iceberg/macros/merge_tags_dict.sql
+++ b/iceberg/macros/merge_tags_dict.sql
@@ -30,10 +30,10 @@
             '{{ v }}' as tag_value,
             current_timestamp as tagged_at
     ) s
-    on t.database_name = s.database_name
-       and t.schema_name = s.schema_name
-       and t.table_name = s.table_name
-       and t.tag_key = s.tag_key
+    on lower(t.database_name) = lower(s.database_name)
+       and lower(t.schema_name) = lower(s.schema_name)
+       and lower(t.table_name) = lower(s.table_name)
+       and lower(t.tag_key) = lower(s.tag_key)
     when matched then update set
         tag_value = s.tag_value,
         tagged_at = s.tagged_at

--- a/iceberg/models/ez_metrics/pancakeswap/ez_pancakeswap_metrics_by_pool_iceberg.sql
+++ b/iceberg/models/ez_metrics/pancakeswap/ez_pancakeswap_metrics_by_pool_iceberg.sql
@@ -8,7 +8,8 @@
         alias="EZ_METRICS_BY_POOL",
         post_hook = "{{ merge_tags_dict({
             'duckdb': 'true',
-            'order_by': 'date, pool'
+            'order_by': 'pool',
+            'partitioned_order_by': 'date'
         }) }}"
     )
 }}


### PR DESCRIPTION
# Description

Pancakeswap table is too large to do a order by on the entire table for duckdb (it overwhelms the ephemeral storage), so making the date column a `partitioned_order_by` where it first partitions distinct values into separate tables, orders those tables independently, and then combines them back in order.

# Tests

Ran locally