### PR TITLE
feature/perpetual protocol token incentives

### DIFF
--- a/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics.sql
+++ b/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics.sql
@@ -35,6 +35,14 @@ WITH
     )
     , price as ({{ get_coingecko_metrics("perpetual-protocol") }})
 
+    , token_incentives as (
+        select
+            date,
+            SUM(total_token_incentives) as token_incentives
+        from {{ref('fact_perpetual_token_incentives')}}
+        group by 1
+    )
+
 SELECT
     date
     , app
@@ -60,6 +68,8 @@ SELECT
     , token_turnover_circulating
     , token_turnover_fdv
     , token_volume
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
 FROM perp_data
 LEFT JOIN price USING(date)
+LEFT JOIN token_incentives USING(date)
 WHERE date < to_date(sysdate())

--- a/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics_by_chain.sql
+++ b/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics_by_chain.sql
@@ -37,31 +37,43 @@ with
             SUM(total_token_incentives) as token_incentives
         from {{ref('fact_perpetual_token_incentives')}}
         group by date, chain
+    ),
+    all_date_chain_combinations as (
+        select distinct date, chain from trading_volume_data
+        union
+        select distinct date, chain from unique_traders_data  
+        union
+        select distinct date, chain from fees_data
+        union
+        select distinct date, chain from tvl_data
+        union
+        select distinct date, chain from token_incentives
     )
 
 select
-    date as date
+    base.date as date
     , 'perpetual_protocol' as app
     , 'DeFi' as category
-    , chain
-    , trading_volume
-    , unique_traders
-    , fees
-    , fees * 0.2 as revenue -- https://support.perp.com/general/legacy-reward-programs#how-it-works search '20%'
-    , {{ daily_pct_change('tvl') }} as tvl_growth
+    , base.chain
+    , coalesce(tvd.trading_volume, 0) as trading_volume
+    , coalesce(utd.unique_traders, 0) as unique_traders
+    , coalesce(fd.fees, 0) as fees
+    , coalesce(fd.fees, 0) * 0.2 as revenue -- https://support.perp.com/general/legacy-reward-programs#how-it-works search '20%'
+    , (coalesce(tvl_data.tvl, 0) - LAG(coalesce(tvl_data.tvl, 0)) OVER (PARTITION BY base.chain ORDER BY base.date)) / NULLIF(LAG(coalesce(tvl_data.tvl, 0)) OVER (PARTITION BY base.chain ORDER BY base.date), 0) * 100 as tvl_growth
     -- standardize metrics
-    , trading_volume as perp_volume
-    , unique_traders as perp_dau
-    , tvl
-    , {{ daily_pct_change('tvl') }} as tvl_pct_change
-    , fees as ecosystem_revenue
-    , fees * .2 * .8 as fee_sharing_token_cash_flow
-    , fees * .8 as service_cash_flow
-    , fees * .2 * .2 as treasury_cash_flow
-    , coalesce(token_incentives.token_incentives, 0) as token_incentives
-from unique_traders_data
-left join trading_volume_data using(date, chain)
-left join fees_data using(date, chain)
-left join tvl_data using(date, chain)
-left join token_incentives using(date, chain)
-where date < to_date(sysdate())
+    , coalesce(tvd.trading_volume, 0) as perp_volume
+    , coalesce(utd.unique_traders, 0) as perp_dau
+    , coalesce(tvl_data.tvl, 0) as tvl
+    , (coalesce(tvl_data.tvl, 0) - LAG(coalesce(tvl_data.tvl, 0)) OVER (PARTITION BY base.chain ORDER BY base.date)) / NULLIF(LAG(coalesce(tvl_data.tvl, 0)) OVER (PARTITION BY base.chain ORDER BY base.date), 0) * 100 as tvl_pct_change
+    , coalesce(fd.fees, 0) as ecosystem_revenue
+    , coalesce(fd.fees, 0) * 0.2 * 0.8 as fee_sharing_token_cash_flow
+    , coalesce(fd.fees, 0) * 0.8 as service_cash_flow
+    , coalesce(fd.fees, 0) * 0.2 * 0.2 as treasury_cash_flow
+    , coalesce(ti.token_incentives, 0) as token_incentives
+from all_date_chain_combinations base
+left join trading_volume_data tvd on tvd.date = base.date and tvd.chain = base.chain
+left join unique_traders_data utd on utd.date = base.date and utd.chain = base.chain
+left join fees_data fd on fd.date = base.date and fd.chain = base.chain
+left join tvl_data tvl_data on tvl_data.date = base.date and tvl_data.chain = base.chain
+left join token_incentives ti on ti.date = base.date and ti.chain = base.chain
+where base.date < to_date(sysdate())

