### PR TITLE
Deprecate old dydx endpoint and use new endpoint

### DIFF
--- a/models/projects/dydx/core/ez_dydx_metrics.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics.sql
@@ -14,34 +14,38 @@ WITH
         SELECT * 
         FROM {{ ref('dim_date_spine') }}
         WHERE date BETWEEN '2020-09-20' AND TO_DATE(SYSDATE())
-    ),
-    trading_volume_data_v4 as (
+    )
+    , trading_volume_data_v4 as (
         select date, trading_volume
         from {{ ref("fact_dydx_v4_trading_volume") }}
-    ),
-    fees_data_v4 as (
+    )
+    , fees_data_v4 as (
         select date, maker_fees, taker_fees, fees
         from {{ ref("fact_dydx_v4_fees") }}
-    ),
-    chain_data_v4 as (
-        select date, txn_fees, 
-        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
-    ),
-    unique_traders_data_v4 as (
+    )
+    , chain_data_v4 as (
+        select date, maker_fees, maker_rebates, txn_fees
+        from {{ ref("fact_dydx_v4_txn_fees") }}
+    )
+    , trading_fees_v4 as (
+        select date, total_fees
+        from {{ ref("fact_dydx_v4_trading_fees") }}
+    )
+    , unique_traders_data_v4 as (
         select date, unique_traders
         from {{ ref("fact_dydx_v4_unique_traders") }}
-    ),
-    trading_volume_data as (
+    )
+    , trading_volume_data as (
         select date, trading_volume
         from {{ ref("fact_dydx_trading_volume") }}
         where market_pair is null
-    ),
-    unique_traders_data as (
+    )
+    , unique_traders_data as (
         select date, unique_traders
         from {{ ref("fact_dydx_unique_traders") }}
         where unique_traders < 1e5
-    ), 
-    dydx_supply_data AS (
+    )
+    , dydx_supply_data AS (
         SELECT
             date
             , premine_unlocks_native

--- a/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
@@ -12,25 +12,29 @@ with
     trading_volume_data_v4 as (
         select date, trading_volume
         from {{ ref("fact_dydx_v4_trading_volume") }}
-    ),
-    fees_data_v4 as (
+    )
+    , fees_data_v4 as (
         select date, maker_fees, taker_fees, fees
         from {{ ref("fact_dydx_v4_fees") }}
-    ),
-    chain_data_v4 as (
-        select date, trading_fees, txn_fees
-        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
-    ),
-    unique_traders_data_v4 as (
+    )
+    , chain_data_v4 as (
+        select date, maker_fees, maker_rebates, txn_fees
+        from {{ ref("fact_dydx_v4_txn_fees") }}
+    )
+    , trading_fees_v4 as (
+        select date, total_fees
+        from {{ ref("fact_dydx_v4_trading_fees") }}
+    )
+    , unique_traders_data_v4 as (
         select date, unique_traders
         from {{ ref("fact_dydx_v4_unique_traders") }}
-    ),
-    trading_volume_data as (
+    )
+    , trading_volume_data as (
         select date, trading_volume
         from {{ ref("fact_dydx_trading_volume") }}
         where market_pair is null
-    ),
-    unique_traders_data as (
+    )
+    , unique_traders_data as (
         select date, unique_traders
         from {{ ref("fact_dydx_unique_traders") }}
     )
@@ -43,7 +47,6 @@ select
     , trading_volume_data.trading_volume
     , unique_traders_data.unique_traders
     , NULL as txn_fees
-    , NULL AS trading_fees
     -- standardize metrics
     , trading_volume_data.trading_volume as perp_volume
     , unique_traders_data.unique_traders as perp_dau
@@ -58,7 +61,6 @@ select
     , trading_volume
     , unique_traders
     , txn_fees
-    , trading_fees
     -- standardize metrics
     , trading_volume as perp_volume
     , unique_traders as perp_dau

--- a/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics_by_chain.sql
@@ -47,6 +47,7 @@ select
     , trading_volume_data.trading_volume
     , unique_traders_data.unique_traders
     , NULL as txn_fees
+    , NULL as trading_fees
     -- standardize metrics
     , trading_volume_data.trading_volume as perp_volume
     , unique_traders_data.unique_traders as perp_dau
@@ -61,6 +62,7 @@ select
     , trading_volume
     , unique_traders
     , txn_fees
+    , total_fees as trading_fees
     -- standardize metrics
     , trading_volume as perp_volume
     , unique_traders as perp_dau
@@ -68,4 +70,5 @@ from trading_volume_data_v4
 left join fees_data_v4 on trading_volume_data_v4.date = fees_data_v4.date
 left join chain_data_v4 on trading_volume_data_v4.date = chain_data_v4.date
 left join unique_traders_data_v4 on trading_volume_data_v4.date = unique_traders_data_v4.date
+left join trading_fees_v4 on trading_volume_data_v4.date = trading_fees_v4.date
 where unique_traders_data_v4.date < to_date(sysdate())

--- a/models/projects/dydx/core/ez_dydx_metrics_by_version.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics_by_version.sql
@@ -12,25 +12,29 @@ with
     trading_volume_data_v4 as (
         select date, trading_volume
         from {{ ref("fact_dydx_v4_trading_volume") }}
-    ),
-    fees_data_v4 as (
+    )
+    , fees_data_v4 as (
         select date, fees
         from {{ ref("fact_dydx_v4_fees") }}
-    ),
-    chain_data_v4 as (
-        select date, txn_fees
-        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
-    ),
-    unique_traders_data_v4 as (
+    )
+    , chain_data_v4 as (
+        select date, maker_fees, maker_rebates, txn_fees
+        from {{ ref("fact_dydx_v4_txn_fees") }}
+    )
+    , trading_fees_v4 as (
+        select date, total_fees
+        from {{ ref("fact_dydx_v4_trading_fees") }}
+    )
+    , unique_traders_data_v4 as (
         select date, unique_traders
         from {{ ref("fact_dydx_v4_unique_traders") }}
-    ),
-    trading_volume_data as (
+    )
+    , trading_volume_data as (
         select date, trading_volume
         from {{ ref("fact_dydx_trading_volume") }}
         where market_pair is null
-    ),
-    unique_traders_data as (
+    )
+    ,unique_traders_data as (
         select date, unique_traders
         from {{ ref("fact_dydx_unique_traders") }}
     )

--- a/models/projects/dydx_v4/core/ez_dydx_v4_metrics.sql
+++ b/models/projects/dydx_v4/core/ez_dydx_v4_metrics.sql
@@ -12,16 +12,20 @@ with
     trading_volume_data as (
         select date, trading_volume
         from {{ ref("fact_dydx_v4_trading_volume") }}
-    ),
-    fees_data as (
+    )
+    , fees_data as (
         select date, maker_fees, taker_fees, fees
         from {{ ref("fact_dydx_v4_fees") }}
-    ),
-    chain_data as (
-        select date, trading_fees, txn_fees
-        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
-    ),
-    unique_traders_data as (
+    )
+    , chain_data as (
+        select date, maker_fees, maker_rebates, txn_fees
+        from {{ ref("fact_dydx_v4_txn_fees") }}
+    )
+    , trading_fees as (
+        select date, total_fees
+        from {{ ref("fact_dydx_v4_trading_fees") }}
+    )
+    , unique_traders_data as (
         select date, unique_traders
         from {{ ref("fact_dydx_v4_unique_traders") }}
     )
@@ -32,10 +36,10 @@ select
     , 'DeFi' as category
     , trading_volume
     , unique_traders
-    , maker_fees
+    , fees_data.maker_fees
     , taker_fees
     , fees
-    , trading_fees -- Trading fees is maker_fees+taker_fees
+    , fees_data.maker_fees + fees_data.taker_fees as trading_fees -- Trading fees is maker_fees+taker_fees
     , txn_fees -- chain transaction fees (not really significant)
     -- standardize metrics
     , trading_volume as perp_volume

--- a/models/projects/dydx_v4/core/ez_dydx_v4_metrics_by_chain.sql
+++ b/models/projects/dydx_v4/core/ez_dydx_v4_metrics_by_chain.sql
@@ -12,16 +12,20 @@ with
     trading_volume_data as (
         select date, trading_volume
         from {{ ref("fact_dydx_v4_trading_volume") }}
-    ),
-    fees_data as (
+    )
+    , fees_data as (
         select date, maker_fees, taker_fees, fees
         from {{ ref("fact_dydx_v4_fees") }}
-    ),
-    chain_data as (
-        select date, trading_fees, txn_fees
-        from {{ ref("fact_dydx_v4_txn_and_trading_fees") }}
-    ),
-    unique_traders_data as (
+    )
+    , chain_data as (
+        select date, maker_fees, maker_rebates, txn_fees
+        from {{ ref("fact_dydx_v4_txn_fees") }}
+    )
+    , trading_fees as (
+        select date, total_fees
+        from {{ ref("fact_dydx_v4_trading_fees") }}
+    )
+    , unique_traders_data as (
         select date, unique_traders
         from {{ ref("fact_dydx_v4_unique_traders") }}
     )
@@ -33,10 +37,10 @@ select
     , 'dydx_v4' as chain
     , trading_volume
     , unique_traders
-    , maker_fees
+    , fees_data.maker_fees
     , taker_fees
     , fees
-    , trading_fees -- Trading fees is maker_fees+taker_fees
+    , total_fees as trading_fees -- Trading fees is maker_fees+taker_fees
     , txn_fees -- chain transaction fees (not really significant)
     -- standardize metrics
     , trading_volume as perp_volume
@@ -47,4 +51,5 @@ from trading_volume_data
 left join fees_data on trading_volume_data.date = fees_data.date
 left join chain_data on trading_volume_data.date = chain_data.date
 left join unique_traders_data on trading_volume_data.date = unique_traders_data.date
+left join trading_fees on trading_volume_data.date = trading_fees.date
 where unique_traders_data.date < to_date(sysdate())

--- a/models/staging/dydx/__dydx__sources.yml
+++ b/models/staging/dydx/__dydx__sources.yml
@@ -6,7 +6,8 @@ sources:
       - name: raw_dydx_trading_volume
       - name: raw_dydx_unique_traders
       - name: raw_dydx_v4_trading_volume
-      - name: raw_dydx_v4_txn_and_trading_fees
+      - name: raw_dydx_v4_txn_fees
+      - name: raw_dydx_v4_trading_fees
       - name: raw_dydx_v4_unique_traders
       - name: raw_dydx_v4_fees
       - name: raw_dydx_v4_perpetuals_markets_metadata

--- a/models/staging/dydx/_test_fact_dydx_v4_trading_fees.yml
+++ b/models/staging/dydx/_test_fact_dydx_v4_trading_fees.yml
@@ -1,0 +1,28 @@
+models:
+- name: fact_dydx_v4_trading_fees
+  tests:
+  - 'dbt_expectations.expect_table_row_count_to_be_between:':
+      min_value: 1
+      max_value: 1000000
+  columns:
+  - name: DATE
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+    - dbt_expectations.expect_row_values_to_have_recent_data:
+        datepart: day
+        interval: 3
+        severity: warn
+  - name: CHAIN
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: TOTAL_FEES
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: APP
+    tests:
+    - dbt_expectations.expect_column_to_exist
+  - name: CATEGORY
+    tests:
+    - dbt_expectations.expect_column_to_exist

--- a/models/staging/dydx/_test_fact_dydx_v4_txn_fees.yml
+++ b/models/staging/dydx/_test_fact_dydx_v4_txn_fees.yml
@@ -1,5 +1,5 @@
 models:
-- name: fact_dydx_v4_txn_and_trading_fees
+- name: fact_dydx_v4_txn_fees
   tests:
   - 'dbt_expectations.expect_table_row_count_to_be_between:':
       min_value: 1
@@ -20,7 +20,11 @@ models:
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist
-  - name: TRADING_FEES
+  - name: MAKER_FEES
+    tests:
+    - not_null
+    - dbt_expectations.expect_column_to_exist
+  - name: MAKER_REBATES
     tests:
     - not_null
     - dbt_expectations.expect_column_to_exist

--- a/models/staging/dydx/fact_dydx_v4_trading_fees.sql
+++ b/models/staging/dydx/fact_dydx_v4_trading_fees.sql
@@ -1,0 +1,33 @@
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_dydx_v4_trading_fees") }}
+    ),
+    latest_data as (
+        select parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_dydx_v4_trading_fees") }}
+        where extraction_date = (select max_date from max_extraction)
+    ),
+    flattened_data as (
+        select
+            parse_json(data):labels::timestamp_ntz as date,
+            parse_json(data):total_fees::float as total_fees,
+            'dydx_v4' as app,
+            'DeFi' as category,
+            'dydx_v4' as chain
+        from latest_data
+    ),
+    daily_data as (
+        select
+            date(date) as date,
+            sum(total_fees) as total_fees,
+            app,
+            category,
+            chain
+        from flattened_data
+        group by date(date), app, category, chain
+    )
+select date, total_fees, app, category, chain
+from daily_data
+where date < (select max(date) from daily_data)
+order by date desc

