### PR TITLE
Create stablecoin iceberg tables

### DIFF
--- a/iceberg/models/stablecoins/agg_daily_stablecoin_breakdown_datahub_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_daily_stablecoin_breakdown_datahub_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_daily_stablecoin_breakdown_datahub",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': '_dbt_source_relation',
+        }) }}"
+    )
+}}
+
+SELECT
+    *
+FROM PC_DBT_DB.PROD.agg_daily_stablecoin_breakdown_datahub
+ORDER BY _dbt_source_relation

--- a/iceberg/models/stablecoins/agg_daily_stablecoin_breakdown_with_labels_precomputed_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_daily_stablecoin_breakdown_with_labels_precomputed_iceberg.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_daily_stablecoin_breakdown_with_labels_precomputed",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'parent, value',
+        }) }}"
+    )
+}}
+
+select
+    * EXCLUDE(path),
+    to_json(path) AS path
+from PC_DBT_DB.PROD.agg_daily_stablecoin_breakdown_with_labels_precomputed
+order by parent, value
+
+

--- a/iceberg/models/stablecoins/agg_monthly_stablecoin_breakdown_datahub_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_monthly_stablecoin_breakdown_datahub_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_monthly_stablecoin_breakdown_datahub",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': '_dbt_source_relation',
+        }) }}"
+    )
+}}
+
+SELECT
+    *
+FROM PC_DBT_DB.PROD.agg_monthly_stablecoin_breakdown_datahub
+ORDER BY _dbt_source_relation

--- a/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_application_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_application_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_flows_breakdown_application",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'application',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_flows_breakdown_application
+order by application
+    

--- a/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_category_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_category_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_flows_breakdown_category",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'category',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_flows_breakdown_category
+order by category
+    

--- a/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_chain_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_chain_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_flows_breakdown_chain",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'chain',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_flows_breakdown_chain
+order by chain
+    

--- a/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_symbol_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_flows_breakdown_symbol_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_flows_breakdown_symbol",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'symbol',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_flows_breakdown_symbol
+order by symbol
+    

--- a/iceberg/models/stablecoins/agg_stablecoin_tiles_breakdown_chain_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_tiles_breakdown_chain_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_tiles_breakdown_chain",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'breakdown',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_tiles_breakdown_chain
+order by breakdown
+    

--- a/iceberg/models/stablecoins/agg_stablecoin_tiles_breakdown_symbol_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_stablecoin_tiles_breakdown_symbol_iceberg.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_stablecoin_tiles_breakdown_symbol",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'breakdown',
+        }) }}"
+    )
+}}
+
+select
+    *
+from PC_DBT_DB.PROD.agg_stablecoin_tiles_breakdown_symbol
+order by breakdown
+    

--- a/iceberg/models/stablecoins/agg_weekly_stablecoin_breakdown_datahub_iceberg.sql
+++ b/iceberg/models/stablecoins/agg_weekly_stablecoin_breakdown_datahub_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="agg_weekly_stablecoin_breakdown_datahub",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': '_dbt_source_relation',
+        }) }}"
+    )
+}}
+
+SELECT
+    *
+FROM PC_DBT_DB.PROD.agg_weekly_stablecoin_breakdown_datahub
+ORDER BY _dbt_source_relation

--- a/iceberg/models/stablecoins/dim_stablecoin_table_breakdown_iceberg.sql
+++ b/iceberg/models/stablecoins/dim_stablecoin_table_breakdown_iceberg.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STABLECOINS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="dim_stablecoin_table_breakdown",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'symbol',
+            'partitioned_order_by': 'chain',
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(name, historical_l_30_stablecoin_supply),
+    to_json(name) AS name,
+    to_json(historical_l_30_stablecoin_supply) AS historical_l_30_stablecoin_supply
+FROM PC_DBT_DB.PROD.dim_stablecoin_table_breakdown
+ORDER BY chain, symbol

