### PR TITLE
dbt/Sector Metrics Migration

### DIFF
--- a/models/projects/bedrock/core/ez_bedrock_metrics.sql
+++ b/models/projects/bedrock/core/ez_bedrock_metrics.sql
@@ -40,9 +40,11 @@ select
 
     -- Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
     -- Market Metrics
     , market_metrics.price as price

--- a/models/projects/bedrock/core/ez_bedrock_metrics_by_chain.sql
+++ b/models/projects/bedrock/core/ez_bedrock_metrics_by_chain.sql
@@ -39,9 +39,11 @@ select
 
     -- Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 from date_spine
 left join restaked_eth_metrics using(date)
 where date_spine.date < to_date(sysdate())

--- a/models/projects/bsc/core/ez_bsc_metrics.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics.sql
@@ -116,4 +116,5 @@ left join contract_data on fundamental_data.date = contract_data.date
 left join nft_metrics on fundamental_data.date = nft_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join binance_dex_volumes as dune_dex_volumes_binance on fundamental_data.date = dune_dex_volumes_binance.date
+left join staked_eth_metrics on fundamental_data.date = staked_eth_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/bsc/core/ez_bsc_metrics.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics.sql
@@ -22,6 +22,16 @@ with
         select date, daily_volume as dex_volumes, daily_volume_adjusted as adjusted_dex_volumes
         from {{ ref("fact_binance_daily_dex_volumes") }}
     )
+    , staked_eth_metrics as (
+        select
+            date,
+            sum(num_staked_eth) as num_staked_eth,
+            sum(amount_staked_usd) as amount_staked_usd,
+            sum(num_staked_eth_net_change) as num_staked_eth_net_change,
+            sum(amount_staked_usd_net_change) as amount_staked_usd_net_change
+        from {{ ref('fact_binance_staked_eth_count_with_usd_and_change') }}
+        group by 1
+    )
 select
     fundamental_data.date
     , fundamental_data.chain
@@ -61,6 +71,13 @@ select
     , dau_over_100 AS dau_over_100_balance
     , nft_trading_volume AS chain_nft_trading_volume
     , dune_dex_volumes_binance.dex_volumes AS chain_spot_volume
+
+    -- LST Metrics
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+
     -- Cashflow metrics
     , fees as chain_fees
     , fees_native AS ecosystem_revenue_native

--- a/models/projects/bsc/core/ez_bsc_metrics_by_chain.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics_by_chain.sql
@@ -28,5 +28,13 @@ select
     staked_eth_metrics.amount_staked_usd,
     staked_eth_metrics.num_staked_eth_net_change,
     staked_eth_metrics.amount_staked_usd_net_change
+
+    -- Standardized Metrics
+    -- Usage Metrics
+    , COALESCE(staked_eth_metrics.num_staked_eth, 0) as lst_tvl_native
+    , COALESCE(staked_eth_metrics.num_staked_eth, 0) as tvl_native
+    , COALESCE(staked_eth_metrics.amount_staked_usd, 0) as lst_tvl
+    , COALESCE(staked_eth_metrics.num_staked_eth_net_change, 0) as lst_tvl_native_net_change
+    , COALESCE(staked_eth_metrics.num_staked_eth_net_change, 0) as tvl_native_net_change
 from staked_eth_metrics
 where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/coinbase/core/ez_coinbase_metrics.sql
+++ b/models/projects/coinbase/core/ez_coinbase_metrics.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="COINBASE",
+        database="coinbase",
+        schema="core",
+        alias="ez_metrics",
+    )
+}}
+
+with
+    staked_eth_metrics as (
+        select
+            date,
+            sum(num_staked_eth) as num_staked_eth,
+            sum(amount_staked_usd) as amount_staked_usd,
+            sum(num_staked_eth_net_change) as num_staked_eth_net_change,
+            sum(amount_staked_usd_net_change) as amount_staked_usd_net_change
+        from {{ ref('fact_coinbase_staked_eth_count_with_usd_and_change') }}
+        GROUP BY 1
+    )
+select
+    staked_eth_metrics.date,
+    'coinbase' as app,
+    'DeFi' as category,
+    staked_eth_metrics.num_staked_eth,
+    staked_eth_metrics.amount_staked_usd,
+    staked_eth_metrics.num_staked_eth_net_change,
+    staked_eth_metrics.amount_staked_usd_net_change
+
+    -- Standardized Metrics
+    , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.amount_staked_usd as tvl
+    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as tvl_net_change
+from staked_eth_metrics
+where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/coinbase/core/ez_coinbase_metrics.sql
+++ b/models/projects/coinbase/core/ez_coinbase_metrics.sql
@@ -29,9 +29,9 @@ select
     staked_eth_metrics.amount_staked_usd_net_change
 
     -- Standardized Metrics
