### PR TITLE
dataquality/curve token incentives added to by_chain tables

### DIFF
--- a/models/projects/curve/core/ez_curve_metrics.sql
+++ b/models/projects/curve/core/ez_curve_metrics.sql
@@ -8,90 +8,97 @@
     )
 }}
 
-with
-    trading_volume_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_curve_arbitrum_daily_trading_metrics"),
-                    ref("fact_curve_avalanche_daily_trading_metrics"),
-                    ref("fact_curve_ethereum_daily_trading_metrics"),
-                    ref("fact_curve_optimism_daily_trading_metrics"),
-                    ref("fact_curve_polygon_daily_trading_metrics"),
-                ],
-            )
-        }}
-    ),
-    trading_volume as (
-        select
-            trading_volume_by_pool.date,
-            sum(trading_volume_by_pool.trading_volume) as trading_volume,
-            sum(trading_volume_by_pool.trading_fees) as trading_fees,
-            sum(trading_volume_by_pool.trading_revenue) as trading_revenue,
-            sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
-            sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
-        from trading_volume_by_pool
-        group by trading_volume_by_pool.date
-    )
-    , ez_dex_swaps as (
-        SELECT
-            block_timestamp::date as date,
-            count(distinct sender) as unique_traders,
-            count(*) as spot_txns
-        FROM
-            {{ ref('ez_curve_dex_swaps') }}
-        group by 1
-    )
-    , tvl_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_curve_arbitrum_tvl_by_pool"),
-                    ref("fact_curve_avalanche_tvl_by_pool"),
-                    ref("fact_curve_ethereum_tvl_by_pool"),
-                    ref("fact_curve_optimism_tvl_by_pool"),
-                    ref("fact_curve_polygon_tvl_by_pool"),
-                ],
-            )
-        }}
-    ),
-    tvl as (
-        select
-            tvl_by_pool.date,
-            sum(tvl_by_pool.tvl) as tvl
-        from tvl_by_pool
-        group by tvl_by_pool.date
-    )
-    , token_incentives as (
-        select
-            date,
-            sum(minted_amount) as token_incentives_native,
-            sum(minted_usd) as token_incentives
-        from {{ ref('fact_curve_token_incentives') }}
-        group by 1
-    )
-    , market_metrics as (
-        {{ get_coingecko_metrics('curve-dao-token')}}
-    )
+with trading_volume_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_curve_arbitrum_daily_trading_metrics"),
+                ref("fact_curve_avalanche_daily_trading_metrics"),
+                ref("fact_curve_ethereum_daily_trading_metrics"),
+                ref("fact_curve_optimism_daily_trading_metrics"),
+                ref("fact_curve_polygon_daily_trading_metrics"),
+            ],
+        )
+    }}
+)
+, trading_volume as (
+    select
+        trading_volume_by_pool.date,
+        sum(trading_volume_by_pool.trading_volume) as trading_volume,
+        sum(trading_volume_by_pool.trading_fees) as trading_fees,
+        sum(trading_volume_by_pool.trading_revenue) as trading_revenue,
+        sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
+        sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
+    from trading_volume_by_pool
+    group by trading_volume_by_pool.date
+)
+, ez_dex_swaps as (
+    SELECT
+        block_timestamp::date as date,
+        count(distinct sender) as unique_traders,
+        count(*) as spot_txns
+    FROM
+        {{ ref('ez_curve_dex_swaps') }}
+    group by 1
+)
+, tvl_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_curve_arbitrum_tvl_by_pool"),
+                ref("fact_curve_avalanche_tvl_by_pool"),
+                ref("fact_curve_ethereum_tvl_by_pool"),
+                ref("fact_curve_optimism_tvl_by_pool"),
+                ref("fact_curve_polygon_tvl_by_pool"),
+            ],
+        )
+    }}
+)
+, tvl as (
+    select
+        tvl_by_pool.date,
+        sum(tvl_by_pool.tvl) as tvl
+    from tvl_by_pool
+    group by tvl_by_pool.date
+)
+, token_incentives as (
+    select
+        date,
+        sum(minted_amount) as token_incentives_native,
+        sum(minted_usd) as token_incentives
+    from {{ ref('fact_curve_token_incentives') }}
+    group by 1
+)
+, date_spine as (
+    select
+        date
+    from {{ ref('dim_date_spine') }}
+    where date between (select min(date) from tvl) and to_date(sysdate())
+)
+, market_metrics as (
+    {{ get_coingecko_metrics('curve-dao-token')}}
+)
+
 select
