### PR TITLE
Add REV and average spend per wallet for Solana

### DIFF
--- a/models/projects/solana/core/ez_solana_metrics_by_application_v2.sql
+++ b/models/projects/solana/core/ez_solana_metrics_by_application_v2.sql
@@ -49,6 +49,8 @@ with
             max(category) category,
             sum(case when index = 0 then tx_fee else 0 end) gas,
             sum(case when index = 0 then gas_usd else 0 end) gas_usd,
+            sum(case when index = 0 then tx_fee + jito_tips else 0 end) rev,
+            sum(case when index = 0 then gas_usd + jito_tips_usd else 0 end) rev_usd,
             count_if(index = 0 and succeeded = 'TRUE') as txns,
             count(distinct(case when succeeded = 'TRUE' then value else null end)) dau
         from {{ ref('fact_solana_transactions_v2') }}, lateral flatten(input => signers)
@@ -62,7 +64,17 @@ select
     friendly_name,
     case when category = 'Tokens' then 'Token' else category end as category,
     gas,
+    CASE 
+        WHEN gas = 0 OR gas IS NULL THEN NULL
+        ELSE dau / gas
+    END AS avg_gas_per_address,
     gas_usd,
+    CASE 
+        WHEN gas_usd = 0 OR gas_usd IS NULL THEN NULL
+        ELSE dau / gas_usd
+    END AS avg_gas_usd_per_address,
+    rev,
+    rev_usd,
     txns,
     dau,
     null AS contract_count,

--- a/models/projects/solana/core/ez_solana_metrics_by_category_v2.sql
+++ b/models/projects/solana/core/ez_solana_metrics_by_category_v2.sql
@@ -54,6 +54,8 @@ with
             end as updated_category,
             sum(case when index = 0 then tx_fee else 0 end) gas,
             sum(case when index = 0 then gas_usd else 0 end) gas_usd,
+            sum(case when index = 0 then tx_fee + jito_tips else 0 end) rev,
+            sum(case when index = 0 then gas_usd + jito_tips_usd else 0 end) rev_usd,
             count_if(index = 0 and succeeded = 'TRUE') as txns,
             count(distinct(case when succeeded = 'TRUE' then value else null end)) dau
         from {{ ref('fact_solana_transactions_v2') }}, lateral flatten(input => signers)
@@ -64,7 +66,17 @@ select
     ifnull(agg_data.updated_category, 'Unlabeled') as category,
     agg_data.chain,
     gas,
+    CASE 
+        WHEN gas = 0 OR gas IS NULL THEN NULL
+        ELSE dau / gas
+    END AS avg_gas_per_address,
     gas_usd,
+    CASE 
+        WHEN gas_usd = 0 OR gas_usd IS NULL THEN NULL
+        ELSE dau / gas_usd
+    END AS avg_gas_usd_per_address,
+    rev,
+    rev_usd,
     txns,
     dau,
     null AS contract_count,

--- a/models/projects/solana/core/ez_solana_metrics_by_contract_v2.sql
+++ b/models/projects/solana/core/ez_solana_metrics_by_contract_v2.sql
@@ -19,6 +19,8 @@ with
             max(friendly_name) as friendly_name,
             sum(case when index = 0 then tx_fee else 0 end) gas,
             sum(case when index = 0 then gas_usd else 0 end) gas_usd,
+            sum(case when index = 0 then tx_fee + jito_tips else 0 end) rev,
+            sum(case when index = 0 then gas_usd + jito_tips_usd else 0 end) rev_usd,
             count_if(index = 0 and succeeded = 'TRUE') as txns,
             count(distinct(case when succeeded = 'TRUE' then value else null end)) dau,
             max(category) category
@@ -39,7 +41,17 @@ select
     friendly_name,
     case when category = 'Tokens' then 'Token' else category end as category,
     gas,
+    CASE 
+        WHEN gas = 0 OR gas IS NULL THEN NULL
+        ELSE dau / gas
+    END AS avg_gas_per_address,
     gas_usd,
+    CASE 
+        WHEN gas_usd = 0 OR gas_usd IS NULL THEN NULL
+        ELSE dau / gas_usd
+    END AS avg_gas_usd_per_address,
+    rev,
+    rev_usd,
     txns,
     dau,
     null AS real_users

