### PR TITLE
Add BAM Datahub to DuckDB

### DIFF
--- a/iceberg/models/labels/fact_daily_bam_datahub_v2_iceberg.sql
+++ b/iceberg/models/labels/fact_daily_bam_datahub_v2_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="LABELS",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="fact_daily_bam_datahub_v2",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'chain, date'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE (date),
+    date::TIMESTAMP_NTZ(6) AS date
+FROM PC_DBT_DB.PROD.FACT_DAILY_BAM_DATAHUB_V2


### PR DESCRIPTION
# Description

We will be trying to move BAM Datahub from Postgres to DuckDB. This is the first part.

# Tests

Ran locally