### PR TITLE
dataquality/vertex token_incentives

### DIFF
--- a/models/projects/vertex/core/ez_vertex_metrics.sql
+++ b/models/projects/vertex/core/ez_vertex_metrics.sql
@@ -51,7 +51,7 @@ select
     , unique_traders_data.unique_traders as perp_dau
 
     -- Cashflow Incentives
-    , token_incentives.token_incentives
+    , coalesce(token_incentives.token_incentives, 0) as token_incentives
 
     -- Turnover Metrics
     , market_metrics.token_turnover_circulating


### PR DESCRIPTION
Added:
- coalesce around vertex_token_incentives to flow data through present day on the front-end
- previously, the chart only showed data through the last non-null value. Now it should show through present day