-    , staked_eth_metrics.num_staked_eth as tvl_native
-    , staked_eth_metrics.amount_staked_usd as tvl
-    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
-    , staked_eth_metrics.amount_staked_usd_net_change as tvl_net_change
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
 from staked_eth_metrics
 where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/coinbase/core/ez_coinbase_metrics_by_chain.sql
+++ b/models/projects/coinbase/core/ez_coinbase_metrics_by_chain.sql
@@ -28,5 +28,11 @@ select
     staked_eth_metrics.amount_staked_usd,
     staked_eth_metrics.num_staked_eth_net_change,
     staked_eth_metrics.amount_staked_usd_net_change
+
+    -- Standardized Metrics
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
 from staked_eth_metrics
 where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/drift/core/ez_drift_metrics.sql
+++ b/models/projects/drift/core/ez_drift_metrics.sql
@@ -13,7 +13,7 @@ WITH parsed_log_metrics AS (
         SUM(IFF(market_type = 1, total_taker_fee, 0)) AS perp_fees,
         SUM(IFF(market_type = 1, total_revenue, 0)) AS perp_revenue,
         SUM(IFF(market_type = 1, total_volume, 0)) AS perp_trading_volume,
-        SUM(IFF(market_type = 0, total_revenue, 0)) AS spot_fees,
+        SUM(IFF(market_type = 0, IFF(total_revenue < 0, 0, total_revenue), 0)) AS spot_fees,
         SUM(IFF(market_type = 0, total_taker_fee, 0)) AS spot_revenue,
         SUM(IFF(market_type = 0, total_volume, 0)) AS spot_trading_volume
     FROM {{ ref("fact_drift_parsed_logs") }}

--- a/models/projects/eigenpie/core/ez_eigenpie_metrics.sql
+++ b/models/projects/eigenpie/core/ez_eigenpie_metrics.sql
@@ -40,9 +40,11 @@ select
 
     -- Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
     -- Market Metrics
     , market_metrics.price as price

--- a/models/projects/eigenpie/core/ez_eigenpie_metrics_by_chain.sql
+++ b/models/projects/eigenpie/core/ez_eigenpie_metrics_by_chain.sql
@@ -39,9 +39,11 @@ select
 
     -- Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
 from date_spine
 left join restaked_eth_metrics using(date)

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -84,6 +84,7 @@ select
     , percent_non_censored
     , dune_dex_volumes_ethereum.dex_volumes
     , dune_dex_volumes_ethereum.adjusted_dex_volumes
+    , submitters
     -- Standardized Metrics
     -- Market Data Metrics
     , price
@@ -129,7 +130,7 @@ select
     , avg_mib_per_second
     , avg_cost_per_mib_gwei
     , avg_cost_per_mib
-    , submitters
+    , submitters as da_dau
     , dune_dex_volumes_ethereum.dex_volumes AS chain_spot_volume
     -- Cashflow metrics
     , fees as chain_fees

--- a/models/projects/etherfi/core/ez_etherfi_metrics.sql
+++ b/models/projects/etherfi/core/ez_etherfi_metrics.sql
@@ -73,9 +73,11 @@ SELECT
 
     --Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
     --Cash Flow Metrics
     , coalesce(liquidity_pool_fees.fees_usd, 0) as liquidity_pool_fees

--- a/models/projects/etherfi/core/ez_etherfi_metrics_by_chain.sql
+++ b/models/projects/etherfi/core/ez_etherfi_metrics_by_chain.sql
@@ -31,8 +31,10 @@ select
     
     --Standardized Metrics
     , num_restaked_eth as tvl_native
+    , num_restaked_eth as lrt_tvl_native
     , amount_restaked_usd as tvl
-    , num_restaked_eth_net_change as tvl_native_net_change
-    , amount_restaked_usd_net_change as tvl_net_change
+    , amount_restaked_usd as lrt_tvl
+    , num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , amount_restaked_usd_net_change as lrt_tvl_net_change
 from restaked_eth_metrics
 where restaked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/frax/core/ez_frax_metrics.sql
+++ b/models/projects/frax/core/ez_frax_metrics.sql
@@ -97,10 +97,10 @@ SELECT
     , dex_data.spot_dau as spot_dau
     , dex_data.spot_volume as spot_volume
     , fractal_l2_txns.l2_txns as chain_txns
-    , staked_eth_metrics.num_staked_eth as stake_tvl_native
-    , staked_eth_metrics.amount_staked_usd as stake_tvl
-    , staked_eth_metrics.num_staked_eth_net_change as stake_tvl_native_net_change
-    , staked_eth_metrics.amount_staked_usd_net_change as stake_tvl_net_change
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
     , tvl_data.tvl as spot_tvl
     , frax_daily_supply_data.frax_circulating_supply as stablecoin_total_supply
     , veFXS_daily_supply_data.circulating_supply as veFXS_total_supply

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -99,8 +99,9 @@ SELECT
     -- Usage Metrics
     , coalesce(tip_txns, 0) as block_infra_txns
     , coalesce(tip_dau, 0) as block_infra_dau
+    , coalesce(tvl, 0) as lst_tvl
     , coalesce(tvl, 0) as tvl
-    , coalesce(tvl_change, 0) as tvl_net_change
+    , coalesce(tvl_change, 0) as lst_tvl_net_change
 
     -- Cashflow Metrics
     , coalesce(withdraw_management_fees, 0) as lst_fees

--- a/models/projects/jito/core/ez_jito_metrics_by_chain.sql
+++ b/models/projects/jito/core/ez_jito_metrics_by_chain.sql
@@ -32,7 +32,8 @@ SELECT
     , coalesce(validator_fee_allocation, 0) as validator_fee_allocation
     , coalesce(block_infra_txns, 0) as block_infra_txns
     , coalesce(block_infra_dau, 0) as block_infra_dau
+    , coalesce(tvl, 0) as lst_tvl
     , coalesce(tvl, 0) as tvl
-    , coalesce(tvl_net_change, 0) as tvl_net_change
+    , coalesce(tvl_net_change, 0) as lst_tvl_net_change
 
 FROM {{ ref('ez_jito_metrics') }}

--- a/models/projects/jito/core/ez_jito_metrics_by_chain.sql
+++ b/models/projects/jito/core/ez_jito_metrics_by_chain.sql
@@ -34,6 +34,6 @@ SELECT
     , coalesce(block_infra_dau, 0) as block_infra_dau
     , coalesce(tvl, 0) as lst_tvl
     , coalesce(tvl, 0) as tvl
-    , coalesce(tvl_net_change, 0) as lst_tvl_net_change
+    , coalesce(tvl - lag(tvl) over (partition by chain order by date), 0) as lst_tvl_net_change
 
 FROM {{ ref('ez_jito_metrics') }}

--- a/models/projects/kelp_dao/core/ez_kelp_dao_metrics.sql
+++ b/models/projects/kelp_dao/core/ez_kelp_dao_metrics.sql
@@ -41,9 +41,11 @@ select
 
     --Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
     
 from date_spine
 left join restaked_eth_metrics using(date)

--- a/models/projects/kelp_dao/core/ez_kelp_dao_metrics_by_chain.sql
+++ b/models/projects/kelp_dao/core/ez_kelp_dao_metrics_by_chain.sql
@@ -39,9 +39,11 @@ select
 
     --Standardized Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 from date_spine
 left join restaked_eth_metrics using(date)
 where date_spine.date < to_date(sysdate())

--- a/models/projects/lido/core/ez_lido_metrics.sql
+++ b/models/projects/lido/core/ez_lido_metrics.sql
@@ -104,10 +104,12 @@ select
     , COALESCE(p.token_volume, 0) as token_volume
 
     --Usage Metrics
+    , COALESCE(s.amount_staked_usd, 0) as lst_tvl
     , COALESCE(s.amount_staked_usd, 0) as tvl
+    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
     , COALESCE(s.num_staked_eth, 0) as tvl_native
-    , COALESCE(s.amount_staked_usd_net_change, 0) as tvl_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as tvl_native_net_change
+    , COALESCE(s.amount_staked_usd_net_change, 0) as lst_tvl_net_change
+    , COALESCE(s.num_staked_eth_net_change, 0) as lst_tvl_native_net_change
 
     --Cash Flow Metrics
     , COALESCE(f.mev_priority_fees, 0) as mev_priority_fees

--- a/models/projects/lido/core/ez_lido_metrics_by_chain.sql
+++ b/models/projects/lido/core/ez_lido_metrics_by_chain.sql
@@ -101,10 +101,12 @@ select
     --Standardized Metrics
 
     --Usage Metrics
+    , COALESCE(s.amount_staked_usd, 0) as lst_tvl
+    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
     , COALESCE(s.amount_staked_usd, 0) as tvl
     , COALESCE(s.num_staked_eth, 0) as tvl_native
-    , COALESCE(s.amount_staked_usd_net_change, 0) as tvl_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as tvl_native_net_change
+    , COALESCE(s.amount_staked_usd_net_change, 0) as lst_tvl_net_change
+    , COALESCE(s.num_staked_eth_net_change, 0) as lst_tvl_native_net_change
 
     --Cash Flow Metrics
     , COALESCE(f.mev_priority_fees, 0) as mev_priority_fees

--- a/models/projects/lido/core/ez_lido_metrics_by_token.sql
+++ b/models/projects/lido/core/ez_lido_metrics_by_token.sql
@@ -100,6 +100,7 @@ SELECT
     --Standardized Metrics
 
     --Usage Metrics
+    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
     , COALESCE(s.num_staked_eth, 0) as tvl_native
 
     --Cash Flow Metrics

--- a/models/projects/mantle/core/ez_mantle_metrics.sql
+++ b/models/projects/mantle/core/ez_mantle_metrics.sql
@@ -128,4 +128,5 @@ left join expenses_data using (date)
 left join rolling_metrics using (date)
 left join treasury_data using (date)
 left join mantle_dex_volumes as dune_dex_volumes_mantle on fundamental_data.date = dune_dex_volumes_mantle.date
+left join staked_eth_metrics on fundamental_data.date = staked_eth_metrics.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/mantle/core/ez_mantle_metrics.sql
+++ b/models/projects/mantle/core/ez_mantle_metrics.sql
@@ -34,6 +34,15 @@ fundamental_data as ({{ get_fundamental_data_for_chain("mantle", "v2") }})
     select date, daily_volume as dex_volumes, daily_volume_adjusted as adjusted_dex_volumes
     from {{ ref("fact_mantle_daily_dex_volumes") }}
 )