--- a/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels_precomputed.sql
+++ b/models/metrics/stablecoins/breakdowns/agg_daily_stablecoin_breakdown_with_labels_precomputed.sql
@@ -1,0 +1,110 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='STABLECOIN_V2_LG'
+    )
+}}
+
+WITH max_date AS (
+    SELECT
+        MAX(date) AS max_date
+    FROM {{ ref('agg_daily_stablecoin_breakdown_with_labels') }}
+), base AS (
+    -- Child Rows
+    SELECT
+        date,
+        LOWER(symbol) as parent_value,
+        LOWER(chain) as child_value,
+        LOWER(symbol) AS parent,
+        SUM(stablecoin_daily_txns) AS stablecoin_daily_transfers,
+        COUNT(DISTINCT case when stablecoin_daily_txns > 0 then address end) AS stablecoin_dau,
+        SUM(stablecoin_supply) AS stablecoin_supply,
+        SUM(stablecoin_transfer_volume) AS stablecoin_transfer_volume
+    FROM {{ ref('agg_daily_stablecoin_breakdown_with_labels') }}
+    WHERE
+        (
+            date = (SELECT max_date FROM max_date)
+            OR date = DATEADD(day, -30, (SELECT max_date FROM max_date))
+        )
+        
+    GROUP BY
+        date, parent_value, child_value
+    UNION ALL
+
+    -- Parent Rows
+    SELECT
+        date,
+        LOWER(symbol) as parent_value,
+        NULL AS child_value,
+        NULL AS parent,
+        SUM(stablecoin_daily_txns) AS stablecoin_daily_transfers,
+        COUNT(DISTINCT CASE WHEN stablecoin_daily_txns > 0 THEN address END) AS stablecoin_dau,
+        SUM(stablecoin_supply) AS stablecoin_supply,
+        SUM(stablecoin_transfer_volume) AS stablecoin_transfer_volume
+    FROM {{ ref('agg_daily_stablecoin_breakdown_with_labels') }}
+    WHERE
+        (
+            date = (SELECT max_date FROM max_date)
+            OR date = DATEADD(day, -29, (SELECT max_date FROM max_date))
+        )
+        
+    GROUP BY
+        date, parent_value
+), agg AS (
+    SELECT
+        date,
+        LOWER(parent_value) AS parent_value,
+        LOWER(child_value) AS child_value,
+        ARRAY_AGG(child_value) AS path_arr,
+        MAX(parent) AS parent,
+        MAX(stablecoin_daily_transfers) AS stablecoin_daily_transfers,
+        MAX(stablecoin_dau) AS stablecoin_dau,
+        MAX(stablecoin_supply) AS stablecoin_supply,
+        MAX(stablecoin_transfer_volume) AS stablecoin_transfer_volume
+    FROM base
+    GROUP BY
+        date, parent_value, child_value
+), ranked AS (
+SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY parent_value, child_value ORDER BY date DESC) AS row_num,
+    LAG(stablecoin_daily_transfers) OVER (PARTITION BY parent_value, child_value ORDER BY date) AS prev_stablecoin_daily_transfers,
+    LAG(stablecoin_dau) OVER (PARTITION BY parent_value, child_value ORDER BY DATE) AS prev_stablecoin_dau,
+    LAG(stablecoin_supply) OVER (PARTITION BY parent_value, child_value ORDER BY DATE) AS prev_stablecoin_supply,
+    LAG(stablecoin_transfer_volume) OVER (PARTITION BY parent_value, child_value ORDER BY DATE) AS prev_stablecoin_transfer_volume
+FROM agg
+), calculated_changes AS (
+SELECT
+    *,
+    case
+        when prev_stablecoin_daily_transfers is null or prev_stablecoin_daily_transfers = 0 then 0
+        else (stablecoin_daily_transfers - prev_stablecoin_daily_transfers) / prev_stablecoin_daily_transfers * 100
+    end AS stablecoin_daily_transfers_pct_chg,
+    case
+        when prev_stablecoin_dau is null or prev_stablecoin_dau = 0 then 0
+        else (stablecoin_dau - prev_stablecoin_dau) / prev_stablecoin_dau * 100
+    end AS stablecoin_dau_pct_chg,
+    case
+        when prev_stablecoin_supply is null or prev_stablecoin_supply = 0 then 0
+        else (stablecoin_supply - prev_stablecoin_supply) / prev_stablecoin_supply * 100
+    end AS stablecoin_supply_pct_chg,
+    case
+        when prev_stablecoin_transfer_volume is null or prev_stablecoin_transfer_volume = 0 then 0
+        else (stablecoin_transfer_volume - prev_stablecoin_transfer_volume) / prev_stablecoin_transfer_volume * 100
+    end AS stablecoin_transfer_volume_pct_chg
+FROM ranked
+)
+SELECT
+    COALESCE(child_value, parent_value) AS value,
+    ARRAY_CAT([parent_value], ARRAY_SORT(path_arr)) AS path,
+    parent,
+    stablecoin_supply,
+    stablecoin_supply_pct_chg,
+    stablecoin_transfer_volume,
+    stablecoin_transfer_volume_pct_chg,
+    stablecoin_daily_transfers,
+    stablecoin_daily_transfers_pct_chg,
+    stablecoin_dau,
+    stablecoin_dau_pct_chg
+FROM calculated_changes
+WHERE row_num = 1 and (round(stablecoin_supply, 1) > 0 or round(stablecoin_transfer_volume, 1) > 0 or round(stablecoin_daily_transfers, 1) > 0 or round(stablecoin_dau, 1) > 0)

