### PR TITLE
feature/tron token_incentives

### DIFF
--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -9,23 +9,34 @@
     )
 }}
 
-with
-    fundamental_data as ({{ get_fundamental_data_for_chain("tron", "v2") }}),
-    price_data as ({{ get_coingecko_metrics("tron") }}),
-    defillama_data as ({{ get_defillama_metrics("tron") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("tron") }}),
-    github_data as ({{ get_github_metrics("tron") }}),
-    p2p_metrics as ({{ get_p2p_metrics("tron") }}),
-    rolling_metrics as ({{ get_rolling_active_address_metrics("tron") }})
+with fundamental_data as (
+    {{ get_fundamental_data_for_chain("tron", "v2") }}
+)
+,    market_metrics as ({{ get_coingecko_metrics("tron") }})
+,    defillama_data as ({{ get_defillama_metrics("tron") }})
+,    stablecoin_data as ({{ get_stablecoin_metrics("tron") }})
+,    github_data as ({{ get_github_metrics("tron") }})
+,    p2p_metrics as ({{ get_p2p_metrics("tron") }})
+,    rolling_metrics as ({{ get_rolling_active_address_metrics("tron") }})
+,    token_incentives as (
+    select 
+        date,
+        sum(token_incentives) as token_incentives,
+    from {{ ref("fact_tron_token_incentives") }}
+    group by date
+)
+
 select
     coalesce(
         fundamental_data.date,
-        price_data.date,
+        market_metrics.date,
         defillama_data.date,
         stablecoin_data.date,
         github_data.date
     ) as date
     , 'tron' as chain
+
+    --Old Metrics needed for backwards compatibility
     , txns
     , dau
     , wau
@@ -37,16 +48,19 @@ select
     , avg_txn_fee
     , median_txn_fee
     , dex_volumes
+
     -- Standardized Metrics
-    -- Market Data Metrics
-    , price
-    , market_cap
-    , fdmc
-    , tvl
+
+    -- Market Metrics
+    , market_metrics.price
+    , market_metrics.market_cap
+    , market_metrics.fdmc
+    
     -- Chain Usage Metrics
     , dau AS chain_dau
     , wau AS chain_wau
     , mau AS chain_mau
+    , tvl
     , txns AS chain_txns
     , avg_txn_fee AS chain_avg_txn_fee
     , median_txn_fee AS chain_median_txn_fee
@@ -58,17 +72,21 @@ select
     , dex_volumes AS chain_spot_volume
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dex_volumes, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
+
     -- Cash Flow Metrics
     , fees as chain_fees
     , fees_native AS ecosystem_revenue_native
     , fees AS ecosystem_revenue
     , fees_native AS burned_cash_flow_native
     , fees AS burned_cash_flow
+    , token_incentives.token_incentives 
+
     -- Developer Metrics
     , weekly_commits_core_ecosystem
     , weekly_commits_sub_ecosystem
     , weekly_developers_core_ecosystem
     , weekly_developers_sub_ecosystem
+
     -- Stablecoin Metrics
     , stablecoin_total_supply
     , stablecoin_txns
@@ -86,10 +104,11 @@ select
     , p2p_stablecoin_mau
     , stablecoin_data.p2p_stablecoin_transfer_volume
 from fundamental_data
-left join price_data on fundamental_data.date = price_data.date
+left join market_metrics on fundamental_data.date = market_metrics.date
 left join defillama_data on fundamental_data.date = defillama_data.date
 left join stablecoin_data on fundamental_data.date = stablecoin_data.date
 left join github_data on fundamental_data.date = github_data.date
 left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
+left join token_incentives on fundamental_data.date = token_incentives.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/tron/__tron__sources.yml
+++ b/models/staging/tron/__tron__sources.yml
@@ -5,3 +5,16 @@ sources:
     tables:
       - name: raw_tron_erc20_transfer_logs
       - name: raw_tron_erc20_transfer_decoded_logs
+
+  - name: TRON_ALLIUM
+    schema: raw
+    database: TRON_ALLIUM
+    tables:
+      - name: blocks
+      - name: transactions
+
+  - name: TRON_ALLIUM_ASSETS
+    schema: assets
+    database: TRON_ALLIUM
+    tables:
+      - name: trx_token_transfers

