### PR TITLE
Change to hyperliquid perps trading volume fact table

### DIFF
--- a/models/staging/hyperliquid/fact_hyperliquid_trading_volume.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_trading_volume.sql
@@ -18,13 +18,12 @@ with
         union all
 
         select
-            max(parse_json(source_json):daily_volume_total::double) as trading_volume
+            perps_trading_volume as trading_volume
             , null as market
-            , date(to_timestamp(parse_json(source_json):timestamp::number)) as date
-            , max(extraction_date) as extraction_date
-        from LANDING_DATABASE.PROD_LANDING.raw_hyperliquid_perps_trading_volume
-        where date(extraction_date) > '2025-05-24'
-        group by date(to_timestamp(parse_json(source_json):timestamp::number))
+            , date
+            , null as extraction_date
+        from {{ ref("fact_hyperliquid_perps_trading_volume") }}
+        where date > '2025-05-24'
     )
 select
     trading_volume


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
- Change from raw table to fact table as raw table has stale data
now trading_volume has the most updated data
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/318d0a90-9ce2-4298-b67a-1d902bfc2b91" />

ran dagster materialize on raw_hyperliquid_unique_traders and raw_hyperliquid_daily_transactions to get the most updated data from upstream provider -- `2025-06-08` (latest data)

ran all the downstream tables and now data is showing in the front-end
DAU
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/909ffd21-8b89-4c74-a6b9-4c29f3961f32" />

Daily transactions
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/5626ae11-3301-49f1-a329-d889b4acebee" />

- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below

ran RETL 
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/52abe80f-298d-468c-8fdd-9763a4537f85" />

## Other

- [ ] Any other relevant information that may be helpful