### PR TITLE
Re-Enable Meteora Decoded Swaps

### DIFF
--- a/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
+++ b/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
@@ -18,6 +18,9 @@ with swaps as (
     SELECT
         *
     FROM {{ ref('fact_meteora_encoded_swaps') }}
+    {% if is_incremental() %}
+        and block_timestamp > (select MAX(block_timestamp) from {{ this }})
+    {% endif %}
 )
 SELECT
     swaps.*,

--- a/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
+++ b/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
@@ -2,16 +2,18 @@
 {{
     config(
         materialized='incremental',
-        incremental_strategy='microbatch',
-        event_time='block_timestamp',
-        begin='2023-11-27', 
-        batch_size='day',
-        concurrent_batches=true,
         snowflake_warehouse='SNOWPARK_WAREHOUSE',
         full_refresh=false,
-        enabled=false
     )
  }}
+
+-- TODO: microbatch config to add back later
+-- incremental_strategy='microbatch',
+-- event_time='block_timestamp',
+-- begin='2023-11-27', 
+-- batch_size='day',
+-- concurrent_batches=true,
+
 with swaps as (
     SELECT
         *

--- a/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
+++ b/models/projects/meteora/raw/fact_meteora_decoded_swaps.sql
@@ -18,6 +18,7 @@ with swaps as (
     SELECT
         *
     FROM {{ ref('fact_meteora_encoded_swaps') }}
+    WHERE 1=1
     {% if is_incremental() %}
         and block_timestamp > (select MAX(block_timestamp) from {{ this }})
     {% endif %}

--- a/models/projects/meteora/raw/fact_meteora_encoded_swaps.sql
+++ b/models/projects/meteora/raw/fact_meteora_encoded_swaps.sql
@@ -5,11 +5,12 @@
         snowflake_warehouse='METEORA',
         database='METEORA',
         schema='raw',
-        event_time='block_timestamp',
         unique_key=['block_timestamp', '_log_id'],
     )
  }}
 
+-- TODO: microbatch config to add back later
+-- event_time='block_timestamp',
 WITH log_id_add_query as (
     SELECT
         tx_id,

--- a/models/staging/meteora/fact_meteora_decoded_swaps_extract.sql
+++ b/models/staging/meteora/fact_meteora_decoded_swaps_extract.sql
@@ -15,7 +15,7 @@ with decoded_swaps_usd as (
         t.symbol,
         t.price,
         (swap_fee_amount / POW(10, t.decimals) * t.price) as swap_fee_amount_usd, 
-    from pc_dbt_db.prod.fact_meteora_decoded_swaps d 
+    from {{ ref('fact_meteora_decoded_swaps') }} d 
     LEFT JOIN {{ source('SOLANA_FLIPSIDE_PRICE', 'ez_prices_hourly') }} t
             ON d.swap_from_mint = t.token_address
             AND date_trunc('hour', block_timestamp) = t.hour


### PR DESCRIPTION
## Testing

- Re-enable meteora decoded swaps model
- Comment out microbatch config until we implement microbatch ETL in Dagster
- Convert raw DB relations to dbt refs on the decoded swaps model
```
dbt run -s fact_meteora_decoded_swaps fact_meteora_decode
d_swaps_extract fact_meteora_dlmm_metrics ez_meteora_metrics ez_meteora_metrics_by_chain
```
<img width="630" alt="image" src="https://github.com/user-attachments/assets/abf43d06-6c6e-4a53-86b9-6bde78c4e1f9" />
<img width="736" alt="image" src="https://github.com/user-attachments/assets/4ea1bf0d-00e1-440b-8510-8d79eb2e1d59" />

- [x ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets

- [ ] Added clear and concise revenue definition + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

- [ ] Screenshots of changed data **in local frontend**

## Other