+, staked_eth_metrics as (
+    select
+        date,
+        num_staked_eth,
+        amount_staked_usd,
+        num_staked_eth_net_change,
+        amount_staked_usd_net_change
+    from {{ ref('fact_meth_staked_eth_count_with_USD_and_change') }}
+)
 
 select
     fundamental_data.date
@@ -68,6 +77,15 @@ select
     , new_users
     , avg_txn_fee AS chain_avg_txn_fee
     , dune_dex_volumes_mantle.dex_volumes AS chain_spot_volume
+
+    -- LST Metrics
+    , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+
     -- Cashflow Metrics
     , fees as chain_fees
     , fees_native AS ecosystem_revenue_native

--- a/models/projects/mantle/core/ez_mantle_metrics_by_chain.sql
+++ b/models/projects/mantle/core/ez_mantle_metrics_by_chain.sql
@@ -28,5 +28,13 @@ select
     staked_eth_metrics.amount_staked_usd,
     staked_eth_metrics.num_staked_eth_net_change,
     staked_eth_metrics.amount_staked_usd_net_change
+
+    --Standardized Metrics
+    , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
 from staked_eth_metrics
 where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/marinade/core/ez_marinade_metrics.sql
+++ b/models/projects/marinade/core/ez_marinade_metrics.sql
@@ -89,7 +89,12 @@ select
 
     --Usage Metrics
     , tvl * price as tvl
