### PR TITLE
remove dupllicate source

### DIFF
--- a/models/staging/arbitrum/__arbitrum__sources.yml
+++ b/models/staging/arbitrum/__arbitrum__sources.yml
@@ -4,11 +4,7 @@ sources:
     database: PC_DBT_DB
     tables:
       - name: dim_arbitrum_current_balances
-  - name: ARBITRUM_FLIPSIDE
-    schema: core
-    database: arbitrum_flipside
-    tables:
-      - name: ez_decoded_event_logs
+
   - name: ARBITRUM_FLIPSIDE
     schema: price
     database: arbitrum_flipside


### PR DESCRIPTION
Duplicate source in arbitrum__sources and global__sources was throwing an error in backend CI.

Removed the source from the arbitrum file.

Dependent table runs:
![CleanShot 2025-06-24 at 09 47 36@2x](https://github.com/user-attachments/assets/f3d1d371-0ca0-4de4-b969-88b63d405929)

