### PR TITLE
C911: update dune and maker models

### DIFF
--- a/macros/dune/clean_dune_events.sql
+++ b/macros/dune/clean_dune_events.sql
@@ -1,7 +1,7 @@
 {% macro clean_dune_evm_events(chain) %}
     select 
         block_number
-        , block_time::timestamp as block_timestamp
+        , CONVERT_TIMEZONE('America/Los_Angeles', 'UTC', block_time) as block_timestamp
         , tx_hash_hex as transaction_hash
         , tx_index as transaction_index
         , index as event_index


### PR DESCRIPTION
1. Dune timestamps were not being converted properly.
2. flipside deprecated a table effecting maker