### PR TITLE
dataquality/pancakeswap token incentives added to by_chain table

### DIFF
--- a/models/projects/pancakeswap/core/ez_pancakeswap_metrics.sql
+++ b/models/projects/pancakeswap/core/ez_pancakeswap_metrics.sql
@@ -8,64 +8,63 @@
     )
 }}
 
-with
-    trading_volume_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_pancakeswap_v2_arbitrum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_base_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_bsc_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_ethereum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_arbitrum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_base_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_bsc_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_ethereum_trading_vol_fees_traders_by_pool"),
-                ],
-            )
-        }}
-    ),
-    trading_volume as (
-        select
-            trading_volume_pool.date
-            , sum(trading_volume_pool.trading_volume) as trading_volume
-            , sum(trading_volume_pool.trading_fees) as trading_fees
-            , sum(trading_volume_pool.unique_traders) as unique_traders
-            , sum(trading_volume_pool.gas_cost_native) as gas_cost_native
-            , sum(trading_volume_pool.gas_cost_usd) as gas_cost_usd
-        from trading_volume_pool
-        group by trading_volume_pool.date
-    ),
-    tvl_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_pancakeswap_v2_arbitrum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_base_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_bsc_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_ethereum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_arbitrum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_base_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_bsc_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_ethereum_tvl_by_pool"),
-                ],
-            )
-        }}
-    )
-    , tvl as (
-        select
-            tvl_by_pool.date
-            , sum(tvl_by_pool.tvl) as tvl
-        from tvl_by_pool
-        group by tvl_by_pool.date
-    )
-    , token_incentives as (
-        select
-            date,
-            sum(amount_usd) as token_incentives_usd
-        from {{ ref('fact_pancakeswap_token_incentives') }}
-        group by date
-    )
+with trading_volume_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_pancakeswap_v2_arbitrum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_base_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_bsc_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_ethereum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_arbitrum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_base_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_bsc_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_ethereum_trading_vol_fees_traders_by_pool"),
+            ],
+        )
+    }}
+)
+, trading_volume as (
+    select
+        trading_volume_pool.date
+        , sum(trading_volume_pool.trading_volume) as trading_volume
+        , sum(trading_volume_pool.trading_fees) as trading_fees
+        , sum(trading_volume_pool.unique_traders) as unique_traders
+        , sum(trading_volume_pool.gas_cost_native) as gas_cost_native
+        , sum(trading_volume_pool.gas_cost_usd) as gas_cost_usd
+    from trading_volume_pool
+    group by trading_volume_pool.date
+)
+, tvl_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_pancakeswap_v2_arbitrum_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_base_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_bsc_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_ethereum_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_arbitrum_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_base_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_bsc_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_ethereum_tvl_by_pool"),
+            ],
+        )
+    }}
+)
+, tvl as (
+    select
+        tvl_by_pool.date
+        , sum(tvl_by_pool.tvl) as tvl
+    from tvl_by_pool
+    group by tvl_by_pool.date
+)
+, token_incentives as (
+    select
+        date,
+        sum(amount_usd) as token_incentives_usd
+    from {{ ref('fact_pancakeswap_token_incentives') }}
+    group by date
+)
 select
     tvl.date
     , 'pancakeswap' as app

--- a/models/projects/pancakeswap/core/ez_pancakeswap_metrics_by_chain.sql
+++ b/models/projects/pancakeswap/core/ez_pancakeswap_metrics_by_chain.sql
@@ -8,59 +8,67 @@
     )
 }}
 
