### PR TITLE
feature/mux token incentives

### DIFF
--- a/models/projects/mux/core/ez_mux_metrics.sql
+++ b/models/projects/mux/core/ez_mux_metrics.sql
@@ -19,6 +19,13 @@ with
         group by 1
     )
     , price as ({{ get_coingecko_metrics("mcdex") }})
+    , token_incentives as (
+        select
+            date,
+            sum(token_incentives) as token_incentives
+        from {{ ref("fact_mux_token_incentives") }}
+        group by 1
+    )
 select
     date
     , 'mux' as app
@@ -33,6 +40,8 @@ select
     , token_turnover_circulating
     , token_turnover_fdv
     , token_volume
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
 from mux_data
 left join price using(date)
+left join token_incentives using(date)
 where date < to_date(sysdate())

--- a/models/projects/mux/core/ez_mux_metrics_by_chain.sql
+++ b/models/projects/mux/core/ez_mux_metrics_by_chain.sql
@@ -14,6 +14,14 @@ with
         from {{ ref("fact_mux_trading_volume_unique_traders") }}
         where chain is not null
     )
+    , token_incentives as (
+        select
+            date,
+            'arbitrum' as chain,
+            sum(token_incentives) as token_incentives
+        from {{ ref("fact_mux_token_incentives") }}
+        group by date, chain
+    )
 
 select
     date
@@ -25,5 +33,7 @@ select
     -- standardize metrics
     , trading_volume as perp_volume
     , unique_traders as perp_dau
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
 from mux_data
+left join token_incentives using(date, chain)
 where date < to_date(sysdate())

--- a/models/staging/mux/fact_mux_token_incentives.sql
+++ b/models/staging/mux/fact_mux_token_incentives.sql
@@ -1,0 +1,21 @@
+{{ config(materialized="table") }}
+
+
+with mcb_claims as (
+    select
+        date(block_timestamp) as date,
+        sum(
+            TRY_CAST(decoded_log:"amount"::STRING AS FLOAT) / 1e18 * eph.price
+        ) as token_incentives
+    from arbitrum_flipside.core.ez_decoded_event_logs as tt
+    join arbitrum_flipside.price.ez_prices_hourly as eph
+       on lower(eph.token_address) = lower('0x4e352cF164E64ADCBad318C3a1e222E9EBa4Ce42') and eph.hour = date_trunc('hour', tt.block_timestamp)
+    where lower(contract_address) IN (
+        lower('0xBCF8c124975DE6277D8397A3Cad26E2333620226')
+    )
+    and event_name = 'Claim'
+    and MOD(TRY_CAST(decoded_log:"amount"::STRING AS FLOAT) / 1e18, 1) != 0
+    group by date
+)
+
+select * from mcb_claims


### PR DESCRIPTION
Added:
Data model for mux protocol token incentives

CAD: [Updated](https://www.notion.so/artemisxyz/72f60456ca1d4942a8d5dcaa65f71b6a?v=6fefa7090768453ab7c72be16e586142&p=20446f0265b48064baa1edd7625c3d46&pm=s)

Key Notes:
Token incentives data prior to September 2022 is intentionally excluded from our model. Unlike Token Terminal, which includes this earlier period, we do not count these distributions because they represent vested token allocations to MCB Series A investors, not actual incentive rewards. I confirmed this with the MUX team as well. 


Validation:
<img width="520" alt="image" src="https://github.com/user-attachments/assets/9fa44396-a5d4-41a7-a71d-e59a21673b1e" />

<img width="843" alt="image" src="https://github.com/user-attachments/assets/2e18a562-81b5-4374-934f-4b79bb4e7683" />
