### PR TITLE
Add blob fees to ethereum fees and revenue

### DIFF
--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -69,11 +69,11 @@ select
     , wau
     , mau
     , fees_native
-    , case when fees is null then fees_native * price else fees end as fees
+    , case when fees is null then (coalesce(blob_fees_native, 0) + fees_native) * price else fees + coalesce(blob_fees, 0) end as fees
     , avg_txn_fee
     , median_txn_fee
-    , revenue_native
-    , revenue
+    , revenue_native + coalesce(blob_fees_native, 0) as revenue_native
+    , revenue + coalesce(blob_fees, 0) as revenue
     , case
         when fees is null then (fees_native * price) - revenue else fees - revenue
     end as priority_fee_usd


### PR DESCRIPTION
Blob fees were previously excluded from fees and revenue for Ethereum due to them making up a negligible amount of both metrics. For both correctness and future proofing our data models, blob fees are being added to both metrics.

### Data Comparison

**Fees Before**
April '24 ~220.6m
![CleanShot 2025-06-12 at 01 34 49](https://github.com/user-attachments/assets/142d8800-0cc8-4223-8d0d-65974ee66efe)

**Fees After**
April '24 ~221.9m
![CleanShot 2025-06-12 at 01 35 51](https://github.com/user-attachments/assets/96074a5b-1e56-4f30-883c-fbed941c0594)

Difference is 1.3-1.4m

**Blob Fees**
April '24 ~1.4m
![CleanShot 2025-06-12 at 01 36 28](https://github.com/user-attachments/assets/a6e7ada2-ae5e-48be-a2e4-81a5565aa5c7)


**Revenue Before**
jan '25 ~113.5
![CleanShot 2025-06-12 at 01 37 19](https://github.com/user-attachments/assets/8755b787-eba4-4f6e-9515-cf19ae149ea6)

**Revenue After**
Jan '25 ~117m
![CleanShot 2025-06-12 at 01 38 04](https://github.com/user-attachments/assets/d5b116be-5665-4e29-b77f-24ae4d9fdf54)

Difference is ~3.5m

**Blob Fees**
Jan '25 ~3.5m
![CleanShot 2025-06-12 at 01 38 48](https://github.com/user-attachments/assets/9384d21f-2547-41dc-b909-6a2de41bb5c7)


Numbers check out!

model compiles
![CleanShot 2025-06-12 at 01 39 26@2x](https://github.com/user-attachments/assets/cab246c0-b38f-48f1-baab-5083556f4ff8)
