### PR TITLE
Add hyperliquid burns

### DIFF
--- a/macros/goldsky/get_goldsky_chain_fundamental_metrics.sql
+++ b/macros/goldsky/get_goldsky_chain_fundamental_metrics.sql
@@ -8,6 +8,15 @@
         from {{ ref("fact_" ~ chain ~ "_transactions" ~ (model_version)) }}
         where gas > 0
         group by to_timestamp(block_timestamp)::date
+    {% elif chain == "hyperliquid" %}
+        select
+            to_timestamp(block_timestamp)::date as date
+            , count (distinct from_address) as daa
+            , count(*) as txns
+            , sum((receipt_gas_used * receipt_effective_gas_price)) / 1e18 as hyperevm_burns_native
+        from {{ ref("fact_" ~ chain ~ "_hyperevm_transactions" ~ (model_version)) }}
+        where gas > 0
+        group by to_timestamp(block_timestamp)::date
     {% else %}
         select
             to_timestamp(block_timestamp)::date as date

--- a/models/projects/hyperliquid/core/__hyperliquid__schema.yml
+++ b/models/projects/hyperliquid/core/__hyperliquid__schema.yml
@@ -18,6 +18,10 @@ column_definitions:
       - artemis_gaap
       - override
 
+  burns_native: &burns_native
+    name: burns_native
+    description: "HyperCore (Spot Tokens Fees) + HyperEvm (Gas)"
+
   buyback_fee_allocation: &buyback_fee_allocation
     name: buyback_fee_allocation
     description: "A portion of protocol revenue is allocated to the Assistance Fund (AF) for HYPE buybacks — (97%). The 97% is based on confirmation from the Hyperliquid team and matches our observed fee data from assistancefund.top and asxn data."
@@ -41,18 +45,18 @@ column_definitions:
     name: circulating_supply_native
     description: "The circulating supply of a token in native tokens"
 
-  fdmc: &fdmc
-    name: fdmc
-    description: "The fully diluted market cap of a token in USD"
-    tags:
-      - artemis_gaap
-
   ecosystem_revenue: &ecosystem_revenue
     name: ecosystem_revenue
     description: "Gross protocol revenue includes layer 1 transaction fees and trading fees, composed of spot fees, perp fees, and auction fees."
     tags:
       - artemis_gaap
       - override
+
+  fdmc: &fdmc
+    name: fdmc
+    description: "The fully diluted market cap of a token in USD"
+    tags:
+      - artemis_gaap
 
   market_cap: &market_cap
     name: market_cap
@@ -137,6 +141,10 @@ column_definitions:
       - artemis_gaap
       - override
 
+  tvl: &tvl
+    name: tvl
+    description: "The total value locked in a protocol"
+
 models:
   - name: ez_hyperliquid_metrics_by_chain
     description: "This table stores metrics for the HYPERLIQUID protocol"
@@ -146,8 +154,8 @@ models:
       - *buyback_fee_allocation
       - *buybacks_native
       - *chain_fees
-      - *fdmc
       - *ecosystem_revenue
+      - *fdmc
       - *market_cap
       - *perp_dau
       - *perp_fees
@@ -165,12 +173,13 @@ models:
     columns:
       - *burned_fee_allocation
       - *burned_fee_allocation_native
+      - *burns_native
       - *buyback_fee_allocation
       - *buybacks_native
       - *chain_fees
       - *circulating_supply_native
-      - *fdmc
       - *ecosystem_revenue
+      - *fdmc
       - *market_cap
       - *net_supply_change_native
       - *perp_dau
@@ -184,4 +193,5 @@ models:
       - *token_turnover_circulating
       - *token_turnover_fdv
       - *token_volume
+      - *tvl
 

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
@@ -67,8 +67,8 @@ with trading_volume_data as (
     FROM {{ref("dim_date_spine")}}
     WHERE date between '2023-06-13' and to_date(sysdate())
 )
