### PR TITLE
Fix Solana transactions jito tips sig figs

### DIFF
--- a/models/staging/marinade/fact_marinade_v1_fees.sql
+++ b/models/staging/marinade/fact_marinade_v1_fees.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized="table",
-    snowflake_warehouse="MARINADE"
+    snowflake_warehouse="MARINADE_LG"
 ) }}
 
 with marinade_unstake_txns as (

--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -134,8 +134,8 @@ with
             'solana' as chain,
             fee / 1e9 as tx_fee,
             (fee / 1e9) * price as gas_usd,
-            grouped_transfer_tips.amount / 1e9 as jito_tips,
-            (grouped_transfer_tips.amount / 1e9) * price as jito_tips_usd,
+            grouped_transfer_tips.amount as jito_tips,
+            (grouped_transfer_tips.amount * price) as jito_tips_usd,
             succeeded,
             case
                 when program_id = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'


### PR DESCRIPTION
# Description

Realized that we don't need to divide by 1e9 for Solana transfer amounts.

# Tests

Ran locally