--- a/models/staging/tron/fact_tron_token_incentives.sql
+++ b/models/staging/tron/fact_tron_token_incentives.sql
@@ -1,0 +1,75 @@
+{{
+    config(
+        materialized="incremental",
+        snowflake_warehouse="ANALYTICS_XL",
+        unique_key=["date", "incentive_type"],
+    )
+}}
+
+--QUERY
+
+-- Takes 12 min to run 2 month historic data on warehouse ANALYTICS_XL
+with block_rewards as (
+    select
+        b.timestamp,
+        b.timestamp::date as date,
+        b.number,
+        b.hash,
+        b.miner,
+        b.gas_used,
+        16 as block_rewards_trx,
+        160 as voting_rewards_trx,
+        MAX(t.usd_exchange_rate) as max_usd_exchange_rate,
+        b.gas_used / POW(10, 6) * MAX(t.usd_exchange_rate) as block_creation_fee,
+        block_rewards_trx * AVG(t.usd_exchange_rate) as block_rewards --https://www.findas.org/tokenomics-review/coins/the-tokenomics-of-tron-trx/r/3cDzc5MHjcKZKSnt6hkBje
+    from {{ source('TRON_ALLIUM', 'blocks') }} b
+    left join {{ source('TRON_ALLIUM_ASSETS', 'trx_token_transfers') }} t
+        on DATE_TRUNC('hour', t.block_timestamp) = DATE_TRUNC('hour', b.timestamp)
+    {% if is_incremental() %}
+        where b.timestamp::date >= (select dateadd('day', -3, max(date)) from {{ this }})
+    {% endif %}
+    group by b.number, b.timestamp, b.hash, b.miner, b.gas_used
+)
+, daily_trx_price as (
+    select
+        date_trunc('hour', block_timestamp) as hour,
+        AVG(usd_exchange_rate) as price
+    from {{ source('TRON_ALLIUM_ASSETS', 'trx_token_transfers') }}
+    {% if is_incremental() %}
+        where block_timestamp::date >= (select dateadd('day', -3, max(date)) from {{ this }})
+    {% endif %}
+    group by hour
+)
+, bandwidth_fees as (
+    select
+        tx.block_timestamp as block_timestamp,
+        tx.block_timestamp::date as date,
+        tx.hash,
+        tx.gas,
+        tx.gas_price,
+        (tx.gas * tx.gas_price) / 1e6  as transaction_fee,
+        ((tx.gas * tx.gas_price) / 1e6) * (t.price)  as transaction_fee_usd,
+    from {{ source('TRON_ALLIUM', 'transactions') }} tx
+    left join daily_trx_price t
+        on t.hour = DATE_TRUNC('hour', tx.block_timestamp)
+    {% if is_incremental() %}
+        where tx.block_timestamp::date >= (select dateadd('day', -3, max(date)) from {{ this }})
+    {% endif %}
+)  
+
+select
+    date,
+    'bandwidth_fees' as incentive_type,
+    sum(transaction_fee_usd) as token_incentives
+from bandwidth_fees
+
+group by date
+
+union all 
+
+select
+    date,
+    'block_rewards' as incentive_type,
+    sum(block_rewards)
+from block_rewards
+group by date


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- [n/a] Added a database and warehouse
- [n/a] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [x] `ez_metrics` column names adhere to naming convention
- [n/a] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [n/a] Running all new models, and all downstream models compiles
- [x] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist: CAD work in progress

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below
![Screenshot 2025-06-03 at 9 24 48 AM](https://github.com/user-attachments/assets/d7936f65-ebbe-4fef-97ef-61c809bfed18)

## Key Notes:
- token_incentives has been added to ez_tron_metrics. Since chains don't have. by_chain tables, I'm assuming that token_incentives will be pulled to the front-end regardless as the ez_tron_metrics table does have a 'chain' field. (also going to look into the Goku adaptor set-up to determine this. If not, we'll likely have to add a new metric for L1L2 token incentives which are by day, not chain.
- CAD is a work-in-progress for methodology documentation. Will update the PR once CAD is complete.