--- a/models/staging/dydx/fact_dydx_v4_txn_fees.sql
+++ b/models/staging/dydx/fact_dydx_v4_txn_fees.sql
@@ -1,18 +1,19 @@
 with
     max_extraction as (
         select max(extraction_date) as max_date
-        from {{ source("PROD_LANDING", "raw_dydx_v4_txn_and_trading_fees") }}
+        from {{ source("PROD_LANDING", "raw_dydx_v4_txn_fees") }}
     ),
     latest_data as (
         select parse_json(source_json) as data
-        from {{ source("PROD_LANDING", "raw_dydx_v4_txn_and_trading_fees") }}
+        from {{ source("PROD_LANDING", "raw_dydx_v4_txn_fees") }}
         where extraction_date = (select max_date from max_extraction)
     ),
     flattened_data as (
         select
             parse_json(data):labels::timestamp_ntz as date,
-            parse_json(data):trading_fees::float as trading_fees,
-            parse_json(data):tx_fees::float as txn_fees,
+            parse_json(data):maker_fees::float as maker_fees,
+            parse_json(data):maker_rebates::float as maker_rebates,
+            parse_json(data):txn_fees::float as txn_fees,
             'dydx_v4' as app,
             'DeFi' as category,
             'dydx_v4' as chain
@@ -21,7 +22,8 @@ with
     daily_data as (
         select
             date(date) as date,
-            sum(trading_fees) as trading_fees,
+            sum(maker_fees) as maker_fees,
+            sum(maker_rebates) as maker_rebates,
             sum(txn_fees) as txn_fees,
             app,
             category,
@@ -29,7 +31,7 @@ with
         from flattened_data
         group by date(date), app, category, chain
     )
-select date, trading_fees, txn_fees, app, category, chain
+select date, maker_fees, maker_rebates, txn_fees, app, category, chain
 from daily_data
 where date < (select max(date) from daily_data)
 order by date desc


### PR DESCRIPTION
## :pushpin: References

## 🎄 Asset Checklist

- [x] Added new `fact` tables if necessary
created `fact_dydx_v4_txn_fees`
`txn_fees`
<img width="1526" alt="image" src="https://github.com/user-attachments/assets/40ee629f-4a8a-411f-a9ae-50833a977053" />

and `fact_dydx_v4_trading_fees`
`total_fees` = `trading_fees`
<img width="1525" alt="image" src="https://github.com/user-attachments/assets/a5818e1c-0edc-4338-b422-aaf003f28e2d" />

updated the formatting for the ez_tables

created the test yml files as well

- [ ] Added a database and warehouse
- [ ] Added an `ez_metrics` and `ez_metrics_by_chain` model
- [ ] `ez_metrics` column names adhere to naming convention
- [ ] `ez_metrics_by_chain` column names adhere to naming convention

## 🧮 Final Checklist

- [ ] Running all new models, and all downstream models compiles
- [ ] Data in Snowflake matches expectations for what metric value should be

## 📚 Documentation Checklist

- [ ] Added clear asset and metric documentation to CAD
- [ ] Added metric definitions to Terminal (if applicable)
- [ ] Added references to metric sources to CAD

## 📚 Testing Checklist

- [x] Add any relevant data screenshots below
ran RETL for dydx_v4
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/974a6469-82df-4da9-b74a-c1c654aeeaf8" />

ran RETL for dydx
![image](https://github.com/user-attachments/assets/f2ddfc19-92e3-4b45-b256-ae296c3e620e)


## Other

- [ ] Any other relevant information that may be helpful