### PR TITLE
dataquality/trader_joe token_incentives added to by_chain table

### DIFF
--- a/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
+++ b/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
@@ -8,11 +8,8 @@
     )
 }}
 
-with market_data as (
-    {{ get_coingecko_metrics("joe") }}
-)
-, protocol_data as (
-    SELECT
+with protocol_data as (
+    select
         date
         , app
         , category
@@ -32,10 +29,9 @@ with market_data as (
         , sum(gas_cost_native) as gas_cost_native
         , sum(gas_cost) as gas_cost
 
-    FROM {{ ref("ez_trader_joe_metrics_by_chain") }}
-    GROUP BY 1, 2, 3
+    from {{ ref("ez_trader_joe_metrics_by_chain") }}
+    group by 1, 2, 3
 )
-
 , supply_data as (
     select
         date
@@ -53,49 +49,63 @@ with market_data as (
     from {{ ref("fact_trader_joe_token_incentives") }}
     group by date
 )
-SELECT
-    date(date) as date
-    , app
-    , category
-    , trading_volume
-    , trading_fees
-    , unique_traders
-    , number_of_swaps
-    , gas_cost_usd
+, date_spine as (
+    select
+        date
+    from {{ ref('dim_date_spine') }}
+    where date between (select min(date) from protocol_data) and to_date(sysdate())
+)
+, market_metrics as (
+    {{ get_coingecko_metrics("joe") }}
+)
+
+select
+    date_spine.date
+    , protocol_data.app
+    , protocol_data.category
+
+    -- Old Metrics needed for compatibility
+    , protocol_data.trading_volume
+    , protocol_data.trading_fees
+    , protocol_data.unique_traders
+    , protocol_data.number_of_swaps
+    , protocol_data.gas_cost_usd
 
     -- Standardized Metrics
 
-    -- Supply Metrics
-    , premine_unlocks_native
-    , gross_emissions_native
-    , burns_native
-    , net_supply_change_native
-    , circulating_supply_native
+    -- Market Metrics
+    , market_metrics.price
+    , market_metrics.market_cap
+    , market_metrics.fdmc
+    , market_metrics.token_volume
 
-    -- Token Metrics
-    , market_data.price
-    , market_data.market_cap
-    , market_data.fdmc
-    , market_data.token_volume
-
-    -- Usage/Sector Metrics
-    , spot_dau
-    , spot_txns
-    , spot_volume
-    , tvl
+    -- Usage Metrics
+    , protocol_data.spot_dau
+    , protocol_data.spot_txns
+    , protocol_data.spot_volume
+    , protocol_data.tvl
 
     -- Cashflow Metrics
-    , trading_fees as spot_fees
-    , ecosystem_revenue
-    , token_incentives
-    , gas_cost_native
-    , gas_cost
+    , protocol_data.spot_fees
+    , protocol_data.ecosystem_revenue
+    , token_incentives.token_incentives
+    , protocol_data.gas_cost_native
+    , protocol_data.gas_cost
+
+    -- LFJ Token Supply Data
+    , supply_data.premine_unlocks_native
+    , supply_data.gross_emissions_native
+    , supply_data.burns_native
+    , supply_data.net_supply_change_native
+    , supply_data.circulating_supply_native
 
     -- Other Metrics
-    , market_data.token_turnover_circulating
-    , market_data.token_turnover_fdv
-FROM protocol_data
-LEFT JOIN market_data using(date)
-LEFT JOIN supply_data using(date)
-LEFT JOIN token_incentives using(date)
-WHERE date < to_date(sysdate())
+    , market_metrics.token_turnover_circulating
+    , market_metrics.token_turnover_fdv
+
+from date_spine
+left join protocol_data using(date)
+left join market_metrics using(date)
+left join token_incentives using(date)
+left join supply_data using(date)
+where date_spine.date < to_date(sysdate())

--- a/models/projects/trader_joe/core/ez_trader_joe_metrics_by_chain.sql
+++ b/models/projects/trader_joe/core/ez_trader_joe_metrics_by_chain.sql
@@ -8,77 +8,94 @@
     )
 }}
 
