### PR TITLE
Add Supply Data and New Users

### DIFF
--- a/models/projects/hyperliquid/core/__hyperliquid__schema.yml
+++ b/models/projects/hyperliquid/core/__hyperliquid__schema.yml
@@ -20,7 +20,7 @@ column_definitions:
 
   burns_native: &burns_native
     name: burns_native
-    description: "HyperCore (Spot Tokens Fees) + HyperEvm (Gas)"
+    description: "The amount of native tokens burned"
 
   buyback_fee_allocation: &buyback_fee_allocation
     name: buyback_fee_allocation
@@ -67,6 +67,10 @@ column_definitions:
   net_supply_change_native: &net_supply_change_native
     name: net_supply_change_native
     description: "The net change in the circulating supply of a token in native tokens"
+
+  new_users: &new_users
+    name: new_users
+    description: "The number of new users on a chain"
 
   perp_dau: &perp_dau
     name: perp_dau
@@ -157,6 +161,7 @@ models:
       - *ecosystem_revenue
       - *fdmc
       - *market_cap
+      - *new_users
       - *perp_dau
       - *perp_fees
       - *perp_txns
@@ -182,6 +187,7 @@ models:
       - *fdmc
       - *market_cap
       - *net_supply_change_native
+      - *new_users
       - *perp_dau
       - *perp_fees
       - *perp_txns

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics_by_chain.sql
@@ -54,11 +54,16 @@ with
             date,
             'hyperliquid' as chain
         FROM {{ref("dim_date_spine")}}
-        WHERE date between '2023-06-13' and to_date(sysdate())
+        -- start date of Hyperliquid
+        WHERE date between '2024-11-29' and to_date(sysdate())
     )
     , hyperevm_fundamental_metrics_data as (
         select date, chain, daa, txns, hyperevm_burns, hyperevm_burns_native
         from {{ ref("fact_hyperliquid_hyperevm_fundamental_metrics") }}
+    )
+    , new_users_data as (
+        select date, chain,new_users
+        from {{ ref("fact_hyperliquid_new_users") }}
     )
 select
     date
@@ -71,7 +76,8 @@ select
     , trades as txns
     , trading_fees as fees
     , auction_fees
-    , hypercore_burns_native + hyperevm_burns_native as daily_burns_native
+    -- all l1 fees are burned (HyperEVM) + Hypercore (Spot Token Fees Burned)
+    , coalesce(hypercore_burns_native, 0) + coalesce(hyperevm_burns_native, 0) as daily_burns_native
     , trading_fees * 0.03 as primary_supply_side_revenue
     -- add daily burn back to the revenue
     , (daily_buybacks_native * mm.price) + (daily_burns_native * mm.price) as revenue
@@ -84,12 +90,13 @@ select
     , perp_volume
     , spot_trading_volume as spot_volume
     , trades + hyperevm_data.txns as perp_txns
+    , new_users
 
     -- Revenue Metrics
     , perp_fees as perp_fees
     , spot_fees as spot_fees
-    -- all l1 fees are burned (HyperEVM) + Hypercore (Spot Token Fees Burned)
-    , daily_burns_native * mm.price as chain_fees
+    -- all l1 fees are burned (HyperEVM)
+    , hyperevm_burns_native * mm.price as chain_fees
     , trading_fees + (daily_burns_native * mm.price) as ecosystem_revenue
     , trading_fees * 0.03 as service_fee_allocation
     , (daily_buybacks_native * mm.price) as buyback_fee_allocation
@@ -115,4 +122,5 @@ left join daily_assistance_fund_data using(date, chain)
 left join hype_staked_data using(date, chain)
 left join spot_trading_volume_data using(date, chain)
 left join market_metrics mm using(date)
+left join new_users_data using(date, chain)
 where date < to_date(sysdate())

--- a/models/staging/hyperliquid/__hyperliquid__sources.yml
+++ b/models/staging/hyperliquid/__hyperliquid__sources.yml
@@ -19,6 +19,7 @@ sources:
       - name: raw_hyperevm_logs_parquet
       - name: raw_hyperliquid_hlp_tvl
       - name: raw_hyperliquid_perps_trading_volume
+      - name: raw_hyperliquid_new_users
   - name: MANUAL_STATIC_TABLES
     schema: PROD
     database: pc_dbt_db

--- a/models/staging/hyperliquid/fact_hyperliquid_new_users.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_new_users.sql
@@ -1,0 +1,22 @@
+{{ config(materialized="table", snowflake_warehouse="HYPERLIQUID") }}
+
+with latest_source_json as (
+    select extraction_date, source_url, source_json
+    from {{ source("PROD_LANDING", "raw_hyperliquid_new_users") }}
+    where extraction_date = (select max(extraction_date) from {{ source("PROD_LANDING", "raw_hyperliquid_new_users") }})
+),
+
+extracted_new_users as (
+    select
+        value:cumulative_new_users::number as cumulative_new_users
+        , value:daily_new_users::number as new_users
+        , value:time as timestamp
+    from latest_source_json, lateral flatten(input => parse_json(source_json))
+)
+
+select
+    date(timestamp) as date,
+    cumulative_new_users
+    , new_users
+    , 'hyperliquid' as chain
+from extracted_new_users