+    , tvl * price as lst_tvl
     , tvl as tvl_native
+    , tvl as lst_tvl_native
+    , coalesce(tvl - lag(tvl) over (order by date), 0) as lst_tvl_net_change
+    , coalesce(tvl_native - lag(tvl_native) over (order by date), 0) as lst_tvl_native_net_change
+
     , dau as lst_dau
     , txns as lst_txns
     , liquid as tvl_liquid_stake

--- a/models/projects/marinade/core/ez_marinade_metrics_by_chain.sql
+++ b/models/projects/marinade/core/ez_marinade_metrics_by_chain.sql
@@ -83,11 +83,16 @@ select
 
     --Usage Metrics 
     , tvl * price as tvl
+    , tvl * price as lst_tvl
     , tvl as tvl_native
-    , dau as lst_dau
-    , txns as lst_txns
+    , tvl as lst_tvl_native
+    , coalesce(tvl - lag(tvl) over (order by date), 0) as lst_tvl_net_change
+    , coalesce(tvl_native - lag(tvl_native) over (order by date), 0) as lst_tvl_native_net_change
     , liquid as tvl_liquid_stake
     , native as tvl_native_stake
+
+    , dau as lst_dau
+    , txns as lst_txns
 
     --Cash Flow Metrics
     , unstaking_fees_native * price as unstaking_fees

