### PR TITLE
Deprecating previous Hyperliquid upstream provider and using hyperliquid API

### DIFF
--- a/models/staging/hyperliquid/__hyperliquid__sources.yml
+++ b/models/staging/hyperliquid/__hyperliquid__sources.yml
@@ -18,6 +18,7 @@ sources:
       - name: raw_hyperevm_transactions_parquet
       - name: raw_hyperevm_logs_parquet
       - name: raw_hyperliquid_hlp_tvl
+      - name: raw_hyperliquid_perps_trading_volume
   - name: MANUAL_STATIC_TABLES
     schema: PROD
     database: pc_dbt_db

--- a/models/staging/hyperliquid/fact_hyperliquid_perps_trading_volume.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_perps_trading_volume.sql
@@ -1,0 +1,19 @@
+{{ config(materialized="table", snowflake_warehouse="HYPERLIQUID") }}
+
+with 
+    hyperliquid_perps_trading_volume as (
+        select
+            to_date(to_timestamp_ltz(parse_json(source_json):timestamp::number)) as date,
+            parse_json(source_json):daily_volume_total::float as perps_trading_volume
+            , 'hyperliquid' as app
+            , 'hyperliquid' as chain
+            , 'DeFi' as category
+        from {{ source("PROD_LANDING", "raw_hyperliquid_perps_trading_volume") }}
+    )
+select 
+    date
+    , round(perps_trading_volume, 2) as perps_trading_volume
+    , app
+    , chain
+    , category
+from hyperliquid_perps_trading_volume

--- a/models/staging/hyperliquid/fact_hyperliquid_trading_volume.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_trading_volume.sql
@@ -5,21 +5,31 @@ with
     ),
     trading_volume_market as (
         select
-            value:total_volume::double as trading_volume,
-            value:coin::string as market,
-            date(value:time) as date,
-            extraction_date
+            sum(value:total_volume::double) as trading_volume
+            , max(value:coin::string) as market
+            , date(value:time) as date
+            , max(extraction_date) as extraction_date
         from
             {{ source("PROD_LANDING", "raw_hyperliquid_trading_volume") }},
             lateral flatten(input => parse_json(source_json))
-        where extraction_date = (select extraction_date from max_date)
+        where date(extraction_date) = '2025-05-28'
+        group by date
+
+        union all
+
+        select
+            max(parse_json(source_json):daily_volume_total::double) as trading_volume
+            , null as market
+            , date(to_timestamp(parse_json(source_json):timestamp::number)) as date
+            , max(extraction_date) as extraction_date
+        from LANDING_DATABASE.PROD_LANDING.raw_hyperliquid_perps_trading_volume
+        where date(extraction_date) > '2025-05-24'
+        group by date(to_timestamp(parse_json(source_json):timestamp::number))
     )
 select
-    sum(trading_volume) as trading_volume,
-    null as market,
-    date,
-    'hyperliquid' as app,
-    'hyperliquid' as chain,
-    'DeFi' as category
+    trading_volume
+    , date
+    , 'hyperliquid' as app
+    , 'hyperliquid' as chain
+    , 'DeFi' as category
 from trading_volume_market
-group by date


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- add fact_hyperliquid_perps_trading_volume (only pushed to prod on `2025-05-22` hence we only have daily data since then)
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/6ad39ea7-63a4-467e-bbd7-3f7f1b6d5fa7" />

- deprecate hypurrscan and use hyperliquid API data
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/716097cc-f069-4cf3-a1b0-b2d56a495b60" />

- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below

ran RETL to make sure backwards compatibility works
<img width="921" alt="image" src="https://github.com/user-attachments/assets/f4d7cadf-ae92-4c1f-85c4-6f9907c78eab" />

## Other

- [ ] Any other relevant information that may be helpful