--- a/models/staging/hyperliquid/fact_hyperliquid_supply_data.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_supply_data.sql
@@ -1,0 +1,88 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="HYPERLIQUID"
+    )
+}}
+
+
+with hyperliquid_genesis as (
+    select
+        date(extraction_date) as date,
+        count(*) as user_balance_count,
+        sum(try_to_decimal(f.value[1]::string)) as total_balance
+    from landing_database.prod_landing.raw_hyperliquid_supply_data,
+    lateral flatten(input => source_json:genesis.userBalances) as f
+    group by date(extraction_date)
+)
+, unvested_tokens as (
+    select
+        date(extraction_date) as date
+        , sum(try_to_decimal(f.value[1]::string)) as unvested_tokens
+    from landing_database.prod_landing.raw_hyperliquid_supply_data,
+        lateral flatten(input => source_json:nonCirculatingUserBalances) as f
+    where f.value[0] = '0x43e9abea1910387c4292bca4b94de81462f8a251'
+    group by date(extraction_date)
+)
+, dead_tokens as (
+    select
+        date(extraction_date) as date
+        , sum(try_to_decimal(f.value[1]::string)) as dead_tokens
+    from landing_database.prod_landing.raw_hyperliquid_supply_data,
+        lateral flatten(input => source_json:nonCirculatingUserBalances) as f
+    where f.value[0] in ('0x0000000000000000000000000000000000000000', '0x000000000000000000000000000000000000dead')
+    group by date(extraction_date)
+)
+, hyperliquid_metrics as (
+    select
+        date(extraction_date) as date,
+        max(try_to_decimal(source_json:maxSupply::string)) as max_supply,
+        max(try_to_decimal(source_json:totalSupply::string)) as hype_total_supply,
+        max(try_to_decimal(source_json:circulatingSupply::string)) as circulating_supply,
+        max(try_to_decimal(source_json:futureEmissions::string)) as future_emissions
+    from landing_database.prod_landing.raw_hyperliquid_supply_data
+    group by date(extraction_date)
+)
+, foundation_owned as (
+    select
+        date(extraction_date) as date
+        , sum(try_to_decimal(f.value[1]::string)) as foundation_owned
+    from landing_database.prod_landing.raw_hyperliquid_supply_data supply,
+        lateral flatten(input => source_json:genesis.userBalances) as f
+    where f.value[0] in ('0xd57ecca444a9acb7208d286be439de12dd09de5d', '0xa20fcfa0507fe762011962cc581b95bbbc3bbdba', '0xffffffffffffffffffffffffffffffffffffffff')
+    group by date(extraction_date)
+)
+, burn_tokens as (
+    select
+        date
+        , case when 
+            date = '2025-06-16' then (max_supply - hype_total_supply)
+        else (hype_total_supply - lag(hype_total_supply) over (order by date) ) * -1
+    end as burn_tokens
+    from hyperliquid_metrics
+)
+, cumulative_burn_tokens as (
+    select
+        burn_tokens.date
+        , sum(burn_tokens) over (order by burn_tokens.date) as cumulative_burn_tokens
+        , sum(burn_tokens) over (order by burn_tokens.date) + coalesce(dead_tokens.dead_tokens, 0) as burn_tokens
+    from burn_tokens
+    left join dead_tokens on dead_tokens.date = burn_tokens.date
+)
+select
+    hype.date
+    , max_supply
+    -- futureEmissions increases as undistributed tokens are allocated for future distribution
+    , future_emissions as uncreated_tokens
+    , (max_supply - uncreated_tokens) as total_supply
+    , burn_tokens
+    , foundation_owned
+    , total_supply - foundation_owned - burn_tokens as issued_supply
+    , unvested_tokens
+    , issued_supply - unvested_tokens as circulating_supply
+from hyperliquid_metrics hype
+left join hyperliquid_genesis genesis on hype.date = genesis.date
+left join unvested_tokens unvested on hype.date = unvested.date
+left join foundation_owned foundation on hype.date = foundation.date
+left join cumulative_burn_tokens cumulative_burns on hype.date = cumulative_burns.date
+order by hype.date desc


### PR DESCRIPTION
## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
`dbt build fact_hyperliquid_new_users+`
<img width="881" alt="image" src="https://github.com/user-attachments/assets/10014e08-c9e1-4c57-9991-462d95edd4bc" />

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/90888347-097d-41af-a55f-158366edfcec" />

`dbt build fact_hyperliquid_supply_data+`
<img width="832" alt="image" src="https://github.com/user-attachments/assets/6baa80f6-83fd-4341-875e-46f6b087c4e9" />
<img width="870" alt="image" src="https://github.com/user-attachments/assets/6016a0c7-efd9-4db8-9ce0-ed32f5deb1ea" />


- [x] Successful RETL screenshot
<img width="686" alt="image" src="https://github.com/user-attachments/assets/e2606eb4-8951-4cd4-953b-1ce92a89dfe8" />

- [x] Ran make generate schema for changed assets
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/fd8dc71a-6156-44a4-933c-e184d8672abe" />

- [x] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other

We only start indexing supply data for hyperliquid from `2025-06-16`