-, hyperevm_burns_data as (
-    select date, chain, hyperevm_burns, hyperevm_burns_native
+, hyperevm_fundamental_metrics_data as (
+    select date, chain, daa, txns, hyperevm_burns, hyperevm_burns_native
     from {{ ref("fact_hyperliquid_hyperevm_fundamental_metrics") }}
 )
     
@@ -102,9 +102,9 @@ select
     , token_turnover_fdv
 
     -- Usage Metrics
-    , unique_traders::string as perp_dau
+    , unique_traders::string + hyperevm_data.daa as perp_dau
     , perp_volume as perp_volume
-    , trades as perp_txns
+    , trades + hyperevm_data.txns as perp_txns
     , perps_tvl_data.tvl as tvl
     
     -- Cash Flow Metrics
@@ -133,7 +133,7 @@ left join trading_volume_data using(date)
 left join daily_transactions_data using(date)
 left join fees_data using(date)
 left join hypercore_spot_burns_data using(date)
-left join hyperevm_burns_data using(date)
+left join hyperevm_fundamental_metrics_data hyperevm_data using(date)
 left join daily_supply_data using(date)
 left join auction_fees_data using(date)
 left join hype_staked_data using(date)

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
@@ -56,8 +56,8 @@ with
         FROM {{ref("dim_date_spine")}}
         WHERE date between '2023-06-13' and to_date(sysdate())
     )
-    , hyperevm_burns_data as (
-        select date, chain, hyperevm_burns, hyperevm_burns_native
+    , hyperevm_fundamental_metrics_data as (
+        select date, chain, daa, txns, hyperevm_burns, hyperevm_burns_native
         from {{ ref("fact_hyperliquid_hyperevm_fundamental_metrics") }}
     )
 select
@@ -80,10 +80,10 @@ select
     , staked_hype
 
     -- Standardized Metrics
-    , unique_traders::string as perp_dau
+    , unique_traders::string + hyperevm_data.daa as perp_dau
     , perp_volume
     , spot_trading_volume as spot_volume
-    , trades as perp_txns
+    , trades + hyperevm_data.txns as perp_txns
 
     -- Revenue Metrics
     , perp_fees as perp_fees
@@ -110,7 +110,7 @@ left join daily_transactions_data using(date, chain)
 left join fees_data using(date, chain)
 left join auction_fees_data using(date, chain)
 left join hypercore_spot_burns_data using(date, chain)
-left join hyperevm_burns_data using(date, chain)
+left join hyperevm_fundamental_metrics_data hyperevm_data using(date, chain)
 left join daily_assistance_fund_data using(date, chain)
 left join hype_staked_data using(date, chain)
 left join spot_trading_volume_data using(date, chain)

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
@@ -30,9 +30,9 @@ with
         from {{ ref("fact_hyperliquid_auction_fees") }}
         group by 1, 2
     )