--- a/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_datahub.sql
+++ b/models/metrics/stablecoins/breakdowns/daily/agg_daily_stablecoin_breakdown_datahub.sql
@@ -1,0 +1,22 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='STABLECOIN_DAILY'
+    )
+}}
+
+{{ dbt_utils.union_relations(
+    relations=[
+        ref("agg_daily_stablecoin_breakdown_application_chain"),
+        ref("agg_daily_stablecoin_breakdown_application_symbol"),
+        ref("agg_daily_stablecoin_breakdown_application"),
+        ref("agg_daily_stablecoin_breakdown_category_chain"),
+        ref("agg_daily_stablecoin_breakdown_category_symbol_chain"),
+        ref("agg_daily_stablecoin_breakdown_category_symbol"),
+        ref("agg_daily_stablecoin_breakdown_category"),
+        ref("agg_daily_stablecoin_breakdown_chain"),
+        ref("agg_daily_stablecoin_breakdown_symbol_chain"),
+        ref("agg_daily_stablecoin_breakdown_symbol"),
+    ],
+    include=["date_granularity", "symbol", "application", "category", "chain", "stablecoin_dau", "stablecoin_transfer_volume", "stablecoin_daily_txns", "stablecoin_avg_txn_value", "artemis_stablecoin_dau", "artemis_stablecoin_transfer_volume", "artemis_stablecoin_daily_txns", "artemis_stablecoin_avg_txn_value", "p2p_stablecoin_dau", "p2p_stablecoin_transfer_volume", "p2p_stablecoin_daily_txns", "p2p_stablecoin_avg_txn_value", "stablecoin_supply", "p2p_stablecoin_supply"]
+) }}

--- a/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_datahub.sql
+++ b/models/metrics/stablecoins/breakdowns/monthly/agg_monthly_stablecoin_breakdown_datahub.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='STABLECOIN_WEEKLY'
+    )
+}}
+
+{{ dbt_utils.union_relations(
+    relations=[
+        ref("agg_monthly_stablecoin_breakdown_category_chain"),
+        ref("agg_monthly_stablecoin_breakdown_category_symbol_chain"),
+        ref("agg_monthly_stablecoin_breakdown_category_symbol"),
+        ref("agg_monthly_stablecoin_breakdown_category"),
+        ref("agg_monthly_stablecoin_breakdown_chain"),
+        ref("agg_monthly_stablecoin_breakdown_symbol_chain"),
+        ref("agg_monthly_stablecoin_breakdown_symbol"),
+    ],
+    include=["date_granularity", "symbol", "category", "chain", "stablecoin_dau", "stablecoin_transfer_volume", "stablecoin_daily_txns", "stablecoin_avg_txn_value", "artemis_stablecoin_dau", "artemis_stablecoin_transfer_volume", "artemis_stablecoin_daily_txns", "artemis_stablecoin_avg_txn_value", "p2p_stablecoin_dau", "p2p_stablecoin_transfer_volume", "p2p_stablecoin_daily_txns", "p2p_stablecoin_avg_txn_value", "stablecoin_supply", "p2p_stablecoin_supply"]
+) }}

--- a/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_datahub.sql
+++ b/models/metrics/stablecoins/breakdowns/weekly/agg_weekly_stablecoin_breakdown_datahub.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized='table',
+        snowflake_warehouse='STABLECOIN_MONTHLY'
+    )
+}}
+
+{{ dbt_utils.union_relations(
+    relations=[
+        ref("agg_weekly_stablecoin_breakdown_category_chain"),
+        ref("agg_weekly_stablecoin_breakdown_category_symbol_chain"),
+        ref("agg_weekly_stablecoin_breakdown_category_symbol"),
+        ref("agg_weekly_stablecoin_breakdown_category"),
+        ref("agg_weekly_stablecoin_breakdown_chain"),
+        ref("agg_weekly_stablecoin_breakdown_symbol_chain"),
+        ref("agg_weekly_stablecoin_breakdown_symbol"),
+    ],
+    include=["date_granularity", "symbol", "category", "chain", "stablecoin_dau", "stablecoin_transfer_volume", "stablecoin_daily_txns", "stablecoin_avg_txn_value", "artemis_stablecoin_dau", "artemis_stablecoin_transfer_volume", "artemis_stablecoin_daily_txns", "artemis_stablecoin_avg_txn_value", "p2p_stablecoin_dau", "p2p_stablecoin_transfer_volume", "p2p_stablecoin_daily_txns", "p2p_stablecoin_avg_txn_value", "stablecoin_supply", "p2p_stablecoin_supply"]
+) }}


### PR DESCRIPTION
# Description

Create stablecoin datahubs and iceberg tables for the Snowflake tables that the terminal is currently hitting. That way, these tables will be written into DuckDB and the terminal will be redirected to hit DuckDB instead.

# Tests

Ran locally