### PR TITLE
c911 Ethereum Stablecoin and update Artemis events

### DIFF
--- a/macros/coingecko/waterfall_stablecoin_prices.sql
+++ b/macros/coingecko/waterfall_stablecoin_prices.sql
@@ -8,10 +8,15 @@ coalesce(
                 where coingecko_id = 'flex-usd'
                 qualify row_number() over (partition by coingecko_id order by date desc) = 1
             ) 
+            when {{token_data_name}}.coingecko_id = 'anchored-coins-eur' then (
+                select shifted_token_price_usd
+                from {{ ref("fact_coingecko_token_date_adjusted_gold") }}
+                where coingecko_id = 'anchored-coins-eur'
+                qualify row_number() over (partition by coingecko_id order by date desc) = 1
+            ) 
             when {{token_data_name}}.coingecko_id = 'tether-eurt' then ({{ avg_l7d_coingecko_price('tether-eurt') }})
             when {{token_data_name}}.coingecko_id = 'stasis-eurs' then ({{ avg_l7d_coingecko_price('stasis-eurs') }})
             when {{token_data_name}}.coingecko_id = 'ageur' then ({{ avg_l7d_coingecko_price('ageur') }})
-            when {{token_data_name}}.coingecko_id = 'anchored-coins-eur' then ({{ avg_l7d_coingecko_price('anchored-coins-eur') }})
             when {{token_data_name}}.coingecko_id = 'euro-coin' then ({{ avg_l7d_coingecko_price('euro-coin') }})
             when {{token_data_name}}.coingecko_id = 'celo-euro' then ({{ avg_l7d_coingecko_price('celo-euro') }})
             when {{token_data_name}}.coingecko_id = 'celo-real-creal' then ({{ avg_l7d_coingecko_price('celo-real-creal') }})

--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -1,4 +1,7 @@
 {% macro p2p_stablecoin_transfers(chain, new_stablecoin_address) %}
+
+{% set backfill_days = 3 %}
+
 with 
     stablecoin_transfers as (
         select * from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }}
@@ -38,7 +41,7 @@ with
             {% endif %}
             {% if is_incremental() and new_stablecoin_address == '' %} 
                 and block_timestamp >= (
-                    select dateadd('day', -3, max(block_timestamp))
+                    select dateadd('day', -{{ backfill_days }}, max(block_timestamp))
                     from {{ this }}
                 )
             {% endif %}
@@ -72,7 +75,7 @@ with
                 and not t1.from_address in (select contract_address from distinct_contracts)
             {% if is_incremental() and new_stablecoin_address == '' %} 
                 and block_timestamp >= (
-                    select dateadd('day', -3, max(block_timestamp))
+                    select dateadd('day', -{{ backfill_days }}, max(block_timestamp))
                     from {{ this }}
                 )
             {% endif %}
@@ -115,7 +118,7 @@ with
     {% endif %}
     {% if is_incremental() and new_stablecoin_address == '' %} 
         and block_timestamp >= (
-            select dateadd('day', -3, max(block_timestamp))
+            select dateadd('day', -{{ backfill_days }}, max(block_timestamp))
             from {{ this }}
         )
     {% endif %}

--- a/macros/stablecoins/stablecoin_metrics_all.sql
+++ b/macros/stablecoins/stablecoin_metrics_all.sql
@@ -1,4 +1,7 @@
 {% macro stablecoin_metrics_all(chain, new_stablecoin_address) %}
