### PR TITLE
feature/optimism token_incentives

### DIFF
--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -40,6 +40,13 @@ with
         select date, adj_daus as adjusted_dau
         from {{ ref("ez_optimism_adjusted_dau") }}
     )
+    , token_incentives as (
+        select 
+            date, 
+            sum(token_incentives) as token_incentives
+        from {{ ref("fact_optimism_token_incentives") }}
+        group by 1
+    )
 
 select
     coalesce(
@@ -69,12 +76,15 @@ select
     , nft_trading_volume
     , dune_dex_volumes_optimism.dex_volumes
     , dune_dex_volumes_optimism.adjusted_dex_volumes
+
     -- Standardized Metrics
+
     -- Market Data Metrics
     , price
     , market_cap
     , fdmc
     , tvl
+
     -- Chain Usage Metrics
     , txns AS chain_txns
     , dau AS chain_dau
@@ -96,6 +106,7 @@ select
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dune_dex_volumes_optimism.dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
     , dune_dex_volumes_optimism.dex_volumes AS chain_spot_volume
+
     -- Cashflow Metrics
     , fees AS chain_fees
     , fees_native AS ecosystem_revenue_native
@@ -104,6 +115,8 @@ select
     , l1_data_cost AS l1_cash_flow
     , coalesce(fees_native, 0) - l1_data_cost_native as treasury_cash_flow_native
     , coalesce(fees, 0) - l1_data_cost as treasury_cash_flow
+    , token_incentives.token_incentives
+
     -- Developer Metrics
     , weekly_commits_core_ecosystem
     , weekly_commits_sub_ecosystem
@@ -111,6 +124,7 @@ select
     , weekly_developers_sub_ecosystem
     , weekly_contracts_deployed
     , weekly_contract_deployers
+
     -- Stablecoin metrics
     , stablecoin_total_supply
     , stablecoin_txns
@@ -127,9 +141,11 @@ select
     , p2p_stablecoin_dau
     , p2p_stablecoin_mau
     , stablecoin_data.p2p_stablecoin_transfer_volume
+
     -- Bridge Metrics
     , bridge_volume
     , bridge_daa
+
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date
@@ -144,4 +160,5 @@ left join bridge_volume_metrics on fundamental_data.date = bridge_volume_metrics
 left join bridge_daa_metrics on fundamental_data.date = bridge_daa_metrics.date
 left join optimism_dex_volumes as dune_dex_volumes_optimism on fundamental_data.date = dune_dex_volumes_optimism.date
 left join adjusted_dau_metrics on fundamental_data.date = adjusted_dau_metrics.date
+left join token_incentives on fundamental_data.date = token_incentives.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/optimism/__optimism__sources.yml
+++ b/models/staging/optimism/__optimism__sources.yml
@@ -12,3 +12,8 @@ sources:
       - name: raw_optimism_genesis_usdce_stablecoin_balances
       - name: raw_optimism_genesis_usdt_stablecoin_balances
       - name: raw_optimism_genesis_s_usd_stablecoin_balances
+  - name: OPTIMISM_FLIPSIDE
+    schema: core
+    database: OPTIMISM_FLIPSIDE
+    tables:
+      - name: ez_token_transfers

--- a/models/staging/optimism/fact_optimism_token_incentives.sql
+++ b/models/staging/optimism/fact_optimism_token_incentives.sql
@@ -1,0 +1,10 @@
+{{ config(materialized="table") }}
+
+select
+    block_timestamp::date as date,
+    sum(amount_usd) as token_incentives
+from {{ source("OPTIMISM_FLIPSIDE", "ez_token_transfers") }}
+where from_address = lower('0x2501c477d0a35545a387aa4a3eee4292a9a8b3f0')
+and contract_address = lower('0x4200000000000000000000000000000000000042')
+and amount_usd < 10000000
+group by date


### PR DESCRIPTION
Added:
- optimism token incentives model & metric in ez_metrics table

Validation:
![Screenshot 2025-06-05 at 9 47 10 AM](https://github.com/user-attachments/assets/07e02e7f-8b28-4889-8042-a8e8a0de9b51)

**Key Notes:**
- This is slightly DIFFERENT than TT's method. Our values correlate, but are not the same as you see in the picture. **Our method calculates all OP token outflows from the Optimism Foundation contract**, which is named the distributor of token incentives in Optimism documentation. 

Why different methologies?
- After spending ~2 days tracking down the smart contract architecture of OP token outflows and cross-referencing against developer docs / twitter posts (see Excalidraw), it's clear that continuing this goose chase is diminishing returns. Current best leads:
- Airdrops might be distributed from a different contract than the Optimism Foundation contract, and could be included in the TT calc (to be confirmed)
- 'Public goods funding' mechanism might be distributed outside of the Optimism Foundation contract

Excalidraw map: https://app.excalidraw.com/s/4Ds2B0Ir5qu/57l1DYJyd90

CAD: There's currently no CAD page Optimsm. Adding this as a TODO, and will transcribe the token incentives methodology as part of that work. The methodology differences of token incentives between Artemis & TT is explained above and will be transcribed in CAD soon