-    tvl.date
+    date_spine.date
     , 'curve' as app
     , 'DeFi' as category
 
     -- Standardized Metrics
+
     -- Market Metrics
     , market_metrics.price
     , market_metrics.market_cap
     , market_metrics.fdmc
     , market_metrics.token_volume
 
-    -- Usage/Sector Metrics
+    -- Usage Metrics
     , ez_dex_swaps.unique_traders as spot_dau
     , ez_dex_swaps.spot_txns
     , trading_volume.trading_volume as spot_volume
     , tvl.tvl
 
-    -- Money Metrics
+    -- Cashflow Metrics
     , trading_volume.trading_fees as spot_fees
     , trading_volume.trading_fees as ecosystem_revenue
     , trading_volume.trading_fees * 0.5 as fee_sharing_token_cash_flow
@@ -101,13 +108,14 @@ select
     , trading_volume.gas_cost_native
     , trading_volume.gas_cost_usd as gas_cost
 
-
     -- Other Metrics
     , market_metrics.token_turnover_circulating
     , market_metrics.token_turnover_fdv
-from tvl
-left join trading_volume using(date)
+
+from date_spine
 left join market_metrics using(date)
 left join ez_dex_swaps using(date)
+left join trading_volume using(date)
+left join tvl using(date)
 left join token_incentives using(date)
-where tvl.date < to_date(sysdate())
+where date_spine.date < to_date(sysdate())

--- a/models/projects/curve/core/ez_curve_metrics_by_chain.sql
+++ b/models/projects/curve/core/ez_curve_metrics_by_chain.sql
@@ -8,78 +8,91 @@
     )
 }}
 
-with
-    trading_volume_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_curve_arbitrum_daily_trading_metrics"),
-                    ref("fact_curve_avalanche_daily_trading_metrics"),
-                    ref("fact_curve_ethereum_daily_trading_metrics"),
-                    ref("fact_curve_optimism_daily_trading_metrics"),
-                    ref("fact_curve_polygon_daily_trading_metrics"),
-                ],
-            )
-        }}
-    ),
-    trading_volume_by_chain as (
-        select
-            trading_volume_by_pool.date,
-            trading_volume_by_pool.chain,
-            sum(trading_volume_by_pool.trading_volume) as trading_volume,
-            sum(trading_volume_by_pool.trading_fees) as trading_fees,
-            sum(trading_volume_by_pool.trading_revenue) as trading_revenue,
-            sum(trading_volume_by_pool.unique_traders) as unique_traders,
-            sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
-            sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
-        from trading_volume_by_pool
-        group by trading_volume_by_pool.date, trading_volume_by_pool.chain
-    ),
-    tvl_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_curve_arbitrum_tvl_by_pool"),
-                    ref("fact_curve_avalanche_tvl_by_pool"),
-                    ref("fact_curve_ethereum_tvl_by_pool"),
-                    ref("fact_curve_optimism_tvl_by_pool"),
-                    ref("fact_curve_polygon_tvl_by_pool"),
-                ],
-            )
-        }}
-    ),
-    tvl_by_chain as (
-        select
-            tvl_by_pool.date,
-            tvl_by_pool.chain,
-            sum(tvl_by_pool.tvl) as tvl
-        from tvl_by_pool
-        group by tvl_by_pool.date, tvl_by_pool.chain
-    )
+with trading_volume_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_curve_arbitrum_daily_trading_metrics"),
+                ref("fact_curve_avalanche_daily_trading_metrics"),
+                ref("fact_curve_ethereum_daily_trading_metrics"),
+                ref("fact_curve_optimism_daily_trading_metrics"),
+                ref("fact_curve_polygon_daily_trading_metrics"),
+            ],
+        )
+    }}
+)
+, trading_volume_by_chain as (
+    select
+        trading_volume_by_pool.date as date,
+        trading_volume_by_pool.chain as chain,
+        sum(trading_volume_by_pool.trading_volume) as trading_volume,
+        sum(trading_volume_by_pool.trading_fees) as trading_fees,
+        sum(trading_volume_by_pool.trading_revenue) as trading_revenue,
+        sum(trading_volume_by_pool.unique_traders) as unique_traders,
+        sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
+        sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
+    from trading_volume_by_pool
+    group by trading_volume_by_pool.date, trading_volume_by_pool.chain
+)
+, tvl_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_curve_arbitrum_tvl_by_pool"),
+                ref("fact_curve_avalanche_tvl_by_pool"),
+                ref("fact_curve_ethereum_tvl_by_pool"),
+                ref("fact_curve_optimism_tvl_by_pool"),
+                ref("fact_curve_polygon_tvl_by_pool"),
+            ],
+        )
+    }}
+)
+, tvl_by_chain as (
+    select
+        tvl_by_pool.date as date,
+        tvl_by_pool.chain as chain,
+        sum(tvl_by_pool.tvl) as tvl
+    from tvl_by_pool
+    group by tvl_by_pool.date, tvl_by_pool.chain
+)
+, token_incentives as (
+    select
+        date as date,
+        'ethereum' as chain,
+        sum(minted_usd) as token_incentives
+    from {{ ref('fact_curve_token_incentives') }}
+    group by 1
+)
+
 select
     tvl_by_chain.date