-with
-    trading_volume_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_pancakeswap_v2_arbitrum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_base_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_bsc_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v2_ethereum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_arbitrum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_base_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_bsc_trading_vol_fees_traders_by_pool"),
-                    ref("fact_pancakeswap_v3_ethereum_trading_vol_fees_traders_by_pool"),
-                ],
-            )
-        }}
-    ),
-    trading_volume_by_chain as (
-        select
-            trading_volume_by_pool.date,
-            trading_volume_by_pool.chain,
-            sum(trading_volume_by_pool.trading_volume) as trading_volume,
-            sum(trading_volume_by_pool.trading_fees) as trading_fees,
-            sum(trading_volume_by_pool.unique_traders) as unique_traders,
-            sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
-            sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
-        from trading_volume_by_pool
-        group by trading_volume_by_pool.date, trading_volume_by_pool.chain
-    ),
-    tvl_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_pancakeswap_v2_arbitrum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_base_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_bsc_tvl_by_pool"),
-                    ref("fact_pancakeswap_v2_ethereum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_arbitrum_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_base_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_bsc_tvl_by_pool"),
-                    ref("fact_pancakeswap_v3_ethereum_tvl_by_pool"),
-                ],
-            )
-        }}
-    ),
-    tvl_by_chain as (
-        select
-            tvl_by_pool.date,
-            tvl_by_pool.chain,
-            sum(tvl_by_pool.tvl) as tvl
-        from tvl_by_pool
-        group by tvl_by_pool.date, tvl_by_pool.chain
-    )
+with trading_volume_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_pancakeswap_v2_arbitrum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_base_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_bsc_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v2_ethereum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_arbitrum_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_base_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_bsc_trading_vol_fees_traders_by_pool"),
+                ref("fact_pancakeswap_v3_ethereum_trading_vol_fees_traders_by_pool"),
+            ],
+        )
+    }}
+)
+, trading_volume_by_chain as (
+    select
+        trading_volume_by_pool.date,
+        trading_volume_by_pool.chain,
+        sum(trading_volume_by_pool.trading_volume) as trading_volume,
+        sum(trading_volume_by_pool.trading_fees) as trading_fees,
+        sum(trading_volume_by_pool.unique_traders) as unique_traders,
+        sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
+        sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
+    from trading_volume_by_pool
+    group by trading_volume_by_pool.date, trading_volume_by_pool.chain
+)
+, tvl_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_pancakeswap_v2_arbitrum_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_base_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_bsc_tvl_by_pool"),
+                ref("fact_pancakeswap_v2_ethereum_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_arbitrum_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_base_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_bsc_tvl_by_pool"),
+                ref("fact_pancakeswap_v3_ethereum_tvl_by_pool"),
+            ],
+        )
+    }}
+)
+, tvl_by_chain as (
+    select
+        tvl_by_pool.date,
+        tvl_by_pool.chain,
+        sum(tvl_by_pool.tvl) as tvl
+    from tvl_by_pool
+    group by tvl_by_pool.date, tvl_by_pool.chain
+)
+, token_incentives as (
+    select
+        date,
+        'bsc' as chain,
+        sum(amount_usd) as token_incentives_usd
+    from {{ ref('fact_pancakeswap_token_incentives') }}
+    where chain = 'bsc'
+    group by date
+)
 select
     tvl_by_chain.date
     , 'pancakeswap' as app
@@ -71,18 +79,22 @@ select
     , trading_volume_by_chain.trading_fees
     , trading_volume_by_chain.unique_traders
     , trading_volume_by_chain.gas_cost_usd
-    , NULL AS token_incentives
+
     -- Standardized Metrics
+
+    -- Usage Metrics
     , trading_volume_by_chain.unique_traders as spot_dau
     , trading_volume_by_chain.trading_volume as spot_volume
-    , trading_volume_by_chain.trading_fees as spot_fees
-    , trading_volume_by_chain.trading_fees as ecosystem_revenue
-    , trading_volume_by_chain.trading_fees * .68 as service_cash_flow
-    -- TODO: see comment in ez_pancakeswap_metrics re: remaining fees
-
     , trading_volume_by_chain.gas_cost_usd as gas_cost
     , trading_volume_by_chain.gas_cost_native
 
+    -- Cashflow Metrics
+    , trading_volume_by_chain.trading_fees as spot_fees
+    , trading_volume_by_chain.trading_fees as ecosystem_revenue
+    , trading_volume_by_chain.trading_fees * .68 as service_cash_flow
+    , token_incentives.token_incentives_usd as token_incentives
+
 from tvl_by_chain
 left join trading_volume_by_chain using(date, chain)
+left join token_incentives using(date, chain)
 where tvl_by_chain.date < to_date(sysdate())


### PR DESCRIPTION
Added:
- pancakeswap token incentives added to by_chain table so that metric data flows to the Artemis terminal

Validation:
![Screenshot 2025-05-26 at 6 32 30 PM](https://github.com/user-attachments/assets/0a6b43ea-d052-4295-9bee-a03d0cfa1f69)

Question:
- Why does the front-end terminal pull from the by_chain table for the token_incentives metric? I take it has to do with the new all-metric adaptor implementation? @akan72 