-with
-    trading_volume_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_trader_joe_arbitrum_trading_vol_fees_traders_by_pool"),
-                    ref("fact_trader_joe_avalanche_trading_vol_fees_traders_by_pool"),
-                ],
-            )
-        }}
-    ),
-    trading_volume_by_chain as (
-        select
-            trading_volume_by_pool.date,
-            trading_volume_by_pool.chain,
-            sum(trading_volume_by_pool.trading_volume) as trading_volume,
-            sum(trading_volume_by_pool.trading_fees) as trading_fees,
-            sum(trading_volume_by_pool.unique_traders) as unique_traders,
-            sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
-            sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
-        from trading_volume_by_pool
-        group by trading_volume_by_pool.date, trading_volume_by_pool.chain
-    ),
-    tvl_by_pool as (
-       {{
-            dbt_utils.union_relations(
-                relations=[
-                    ref("fact_trader_joe_avalanche_tvl_by_pool"),
-                    ref("fact_trader_joe_arbitrum_tvl_by_pool"),
-                ],
-            )
-        }}
-    ),
-    tvl_by_chain as (
-        select
-            tvl_by_pool.date,
-            tvl_by_pool.chain,
-            sum(tvl_by_pool.tvl) as tvl
-        from tvl_by_pool
-        group by tvl_by_pool.date, tvl_by_pool.chain
-    ),
-    daily_txns_data as (
-        select
-            date(block_timestamp) as date
-            , chain
-            , count(*) as daily_txns
-        from {{ ref("ez_trader_joe_dex_swaps")}}
-        group by 1, 2
-    )
+with trading_volume_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_trader_joe_arbitrum_trading_vol_fees_traders_by_pool"),
+                ref("fact_trader_joe_avalanche_trading_vol_fees_traders_by_pool"),
+            ],
+        )
+    }}
+)
+, trading_volume_by_chain as (
+    select
+        trading_volume_by_pool.date,
+        trading_volume_by_pool.chain,
+        sum(trading_volume_by_pool.trading_volume) as trading_volume,
+        sum(trading_volume_by_pool.trading_fees) as trading_fees,
+        sum(trading_volume_by_pool.unique_traders) as unique_traders,
+        sum(trading_volume_by_pool.gas_cost_native) as gas_cost_native,
+        sum(trading_volume_by_pool.gas_cost_usd) as gas_cost_usd
+    from trading_volume_by_pool
+    group by trading_volume_by_pool.date, trading_volume_by_pool.chain
+)
+, tvl_by_pool as (
+    {{
+        dbt_utils.union_relations(
+            relations=[
+                ref("fact_trader_joe_avalanche_tvl_by_pool"),
+                ref("fact_trader_joe_arbitrum_tvl_by_pool"),
+            ],
+        )
+    }}
+)
+, tvl_by_chain as (
+    select
+        tvl_by_pool.date,
+        tvl_by_pool.chain,
+        sum(tvl_by_pool.tvl) as tvl
+    from tvl_by_pool
+    group by tvl_by_pool.date, tvl_by_pool.chain
+)
+, daily_txns_data as (
+    select
+        date(block_timestamp) as date
+        , chain
+        , count(*) as daily_txns
+    from {{ ref("ez_trader_joe_dex_swaps")}}
+    group by 1, 2
+)
+, token_incentives as (
+    select
+        date
+        , 'avalanche' as chain
+        , sum(amount_usd) as token_incentives
+    from {{ ref("fact_trader_joe_token_incentives") }}
+    group by date
+)
+
 select
     tvl_by_chain.date
     , 'trader_joe' as app
     , 'DeFi' as category
     , tvl_by_chain.chain
+
+    --Old metrics needed for compatibility
     , trading_volume_by_chain.trading_volume
     , trading_volume_by_chain.trading_fees
     , trading_volume_by_chain.unique_traders
     , trading_volume_by_chain.gas_cost_usd
     , daily_txns_data.daily_txns as number_of_swaps
-    , NULL AS token_incentives
+    
 
     -- Standardized Metrics
+
+    -- Usage Metrics
     , trading_volume_by_chain.unique_traders as spot_dau
     , daily_txns_data.daily_txns as spot_txns
     , trading_volume_by_chain.trading_volume as spot_volume
-    , trading_volume_by_chain.trading_fees as spot_fees
     , tvl_by_chain.tvl as tvl
+
+    -- Cashflow Metrics
+    , trading_volume_by_chain.trading_fees as spot_fees
     , trading_volume_by_chain.trading_fees as ecosystem_revenue
+    , token_incentives.token_incentives as token_incentives
     , trading_volume_by_chain.gas_cost_native
     , trading_volume_by_chain.gas_cost_usd as gas_cost
+    
 from tvl_by_chain
 left join trading_volume_by_chain using(date, chain)
 left join daily_txns_data using (date, chain)
+left join token_incentives on tvl_by_chain.date = token_incentives.date and tvl_by_chain.chain = token_incentives.chain
 where tvl_by_chain.date < to_date(sysdate())


### PR DESCRIPTION
Added:
- token incentives added to ez_trader_joe_metrics_by_chain tables
- Re-organized ez_metric/ez_metric_by_chain table naming & ordering

Validation:
<img width="1214" alt="Screenshot 2025-05-27 at 10 45 52 AM" src="https://github.com/user-attachments/assets/cc87e51a-5aea-4a03-b854-fa2f1b36f0df" />
<img width="1065" alt="Screenshot 2025-05-27 at 10 46 35 AM" src="https://github.com/user-attachments/assets/b4f4f862-7dff-4d9c-b7f8-8671c8656eb6" />

**Key Notes:**
- Trader Joe's rebranded to 'Let's Fucking Joe' and the token is now LFJ. Adding to the backlog to update the CAD & the protocol information to take account for this re-brand