### PR TITLE
akhil/arbitrum-fees-revenue-with-timeboost

### DIFF
--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -100,6 +100,8 @@ select
     , coalesce(fees, 0) - l1_data_cost + coalesce(0.97 * timeboost_fees, 0) as treasury_fee_allocation
     , l1_data_cost_native AS l1_fee_allocation_native -- fees paid to l1 by sequencer (L1 Fees)
     , l1_data_cost AS l1_fee_allocation
+    , timeboost_fees_native
+    , timeboost_fees
     -- Developer Metrics
     , weekly_commits_core_ecosystem
     , weekly_commits_sub_ecosystem

--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -39,6 +39,10 @@ with
     adjusted_dau_metrics as (
         select date, adj_daus as adjusted_dau
         from {{ ref("ez_arbitrum_adjusted_dau") }}
+    ),
+    timeboost_fees as (
+        select date, timeboost_fees AS timeboost_fees_native, timeboost_fees_usd AS timeboost_fees
+        from {{ ref("fact_arbitrum_timeboost_fees") }}
     )
 select
     fundamental_data.date
@@ -48,12 +52,12 @@ select
     , adjusted_dau
     , wau
     , mau
-    , fees_native
-    , fees
+    , coalesce(fees_native, 0) + coalesce(timeboost_fees_native, 0) as fees_native
+    , coalesce(fees, 0) + coalesce(timeboost_fees, 0) as fees
     , l1_data_cost_native
     , l1_data_cost
-    , coalesce(fees_native, 0) - l1_data_cost_native as revenue_native
-    , coalesce(fees, 0) - l1_data_cost as revenue
+    , coalesce(fees_native, 0) - l1_data_cost_native + coalesce(0.97 * timeboost_fees_native, 0) as revenue_native
+    , coalesce(fees, 0) - l1_data_cost + coalesce(0.97 * timeboost_fees, 0) as revenue
     , avg_txn_fee
     , median_txn_fee
     , dau_over_100
@@ -89,11 +93,11 @@ select
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dune_dex_volumes_arbitrum.dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
     -- Cashflow Metrics
-    , fees_native AS chain_fees
-    , fees_native AS ecosystem_revenue_native -- Total gas fees paid on L2 by users (L2 Fees)
-    , fees AS ecosystem_revenue
-    , coalesce(fees_native, 0) - l1_data_cost_native as treasury_fee_allocation_native  -- supply side: fees paid to squencer - fees paied to l1 (L2 Revenue)
-    , coalesce(fees, 0) - l1_data_cost as treasury_fee_allocation
+    , coalesce(fees_native, 0) + coalesce(timeboost_fees_native, 0) AS chain_fees
+    , coalesce(fees_native, 0) + coalesce(timeboost_fees_native, 0) AS ecosystem_revenue_native -- Total gas fees paid on L2 by users (L2 Fees)
+    , coalesce(fees, 0) + coalesce(timeboost_fees, 0) AS ecosystem_revenue
+    , coalesce(fees_native, 0) - l1_data_cost_native + coalesce(0.97 * timeboost_fees_native, 0) as treasury_fee_allocation_native  -- supply side: fees paid to squencer - fees paied to l1 (L2 Revenue)
+    , coalesce(fees, 0) - l1_data_cost + coalesce(0.97 * timeboost_fees, 0) as treasury_fee_allocation
     , l1_data_cost_native AS l1_fee_allocation_native -- fees paid to l1 by sequencer (L1 Fees)
     , l1_data_cost AS l1_fee_allocation
     -- Developer Metrics
@@ -136,4 +140,5 @@ left join bridge_volume_metrics on fundamental_data.date = bridge_volume_metrics
 left join bridge_daa_metrics on fundamental_data.date = bridge_daa_metrics.date
 left join arbitrum_dex_volumes as dune_dex_volumes_arbitrum on fundamental_data.date = dune_dex_volumes_arbitrum.date
 left join adjusted_dau_metrics on fundamental_data.date = adjusted_dau_metrics.date
+left join timeboost_fees on fundamental_data.date = timeboost_fees.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/staging/arbitrum/__arbitrum__sources.yml
+++ b/models/staging/arbitrum/__arbitrum__sources.yml
@@ -4,3 +4,13 @@ sources:
     database: PC_DBT_DB
     tables:
       - name: dim_arbitrum_current_balances