--- a/models/projects/puffer_finance/core/ez_puffer_finance_metrics.sql
+++ b/models/projects/puffer_finance/core/ez_puffer_finance_metrics.sql
@@ -49,9 +49,11 @@ select
 
     --Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
     --Other Metrics
     , market_metrics.token_turnover_circulating as token_turnover_circulating

--- a/models/projects/puffer_finance/core/ez_puffer_finance_metrics_by_chain.sql
+++ b/models/projects/puffer_finance/core/ez_puffer_finance_metrics_by_chain.sql
@@ -40,9 +40,11 @@ select
 
     --Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 from date_spine
 left join restaked_eth_metrics using(date)
 where date_spine.date < to_date(sysdate())

--- a/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics.sql
+++ b/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics.sql
@@ -113,9 +113,11 @@ select
 
     --Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as tvl_native
+    , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as tvl
-    , restaked_eth_metrics.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
 
     --Other Metrics
     , market_metrics.token_turnover_circulating as token_turnover_circulating

--- a/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics_by_chain.sql
+++ b/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics_by_chain.sql
@@ -95,9 +95,11 @@ select
 
     --Usage Metrics
     , restaked_eth_metrics_by_chain.num_restaked_eth as tvl_native
+    , restaked_eth_metrics_by_chain.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics_by_chain.amount_restaked_usd as tvl
-    , restaked_eth_metrics_by_chain.num_restaked_eth_net_change as tvl_native_net_change
-    , restaked_eth_metrics_by_chain.amount_restaked_usd_net_change as tvl_net_change
+    , restaked_eth_metrics_by_chain.amount_restaked_usd as lrt_tvl
+    , restaked_eth_metrics_by_chain.num_restaked_eth_net_change as lrt_tvl_native_net_change
+    , restaked_eth_metrics_by_chain.amount_restaked_usd_net_change as lrt_tvl_net_change
 from date_spine
 left join restaked_eth_metrics_by_chain using(date)
 where date_spine.date < to_date(sysdate())

--- a/models/projects/rocketpool/core/ez_rocketpool_metrics.sql
+++ b/models/projects/rocketpool/core/ez_rocketpool_metrics.sql
@@ -108,9 +108,11 @@ select
 
     --Usage Metrics
     , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
     , staked_eth_metrics.amount_staked_usd as tvl
-    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
-    , staked_eth_metrics.amount_staked_usd_net_change as tvl_net_change
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
 
     --Cash Flow Metrics
     , COALESCE(f.cl_rewards_usd, 0) as block_rewards

--- a/models/projects/rocketpool/core/ez_rocketpool_metrics_by_chain.sql
+++ b/models/projects/rocketpool/core/ez_rocketpool_metrics_by_chain.sql
@@ -48,7 +48,9 @@ select
 
     --Usage Metrics
     , s.num_staked_eth as tvl_native
+    , s.num_staked_eth as lst_tvl_native
     , s.amount_staked_usd as tvl
+    , s.amount_staked_usd as lst_tvl
 
     --Cash Flow Metrics
     , COALESCE(cl_rewards_usd, 0) as block_rewards

--- a/models/projects/rocketpool/core/ez_rocketpool_metrics_by_token.sql
+++ b/models/projects/rocketpool/core/ez_rocketpool_metrics_by_token.sql
@@ -108,7 +108,9 @@ select
 
     --Usage Metrics
     , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
     , staked_eth_metrics.amount_staked_usd as tvl
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
 
     , COALESCE(f.cl_rewards_eth, 0) as block_rewards_native
     , COALESCE(f.el_rewards_eth, 0) as mev_priority_fees_native

