### PR TITLE
base unit is now gwei instead of wei

### DIFF
--- a/models/staging/ethereum/fact_ethereum_da_metrics.sql
+++ b/models/staging/ethereum/fact_ethereum_da_metrics.sql
@@ -10,7 +10,7 @@ with
             block_timestamp::date as date,
             from_address as submitter,
             (blob_gas_used * blob_gas_price) as blob_fees_gas,
-            blob_fees_gas / 1e18 as blob_fees_native,
+            blob_fees_gas / 1e9 as blob_fees_native,
             blob_fees_native * price as blob_fees
         from ethereum_flipside.core.fact_transactions 
         left join prices on block_timestamp::date = prices.date


### PR DESCRIPTION
Adjust division from 1e18 to 1e9 to account for base unit change in source table.

Data looks accurate now:

![CleanShot 2025-05-29 at 15 46 42@2x](https://github.com/user-attachments/assets/d635cbb5-09f1-4883-b2dd-fc14f45df2f2)

Compared to BW dash:
![CleanShot 2025-05-29 at 15 46 56@2x](https://github.com/user-attachments/assets/65b2467e-0c08-4f98-a4b0-a098033ca364)


and comparing with Blobscan:
![CleanShot 2025-05-29 at 15 48 32@2x](https://github.com/user-attachments/assets/b5691635-cbf0-45ed-8452-bae5fe7d7543)


![CleanShot 2025-05-29 at 15 48 13@2x](https://github.com/user-attachments/assets/7ea09b2d-3ddc-489d-a069-8af81bb800a5)