+  - name: ARBITRUM_FLIPSIDE
+    schema: core
+    database: arbitrum_flipside
+    tables:
+      - name: ez_decoded_event_logs
+  - name: ARBITRUM_FLIPSIDE
+    schema: price
+    database: arbitrum_flipside
+    tables:
+      - name: ez_prices_hourly

--- a/models/staging/arbitrum/fact_arbitrum_timeboost_fees.sql
+++ b/models/staging/arbitrum/fact_arbitrum_timeboost_fees.sql
@@ -1,0 +1,44 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ARBITRUM",
+    )
+}}
+
+WITH decoded_table AS (
+    SELECT
+        DATE(block_timestamp) AS date, 
+        block_number, 
+        block_timestamp, 
+        tx_hash, 
+        decoded_log:firstPriceAmount::NUMBER AS rawFirstPriceAmount, 
+        decoded_log:firstPriceAmount::NUMBER / 1e18 AS firstPriceAmount, 
+        decoded_log:isMultiBidAuction::BOOLEAN AS isMultiBidAuction, 
+        decoded_log:price::NUMBER / 1e18 AS price, 
+        decoded_log:firstPriceAmount::NUMBER / 1e18, 
+        decoded_log,
+    FROM {{ source('ARBITRUM_FLIPSIDE', 'ez_decoded_event_logs') }}
+    WHERE LOWER(contract_address) = LOWER('0x5fcb496a31b7AE91e7c9078Ec662bd7A55cd3079')
+        AND event_name = 'AuctionResolved'
+    ORDER BY DATE(block_timestamp) DESC
+)
+
+SELECT
+    dt.date, 
+    SUM(
+        CASE
+            WHEN dt.isMultiBidAuction THEN dt.price
+            ELSE dt.firstPriceAmount
+        END
+    ) AS timeboost_fees, 
+    SUM(
+        CASE
+            WHEN dt.isMultiBidAuction THEN dt.price * eph.price
+            ELSE dt.firstPriceAmount * eph.price
+        END
+    ) AS timeboost_fees_usd
+FROM decoded_table AS dt
+JOIN {{ source('ARBITRUM_FLIPSIDE', 'ez_prices_hourly') }} AS eph
+    ON DATE_TRUNC('hour', dt.block_timestamp) = eph.hour AND LOWER(eph.token_address) = LOWER('0x82aF49447D8a07e3bd95BD0d56f35241523fBab1')
+GROUP BY 1
+ORDER BY 1 DESC


### PR DESCRIPTION
- Added a new fact table that gave timeboost fees
- Added timeboost fees to `fees` in the EZM table
- `0.97 * timeboost_fees` was added to revenue in the EZM table [[Source](https://dune.com/entropy_advisors/arbitrum-timeboost)]

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

<img width="985" alt="Screenshot 2025-06-18 at 1 15 26 PM" src="https://github.com/user-attachments/assets/24fcb6c7-6ef1-4101-9f36-1dbbf078f67d" />

<img width="1041" alt="Screenshot 2025-06-18 at 12 46 16 PM" src="https://github.com/user-attachments/assets/aaf2d0f0-d2f9-4f34-ba3f-8fa4b02000a8" />

- [X] Successful RETL screenshot

<img width="985" alt="Screenshot 2025-06-18 at 1 13 10 PM" src="https://github.com/user-attachments/assets/e0d31277-77c7-4678-80d7-b03c3b40d913" />

- [ ] Ran make generate schema for changed assets - no new metrics were added

- [ ] Added clear and concise revenue definition + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

- [ ] Screenshots of changed data **in local frontend**

## Other

Our data lines up with comparable sources: 


<img width="1505" alt="Screenshot 2025-06-18 at 12 56 27 PM" src="https://github.com/user-attachments/assets/8c10de07-3925-42fd-b97d-57721705a206" />
<img width="1081" alt="Screenshot 2025-06-18 at 12 56 54 PM" src="https://github.com/user-attachments/assets/be456332-e6a3-4ef2-a561-19a7cea285ff" />