--- a/models/projects/stader/core/ez_stader_metrics.sql
+++ b/models/projects/stader/core/ez_stader_metrics.sql
@@ -53,9 +53,11 @@ select
 
     --Standardized Metrics
     , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
     , staked_eth_metrics.amount_staked_usd as tvl
-    , staked_eth_metrics.num_staked_eth_net_change as tvl_native_net_change
-    , staked_eth_metrics.amount_staked_usd_net_change as tvl_net_change
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
 
     --Other Metrics
     , market_metrics.token_turnover_circulating

--- a/models/projects/stride/core/ez_stride_metrics.sql
+++ b/models/projects/stride/core/ez_stride_metrics.sql
@@ -54,6 +54,8 @@ select
     , fundamental_data.non_sybil_users as non_sybil_users
     , fundamental_data.tvl as tvl
     , fundamental_data.tvl_net_change as tvl_net_change
+    , fundamental_data.tvl as lst_tvl
+    , fundamental_data.tvl_net_change as lst_tvl_net_change
 
     --Cashflow Metrics
     , fundamental_data.fees_usd as chain_fees

--- a/models/projects/stride/core/ez_stride_metrics_by_chain.sql
+++ b/models/projects/stride/core/ez_stride_metrics_by_chain.sql
@@ -52,6 +52,8 @@ select
     , fundamental_data.new_users as chain_new_users
     , fundamental_data.low_sleep_users as chain_low_sleep_users
     , fundamental_data.avg_txn_fee as chain_avg_txn_fee
+    , fundamental_data.tvl as lst_tvl
+    , fundamental_data.tvl_net_change as lst_tvl_net_change
 
     
     --Cashflow Metrics

--- a/models/projects/sushiswap/core/ez_sushiswap_metrics.sql
+++ b/models/projects/sushiswap/core/ez_sushiswap_metrics.sql
@@ -115,6 +115,7 @@ select
     , tvl.tvl
 
     -- Cashflow Metrics
+    , trading_volume.trading_fees as spot_fees
     , cashflow_metrics.ecosystem_revenue as ecosystem_revenue
     , cashflow_metrics.service_fee_allocation as service_fee_allocation
     , cashflow_metrics.staking_fee_allocation as staking_fee_allocation

--- a/models/projects/sushiswap/core/ez_sushiswap_metrics_by_chain.sql
+++ b/models/projects/sushiswap/core/ez_sushiswap_metrics_by_chain.sql
@@ -112,6 +112,7 @@ select
     , tvl_by_chain.tvl
 
     -- Cashflow Metrics
+    , trading_volume_by_chain.trading_fees as spot_fees
     , cashflow_metrics.ecosystem_revenue as ecosystem_revenue
     , cashflow_metrics.service_fee_allocation as service_fee_allocation
     , cashflow_metrics.staking_fee_allocation as staking_fee_allocation

--- a/models/projects/swell/core/ez_swell_metrics.sql
+++ b/models/projects/swell/core/ez_swell_metrics.sql
@@ -60,21 +60,25 @@ select
     , market_metrics.market_cap as market_cap
     , market_metrics.fdmc as fdmc
 
-    --Usage Metrics
+    -- LRT Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
     , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
     , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
+    
+    -- LST Usage Metrics
     , staked_eth_metrics.num_staked_eth as lst_tvl_native
     , staked_eth_metrics.amount_staked_usd as lst_tvl
     , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
     , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+    
+    -- TVL Metrics
     , lst_tvl_native + lrt_tvl_native as tvl_native
     , lst_tvl + lrt_tvl as tvl
     , lst_tvl_native_net_change + lrt_tvl_native_net_change as tvl_native_net_change
     , lst_tvl_net_change + lrt_tvl_net_change as tvl_net_change
 
-    --Market Metrics
+    -- Market Metrics
     , market_metrics.token_turnover_circulating as token_turnover_circulating
     , market_metrics.token_turnover_fdv as token_turnover_fdv
 

--- a/models/projects/swell/core/ez_swell_metrics_by_chain.sql
+++ b/models/projects/swell/core/ez_swell_metrics_by_chain.sql
@@ -53,15 +53,19 @@ select
 
     --Standardized Metrics
 