-    , daily_burn_data as (
-        select date, daily_burn, chain
-        from {{ ref("fact_hyperliquid_daily_burn") }}
+    , hypercore_spot_burns_data as (
+        select date, hypercore_burns_native, chain
+        from {{ ref("fact_hyperliquid_hypercore_burns") }}
     )
     , daily_assistance_fund_data as (
         select date, daily_balance as daily_buybacks_native, balance as assistance_fund_balance, chain
@@ -56,6 +56,10 @@ with
         FROM {{ref("dim_date_spine")}}
         WHERE date between '2023-06-13' and to_date(sysdate())
     )
+    , hyperevm_burns_data as (
+        select date, chain, hyperevm_burns, hyperevm_burns_native
+        from {{ ref("fact_hyperliquid_hyperevm_fundamental_metrics") }}
+    )
 select
     date
     , 'hyperliquid' as app
@@ -67,10 +71,10 @@ select
     , trades as txns
     , trading_fees as fees
     , auction_fees
-    , daily_burn
+    , hypercore_burns_native + hyperevm_burns_native as daily_burns_native
     , trading_fees * 0.03 as primary_supply_side_revenue
     -- add daily burn back to the revenue
-    , (daily_buybacks_native * mm.price) + (daily_burn * mm.price) as revenue
+    , (daily_buybacks_native * mm.price) + (daily_burns_native * mm.price) as revenue
     , daily_buybacks_native
     , num_stakers
     , staked_hype
@@ -84,14 +88,14 @@ select
     -- Revenue Metrics
     , perp_fees as perp_fees
     , spot_fees as spot_fees
-    -- all l1 fees are burned
-    , daily_burn * mm.price as chain_fees
-    , trading_fees + (daily_burn * mm.price) as ecosystem_revenue
+    -- all l1 fees are burned (HyperEVM) + Hypercore (Spot Token Fees Burned)
+    , daily_burns_native * mm.price as chain_fees
+    , trading_fees + (daily_burns_native * mm.price) as ecosystem_revenue
     , trading_fees * 0.03 as service_fee_allocation
     , (daily_buybacks_native * mm.price) as buyback_fee_allocation
     , daily_buybacks_native as buybacks_native
-    , daily_burn as burned_fee_allocation_native
-    , daily_burn * mm.price as burned_fee_allocation
+    , daily_burns_native as burned_fee_allocation_native
+    , daily_burns_native * mm.price as burned_fee_allocation
 
     -- Market metrics
     , mm.price as price
@@ -105,7 +109,8 @@ left join trading_volume_data using(date, chain)
 left join daily_transactions_data using(date, chain)
 left join fees_data using(date, chain)
 left join auction_fees_data using(date, chain)
-left join daily_burn_data using(date, chain)
+left join hypercore_spot_burns_data using(date, chain)
+left join hyperevm_burns_data using(date, chain)
 left join daily_assistance_fund_data using(date, chain)
 left join hype_staked_data using(date, chain)
 left join spot_trading_volume_data using(date, chain)

--- a/models/staging/hyperliquid/fact_hyperliquid_hypercore_burns.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_hypercore_burns.sql
@@ -9,6 +9,7 @@ with
     extracted_daily_burn as (
         select
             key::date as date, 
+            -- HyperCore Spot Token Fees Burned
             value::double as daily_burn,
             'hyperliquid' as app,
             'hyperliquid' as chain,
@@ -17,7 +18,7 @@ with
     )
 select
     date,
-    daily_burn,
+    daily_burn as hypercore_burns_native,
     app,
     chain,
     category

--- a/models/staging/hyperliquid/fact_hyperliquid_hyperevm_fundamental_metrics.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_hyperevm_fundamental_metrics.sql
@@ -1,0 +1,20 @@
+{{ config(materialized="incremental", snowflake_warehouse="HYPERLIQUID", unique_key=["date"]) }}
+
+with 
+fundamental_data as (
+    {{ get_goldsky_chain_fundamental_metrics("hyperliquid") }}
+),
+price as (
+    {{ get_coingecko_price_with_latest('hyperliquid') }}
+)
+
+SELECT 
+    fd.date
+    , fd.daa
+    , fd.txns
+    , fd.hyperevm_burns_native
+    , hyperevm_burns_native * price as hyperevm_burns
+    , 'hyperliquid' as chain
+FROM fundamental_data fd
+LEFT JOIN price p
+ON fd.date = p.date

--- a/models/staging/hyperliquid/fact_hyperliquid_hyperevm_transactions.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_hyperevm_transactions.sql
@@ -1,0 +1,96 @@
+{{ config(materialized="incremental", snowflake_warehouse="HYPERLIQUID", unique_key=["transaction_hash"]) }}
+
+with raw_receipt_transactions as (
+    select
+        parquet_raw:block_hash::string as block_hash
+        , parquet_raw:block_number::string as block_number
+        , parquet_raw:block_timestamp::timestamp_ntz as block_timestamp
+        , parquet_raw:transaction_hash::string as transaction_hash
+        , parquet_raw:from_address::string as from_address
+        , parquet_raw:to_address::string as to_address
+        , parquet_raw:gas::integer as gas
+        , parquet_raw:gas_price::integer as gas_price
+        , parquet_raw:id::string as id
+        , parquet_raw:nonce::integer as nonce
+        , parquet_raw:receipt_cumulative_gas_used::integer as receipt_cumulative_gas_used
+        , parquet_raw:receipt_effective_gas_price::integer as receipt_effective_gas_price
+        , parquet_raw:receipt_gas_used::float as receipt_gas_used 
+        , parquet_raw:input::string as input
+        , case
+            when try_cast(parquet_raw:max_fee_per_blob_gas::string as integer) is not null
+            then try_cast(parquet_raw:max_fee_per_blob_gas::string as integer)
+            else 0
+        end as max_fee_per_blob_gas
+        , case
+            when try_cast(parquet_raw:max_fee_per_gas::string as integer) is not null
+            then try_cast(parquet_raw:max_fee_per_gas::string as integer)
+            else 0
+        end as max_fee_per_gas
+        , case
+            when try_cast(parquet_raw:max_priority_fee_per_gas::string as integer) is not null
+            then try_cast(parquet_raw:max_priority_fee_per_gas::string as integer)
+            else 0
+        end as max_priority_fee_per_gas
+        , case
+            when try_cast(parquet_raw:receipt_l1_blob_base_fee::string as integer) is not null
+            then try_cast(parquet_raw:receipt_l1_blob_base_fee::string as integer)
+            else 0
+        end as receipt_l1_blob_base_fee
+        , case
+            when try_cast(parquet_raw:receipt_l1_fee::string as integer) is not null
+            then try_cast(parquet_raw:receipt_l1_fee::string as integer)
+            else 0
+        end as receipt_l1_fee
+        , case
+            when try_cast(parquet_raw:receipt_l1_fee_scalar::string as integer) is not null
+            then try_cast(parquet_raw:receipt_l1_fee_scalar::string as integer)
+            else 0
+        end as receipt_l1_fee_scalar
+        , case
+            when try_cast(parquet_raw:receipt_l1_gas_price::string as integer) is not null
+            then try_cast(parquet_raw:receipt_l1_gas_price::string as integer)
+            else 0
+        end as receipt_l1_gas_price
+        , case
+            when try_cast(parquet_raw:receipt_l1_gas_used::string as integer) is not null
+            then try_cast(parquet_raw:receipt_l1_gas_used::string as integer)
+            else 0
+        end as receipt_l1_gas_used
+        , parquet_raw:receipt_status::number as receipt_status
+        , parquet_raw:transaction_index::number as transaction_index
+        , parquet_raw:transaction_type::number as transaction_type
+        , parquet_raw:value::string as value
+        from {{ source("PROD_LANDING", "raw_hyperevm_transactions_parquet") }}
+        {% if is_incremental() %}
+            where parquet_raw:block_timestamp::timestamp_ntz >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+        {% endif %}
+)
+select
+    block_hash
+    , block_number
+    , block_timestamp
+    , transaction_hash
+    , from_address
+    , to_address
+    , gas
+    , gas_price
+    , id
+    , nonce
+    , receipt_cumulative_gas_used
+    , receipt_effective_gas_price
+    , receipt_gas_used
+    , input
+    , max_fee_per_blob_gas
+    , max_fee_per_gas
+    , max_priority_fee_per_gas
+    , receipt_l1_blob_base_fee
+    , receipt_l1_fee
+    , receipt_l1_fee_scalar
+    , receipt_l1_gas_price
+    , receipt_l1_gas_used
+    , receipt_status
+    , transaction_index
+    , transaction_type
+    , value
+from raw_receipt_transactions
+qualify row_number() over (partition by transaction_hash order by block_timestamp desc) = 1


### PR DESCRIPTION
## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
`fact_hyperliquid_hyperevm_transactions`
<img width="999" alt="image" src="https://github.com/user-attachments/assets/bef4115d-032c-4daa-8bcf-4ec00a57b112" />

`fact_hyperliquid_hyperevm_fundamental_metrics`
<img width="997" alt="image" src="https://github.com/user-attachments/assets/3f63720b-134b-4767-b2b7-254915471b40" />

renamed `fact_hyperliquid_daily_burn` with `fact_hyperliquid_hypercore_burns` as fact_hyperliquid_daily_burn seems very vague and there are 2 components of burns now - fact_hyperliquid_hypercore and hyperevm
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/9eca62d5-f8d0-471e-9f55-05638a1e79ee" />
<img width="992" alt="image" src="https://github.com/user-attachments/assets/cc2c10c0-057a-4a3c-a897-592fa213b9be" />


- [x] Successful RETL screenshot
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/990341dd-52a8-4667-a3cc-f77dd2331733" />
removed self-register metrics in adapter for hyperliquid (backend PR: https://github.com/Artemis-xyz/gokustats-back-end/pull/3876)

- [x] Ran make generate schema for changed assets
<img width="1073" alt="image" src="https://github.com/user-attachments/assets/e2e4eec3-59cf-4624-8288-9093078b6402" />

- [x] Added clear and concise revenue definition + methodology to the admin dashboard
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/a9bacba2-4607-4ca5-9ade-e0846ee33f32" />

- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

- [x] Screenshots of changed data **in local frontend**
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/73496ccb-2e6d-480d-80aa-86e94d8a4efb" />

## Other