--- a/models/staging/perpetual_protocol/fact_perpetual_token_incentives.sql
+++ b/models/staging/perpetual_protocol/fact_perpetual_token_incentives.sql
@@ -1,0 +1,66 @@
+{{ config(materialized="table") }}
+
+WITH perp_v2_staking_rewards AS (
+    SELECT
+        DATE(block_timestamp) AS date,
+        'optimism' AS chain,
+        SUM(
+            TRY_CAST(decoded_log:"amount"::STRING AS FLOAT) / 1e18 * eph.price
+        ) AS token_incentives
+    FROM optimism_flipside.core.ez_decoded_event_logs AS tt
+    JOIN optimism_flipside.price.ez_prices_hourly AS eph
+        ON LOWER(eph.symbol) = LOWER('PERP') AND eph.hour = DATE_TRUNC('hour', tt.block_timestamp)
+    WHERE LOWER(contract_address) IN ( 
+        LOWER('0xe6410Ef478F3BA4A9d983d205226ACC6cC794b07'),
+        LOWER('0x5Ebe7ee72ab56f82194e61D95d5A0a32CdF722E1')
+    )
+    AND event_name = 'Claimed'
+    GROUP BY date, chain
+),
+
+perp_v1_token_incentives AS (
+    SELECT
+        DATE(block_timestamp) AS date,
+        'ethereum' AS chain,
+        SUM(
+            TRY_CAST(decoded_log:"_balance"::STRING AS FLOAT) / 1e18 * eph.price
+        ) AS token_incentives
+    FROM ethereum_flipside.core.ez_decoded_event_logs AS tt
+    JOIN ethereum_flipside.price.ez_prices_hourly AS eph
+        ON LOWER(eph.symbol) = LOWER('PERP') AND eph.hour = DATE_TRUNC('hour', tt.block_timestamp)
+    WHERE LOWER(contract_address) IN (
+        LOWER('0x49a4B8431Fc24BE4b22Fb07D1683E2c52bC56088'),
+        LOWER('0xc2a9e84D77f4B534F049b593C282c5c91F24808A')
+    )
+    AND event_name = 'Claimed'
+    GROUP BY date, chain
+),
+
+pool_party AS (
+    SELECT
+        DATE(block_timestamp) AS date,
+        'optimism' AS chain,
+        SUM(
+            TRY_CAST(decoded_log:"_balance"::STRING AS FLOAT) / 1e18 * eph.price
+        ) AS token_incentives
+    FROM optimism_flipside.core.ez_decoded_event_logs AS tt
+    JOIN optimism_flipside.price.ez_prices_hourly AS eph
+        ON LOWER(eph.symbol) = LOWER('PERP') AND eph.hour = DATE_TRUNC('hour', tt.block_timestamp)
+    WHERE LOWER(contract_address) = LOWER('0x3230Cbb08C64d0804BE5b7f4cE43834291490a91')
+      AND event_name = 'Claimed'
+    GROUP BY date, chain
+)
+
+SELECT
+    date,
+    chain,
+    SUM(token_incentives) AS total_token_incentives
+FROM (
+    SELECT * FROM perp_v2_staking_rewards
+    UNION ALL
+    SELECT * FROM perp_v1_token_incentives
+    UNION ALL
+    SELECT * FROM pool_party
+) AS combined
+GROUP BY date, chain
+ORDER BY date


### PR DESCRIPTION
Added:
Data model for perpetual protocol token incentives

CAD: [Updated](https://www.notion.so/artemisxyz/72f60456ca1d4942a8d5dcaa65f71b6a?v=6fefa7090768453ab7c72be16e586142&p=20446f0265b48038b34ec3a342e64d4f&pm=s)

Key Notes:
The token incentives model used here differs from Token Terminal's approach. Our model includes:
Pool Party $PERP rewards
Perpetual Protocol V1 staking rewards (on Ethereum)
Perpetual Protocol V2 staking rewards (on Optimism)

In contrast, Token Terminal reports only liquidity incentives (i.e., Pool Party rewards), excluding staking rewards entirely.
Additionally, a discrepancy exists between the ez_metrics and ez_metrics_by_chain tables. The ez_metrics_by_chain model joins token incentives by both date and chain, and since staking rewards from V1 are on Ethereum, they are excluded from the chain-specific view (which currently reflects only Optimism-based data). 

Validation:
<img width="801" alt="Screenshot 2025-05-31 at 9 07 20 PM" src="https://github.com/user-attachments/assets/ce8067a7-2e42-4032-ab4c-f72eadfcfbe9" />