-    --Usage Metrics
+    -- LRT Usage Metrics
     , restaked_eth_metrics.num_restaked_eth as lrt_tvl_native
     , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
     , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
     , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
+    
+    -- LST Usage Metrics
     , staked_eth_metrics.num_staked_eth as lst_tvl_native
     , staked_eth_metrics.amount_staked_usd as lst_tvl
     , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
     , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+    
+    -- TVL Metrics
     , lst_tvl_native + lrt_tvl_native as tvl_native
     , lst_tvl + lrt_tvl as tvl
     , lst_tvl_native_net_change + lrt_tvl_native_net_change as tvl_native_net_change


### PR DESCRIPTION
Related PRs:
Front end: https://github.com/Artemis-xyz/artemis-dashboard-frontend/pull/1954
Backend: https://github.com/Artemis-xyz/gokustats-back-end/pull/3856

**Objective**: Move sector pages to use new metrics as part of push to deprecate old metrics.

**Steps**
- Change metrics in front end
- Deal with any dbt or backend changes as needed

The full sector by sector migration analysis can be found in [this Notion document](https://www.notion.so/artemisxyz/Sector-Metrics-Migration-20646f0265b4809fb778ccff4b20233b).

**This DBT PR contains several key changes needed to ensure this migration is successful**

**Sectorizing TVL**
One of the core issues I found in doing this migration was with LST/LRT TVLs. Since we are moving to using `TVL` instead of `AMT_STAKED_USD`, we must ensure that the underlying models support the appropriate metrics. What I noticed was that there were several instances where using a general `TVL` metric does not make sense. For instance, Binance has the bETH LST, but Binance also has a chain (BSC). Since we treat both the chain and the LST protocol as being under the same entity, and using the same data models, we must distinguish what part of TVL belongs to the LST protocol vs the chain. It would not make sense to compare BSC TVL against Lido in the Liquid Staking dashboard. The same goes for a protocol like Frax that has a liquid staking protocol as well as a chain, a DEX and a stablecoin. Apps/entities continue to increase in complexity. To solve this we need to sectorize TVL to ensure that metrics remain comparable. Following our current denormalized data modeling approach, we should do this by adding the sector prefix before TVL.

A couple thoughts that come to mind:
- We need a separate metric for chain_tvl
- We will need to think about how to represent this in datahub since we aggregate TVL by artemis id. A naive approach would lead to `binance` TVL being the sum of its `chain_tvl` and its `lst_tvl`.

**Sectorizing LST TVL Testing**:

Changed LST Models run.
![CleanShot 2025-06-16 at 00 11 27@2x](https://github.com/user-attachments/assets/0f1fd647-1dda-4adf-8b6b-226060b68599)

RETL on assets with new LST metrics works:
![CleanShot 2025-06-16 at 00 22 24@2x](https://github.com/user-attachments/assets/79bfcf0c-c23f-4e62-87dd-9676226cac2d)

Data in the frontend matches expectations (top is local, bottom is prod)
![CleanShot 2025-06-16 at 00 34 43](https://github.com/user-attachments/assets/b4a1d3f2-878c-4b31-8e67-b64c53e87951)
![CleanShot 2025-06-16 at 00 34 55](https://github.com/user-attachments/assets/299cc8dd-d5f0-4da3-a8df-bc0f6ea2f6f4)



**Sectorizing LRT TVL Testing**

Changed LRT models run (note the run below unintentionally included other models).
![CleanShot 2025-06-16 at 01 00 31@2x](https://github.com/user-attachments/assets/9153cc96-d083-466d-9fd6-dc59d7d0b88a)


RETL on assets with new LRT metrics works:


Data in the frontend matches expectations (top is local, bottom is prod)
![CleanShot 2025-06-16 at 01 03 38@2x](https://github.com/user-attachments/assets/c7f102b1-a2db-449e-9a0d-97b3ba4e8bd5)

![CleanShot 2025-06-16 at 01 01 13](https://github.com/user-attachments/assets/0079b7ee-82fa-4134-af95-38bb1753a7e6)
![CleanShot 2025-06-16 at 01 01 26](https://github.com/user-attachments/assets/72a1b848-0ac1-4797-ba78-83f5cf4526d7)



**TODOs:**
- Continue sectorization by adding spot_tvl and chain_tvl (and any others that may be needed)