### PR TITLE
dataquality/stellar revenue metric added

### DIFF
--- a/models/projects/stellar/core/ez_stellar_metrics.sql
+++ b/models/projects/stellar/core/ez_stellar_metrics.sql
@@ -42,12 +42,15 @@ select
     , fundamental_data.ledgers_closed as ledgers_closed
     , stablecoin_tvl.stablecoin_mc
     , rwa_tvl.rwa_tvl
+
     -- Standardized Metrics
+
     -- Market Data
     , price_data.price
     , price_data.market_cap
     , price_data.fdmc
     , price_data.token_volume
+
     -- Chain Metrics
     , txns as chain_txns
     , dau as chain_dau
@@ -59,11 +62,17 @@ select
     , null as high_sleep_users
     , null as sybil_users
     , null as non_sybil_users
+
     -- Cash Flow Metrics
     , fees as ecosystem_revenue
     , fees_native as ecosystem_revenue_native
+
+    -- Financial Statement Metrics
+    , fees as revenue
+
     -- Real World Asset Metrics
     , rwa_tvl as tokenized_market_cap
+
     -- Stablecoin Metrics
     , stablecoin_mc as stablecoin_total_supply
     , price_data.token_turnover_circulating


### PR DESCRIPTION
Added:
- revenue metric to ez_table which is 100% of fees, this is required metric as we vet stellar for the issued supply project

Validation: 
- https://stellar.org/blog/developers/transaction-submission-timeouts-and-dynamic-fees-faq
- ![Screenshot 2025-06-10 at 3 40 02 PM](https://github.com/user-attachments/assets/f5458350-bf82-4a6b-9bb6-4dde4f009ef7)

*Transaction fees are effectively burned. This can possibly change in the future, but would require public support by XLM holders (?) and network validators.