+
+{% set backfill_days = 3 %}
+
 with
     stablecoin_transfers as (
         select 
@@ -12,7 +15,7 @@ with
         from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
         {% if is_incremental() and new_stablecoin_address == '' %} 
             where block_timestamp >= (
-                select dateadd('day', -3, max(date))
+                select dateadd('day', -{{ backfill_days }}, max(date))
                 from {{ this }}
             )
         {% endif %}
@@ -65,7 +68,7 @@ with
     where date < to_date(sysdate())
     {% if is_incremental() and new_stablecoin_address == '' %} 
         and date >= (
-            select dateadd('day', -3, max(date))
+            select dateadd('day', -{{ backfill_days }}, max(date))
             from {{ this }}
         )
     {% endif %} 

--- a/macros/stablecoins/stablecoin_metrics_artemis.sql
+++ b/macros/stablecoins/stablecoin_metrics_artemis.sql
@@ -1,4 +1,6 @@
 {% macro stablecoin_metrics_artemis(chain, new_stablecoin_address) %}
+
+{% set backfill_days = 3 %}
 with
     stablecoin_transfers as (
         select 
@@ -16,7 +18,7 @@ with
         from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers")}}
         {% if is_incremental() and new_stablecoin_address == '' %} 
             where block_timestamp >= (
-                select dateadd('day', -3, max(date))
+                select dateadd('day', -{{ backfill_days }}, max(date))
                 from {{ this }}
             )
         {% endif %}
@@ -117,7 +119,7 @@ with
     where date < to_date(sysdate())
     {% if is_incremental() and new_stablecoin_address == '' %} 
         and date >= (
-            select dateadd('day', -3, max(date))
+            select dateadd('day', -{{ backfill_days }}, max(date))
             from {{ this }}
         )
     {% endif %} 

--- a/macros/stablecoins/stablecoin_metrics_p2p.sql
+++ b/macros/stablecoins/stablecoin_metrics_p2p.sql
@@ -1,4 +1,7 @@
 {% macro stablecoin_metrics_p2p(chain, new_stablecoin_address) %}
+
+{% set backfill_days = 3 %}
+
 with
     stablecoin_transfers as (
         select 
@@ -14,7 +17,7 @@ with
             on lower(t.token_address) = lower(c.contract_address)
         {% if is_incremental() and new_stablecoin_address == '' %} 
             where block_timestamp >= (
-                select dateadd('day', -3, max(date))
+                select dateadd('day', -{{ backfill_days }}, max(date))
                 from {{ this }}
             )
         {% endif %}
@@ -53,7 +56,7 @@ with
     where date < to_date(sysdate())
     {% if is_incremental() and new_stablecoin_address == '' %} 
         and date >= (
-            select dateadd('day', -3, max(date))
+            select dateadd('day', -{{ backfill_days }}, max(date))
             from {{ this }}
         )
     {% endif %} 

--- a/macros/standardization/decode_artemis_events.sql
+++ b/macros/standardization/decode_artemis_events.sql
@@ -9,7 +9,7 @@
         , topic_data
         , data
         , b.event_name
-        , pc_dbt_db.prod.decode_evm_event_log_v3(event_info, data, topics) AS decoded_log_with_status
+        , pc_dbt_db.prod.decode_evm_event_log_v4(event_info, data, topics) AS decoded_log_with_status
         , decoded_log_with_status[0] as decoded_log
         , decoded_log_with_status[1]::boolean as decoded_log_status
         , b.topic_zero

--- a/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_bridge_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_bridge_addresses.sql
@@ -44,5 +44,10 @@ from
             (
                 '0xdAC17F958D2ee523a2206206994597C13D831ec7',
                 '0x47ac0Fb4F2D84898e4D9E7b4DaB3C24507a6D503'
+            ),
+            -- USDT0
+            (
+                '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+                '0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee'
             )
     ) as results(contract_address, premint_address)

--- a/models/staging/coingecko/fact_coingecko_token.sql
+++ b/models/staging/coingecko/fact_coingecko_token.sql
@@ -93,4 +93,4 @@ select
 from (select * from prices where rn = 1) p
 join (select * from market_caps where rn = 1) m using (coingecko_id, date)
 join (select * from total_volumes where rn = 1) t using (coingecko_id, date)
-join (select * from circulating_supply where rn = 1) c using (coingecko_id, date)
+left join (select * from circulating_supply where rn = 1) c using (coingecko_id, date)


### PR DESCRIPTION
1. Fix fact_coingecko_tokens to left join on circulating supply. This was causing AEUR to be excluded from the table and making the stablecoin job fail
2. Update Artemis Decoded events to use the new decoder. V4 keeps bytes32 values as hexadecimal strings otherwise it returns a bytes array which is difficult to parse and handle in snowflake (https://github.com/Artemis-xyz/gokustats-back-end/pull/3878)
3. Add USDT0 bridge address to the tracked stablecoin bridged on ethereum