### PR TITLE
Fix solana transactions table and increase to 13 month lookback for app retention

### DIFF
--- a/models/projects/solana/core/ez_solana_app_retention_metrics.sql
+++ b/models/projects/solana/core/ez_solana_app_retention_metrics.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         materialized="table",
-        snowflake_warehouse="solana_2xlg",
+        snowflake_warehouse="solana_xlg",
         database="solana",
         schema="core",
         alias="ez_app_cohort_retention",

--- a/models/projects/solana/core/ez_solana_app_retention_metrics.sql
+++ b/models/projects/solana/core/ez_solana_app_retention_metrics.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         materialized="table",
-        snowflake_warehouse="solana_xlg",
+        snowflake_warehouse="solana_2xlg",
         database="solana",
         schema="core",
         alias="ez_app_cohort_retention",
@@ -17,7 +17,7 @@ with solana_table as (
       {{ ref("fact_solana_transactions_v2") }},
       LATERAL FLATTEN(input => signers)
     WHERE
-      raw_date >= DATEADD(month, -12, to_date(sysdate()))
+      raw_date >= DATEADD(month, -13, to_date(sysdate()))
       and succeeded = 'TRUE'
       AND value IS NOT NULL
 ), apps_to_cover as (

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -32,7 +32,7 @@ with
         -- TODO: Figure out a workaround.
         and
             block_timestamp
-            >= (select dateadd('month', -1, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('month', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
     ),
     incremental_solana_transfer_rows as (
@@ -47,7 +47,7 @@ with
         -- TODO: Figure out a workaround.
         and
             block_timestamp
-            >= (select dateadd('month', -1, max(block_timestamp)) from {{ this }})
+            >= (select dateadd('month', -3, max(block_timestamp)) from {{ this }})
         {% endif %}
     ),
     grouped_transfer_tips AS (


### PR DESCRIPTION
# Description

Fix solana transactions table. It wasn't actually running for the past 90 days every Saturday.

Increase to 13 month lookback for app retention. That way, we get month 0 and then 12 months of lookback instead of month 0 and only 11 months of lookback.

# Tests

Running locally