--- a/models/projects/solana/core/ez_solana_metrics_by_subcategory.sql
+++ b/models/projects/solana/core/ez_solana_metrics_by_subcategory.sql
@@ -58,6 +58,8 @@ with
             sub_category,
             sum(case when index = 0 then tx_fee else 0 end) gas,
             sum(case when index = 0 then gas_usd else 0 end) gas_usd,
+            sum(case when index = 0 then tx_fee + jito_tips else 0 end) rev,
+            sum(case when index = 0 then gas_usd + jito_tips_usd else 0 end) rev_usd,
             count_if(index = 0 and succeeded = 'TRUE') as txns,
             count(distinct(case when succeeded = 'TRUE' then value else null end)) dau
         from {{ ref('fact_solana_transactions_v2') }}, lateral flatten(input => signers)
@@ -69,7 +71,17 @@ select
     ifnull(agg_data.sub_category, 'Unlabeled') as sub_category,
     agg_data.chain,
     gas,
+    CASE 
+        WHEN gas = 0 OR gas IS NULL THEN NULL
+        ELSE dau / gas
+    END AS avg_gas_per_address,
     gas_usd,
+    CASE 
+        WHEN gas_usd = 0 OR gas_usd IS NULL THEN NULL
+        ELSE dau / gas_usd
+    END AS avg_gas_usd_per_address,
+    rev,
+    rev_usd,
     txns,
     dau,
     null AS contract_count,

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -35,6 +35,37 @@ with
             >= (select dateadd('month', -1, max(block_timestamp)) from {{ this }})
         {% endif %}
     ),
+    incremental_solana_transfer_rows as (
+        select * from solana_flipside.core.fact_transfers
+        -- Chunking required here for backfills
+        {% if is_incremental() %}
+            where block_timestamp
+            >= (select dateadd('day', CASE WHEN DAYOFWEEK(CURRENT_DATE) = 7 THEN -90 ELSE -30 END, max(block_timestamp)) from {{ this }})
+        {% else %}
+        -- Making code not compile on purpose. Full refresh of entire history
+        -- takes too long, doing last month will wipe out backfill
+        -- TODO: Figure out a workaround.
+        and
+            block_timestamp
+            >= (select dateadd('month', -1, max(block_timestamp)) from {{ this }})
+        {% endif %}
+    ),
+    grouped_transfer_tips AS (
+        SELECT
+            tx_id,
+            sum(amount) AS amount
+        FROM incremental_solana_transfer_rows
+        WHERE tx_to IN ('96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5'
+                    ,'HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe'
+                    ,'Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY'
+                    ,'ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49'
+                    ,'DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh'
+                    ,'ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt'
+                    ,'DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL'
+                    ,'3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT')
+        and mint = 'So11111111111111111111111111111111111111111'
+        group by tx_id
+    ),
     solana_transfers as (
         select
             tx_id,
@@ -103,6 +134,8 @@ with
             'solana' as chain,
             fee / 1e9 as tx_fee,
             (fee / 1e9) * price as gas_usd,
+            grouped_transfer_tips.amount / 1e9 as jito_tips,
+            (grouped_transfer_tips.amount / 1e9) * price as jito_tips_usd,
             succeeded,
             case
                 when program_id = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
@@ -139,6 +172,7 @@ with
         left join app_contracts on lower(t.program_id) = lower(app_contracts.address)
         left join app_contracts as token on lower(token_address) = lower(token.address)
         left join collapsed_prices on raw_date = collapsed_prices.date
+        left join grouped_transfer_tips on t.tx_id = grouped_transfer_tips.tx_id
     )
 select
     tx_hash,
@@ -149,6 +183,8 @@ select
     max(chain) as chain,
     max(tx_fee) as tx_fee,
     max(gas_usd) as gas_usd,
+    max(jito_tips) as jito_tips,
+    max(jito_tips_usd) as jito_tips_usd,
     max(succeeded) as succeeded,
     max(token_address) as token_address,
     max(token_name) as token_name,


### PR DESCRIPTION
# Description

Add REV and average spend per wallet for Solana. Will continue to make changes to more models downstream once these run tonight.

# Tests

Currently running fact_solana_transactions_v2 locally