+    , tvl_by_chain.chain
     , 'curve' as app
     , 'DeFi' as category
-    , tvl_by_chain.chain
+    
+
+    --Old metrics needed for compatibility
     , trading_volume_by_chain.trading_volume
     , trading_volume_by_chain.trading_fees
     , trading_volume_by_chain.unique_traders
 
     -- Standardized Metrics
-    -- Usage/Sector Metrics
+
+    -- Usage Metrics
     , trading_volume_by_chain.trading_volume as spot_volume
     , trading_volume_by_chain.unique_traders as spot_dau
     , tvl_by_chain.tvl
 
-    -- Money Metrics
+    -- Cashflow Metrics
     , trading_volume_by_chain.trading_fees as spot_fees
     , trading_volume_by_chain.trading_fees as ecosystem_revenue
     , trading_volume_by_chain.trading_fees * 0.5 as fee_sharing_token_cash_flow
     , trading_volume_by_chain.trading_fees * 0.5 as service_cash_flow
     , trading_volume_by_chain.gas_cost_native
     , trading_volume_by_chain.gas_cost_usd as gas_cost
-    , NULL AS token_incentives
-    -- , IF(chain = 'ethereum'token_incentives.token_incentives as token_incentives
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
+
 from tvl_by_chain
-left join trading_volume_by_chain using(date, chain)
+left join trading_volume_by_chain on tvl_by_chain.date = trading_volume_by_chain.date and tvl_by_chain.chain = trading_volume_by_chain.chain
+left join token_incentives on tvl_by_chain.date = token_incentives.date and tvl_by_chain.chain = token_incentives.chain
 where tvl_by_chain.date < to_date(sysdate())


### PR DESCRIPTION
Added:
- token incentives added to ez_curve_metrics_by_chain tables
- Re-organized ez_metric table naming & ordering

Validation:
<img width="1049" alt="Screenshot 2025-05-27 at 9 17 05 AM" src="https://github.com/user-attachments/assets/c841172c-a2c5-40a9-af51-c736520b2bba" />
<img width="1049" alt="Screenshot 2025-05-27 at 9 17 20 AM" src="https://github.com/user-attachments/assets/22c0edae-7b52-4a5d-82ad-f3a697d14285" />

**Key Notes:**
- There are very slight differences between the Artemis & token terminal token incentives. Trends are exactly the same, and magnitudes are near-identical. However, magnitudes differ very slightly. Investigation & CAD documentation on this will be a P1 fast follow on 