### PR TITLE
Update decoder to v5

### DIFF
--- a/macros/standardization/decode_artemis_events.sql
+++ b/macros/standardization/decode_artemis_events.sql
@@ -1,4 +1,24 @@
 {% macro decode_artemis_events(chain) %}
+    with
+    events as (
+        select
+            block_number
+            , block_timestamp
+            , transaction_hash
+            , transaction_index
+            , event_index
+            , contract_address
+            , topic_data
+            , topic_zero
+            , topics
+            , data
+            , array_size(topics) - 1 as indexed_topic_count
+        from {{ ref("fact_" ~ chain ~ "_events") }}
+        {% if is_incremental() %}
+            where
+                block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+        {% endif %}
+    )
     select
         block_number
         , block_timestamp
@@ -9,17 +29,13 @@
         , topic_data
         , data
         , b.event_name
-        , pc_dbt_db.prod.decode_evm_event_log_v4(event_info, data, topics) AS decoded_log_with_status
+        , pc_dbt_db.prod.decode_evm_event_log_v5(event_info, data, topics) AS decoded_log_with_status
         , decoded_log_with_status[0] as decoded_log
         , decoded_log_with_status[1]::boolean as decoded_log_status
         , b.topic_zero
         , b.event_info
-    from {{ ref("fact_" ~ chain ~ "_events") }} a
+    from events a
     inner join {{ ref("dim_events_silver") }} b 
-        on a.topic_zero = b.topic_zero
-    {% if is_incremental() %}
-        where
-            block_timestamp
-            >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
-    {% endif %}
+        -- We need to join on the number of indexed topics
+        on a.topic_zero = b.topic_zero and a.indexed_topic_count = b.indexed_topic_count
 {% endmacro %}

--- a/models/dimensions/events/dim_events_silver.sql
+++ b/models/dimensions/events/dim_events_silver.sql
@@ -1,8 +1,7 @@
 {{ 
     config(
         materialized="table",
-        unique_key="topic_zero",
-        sort="topic_zero",
+        unique_key=["topic_zero", "indexed_topic_count"],
         snowflake_warehouse='BALANCES_LG',
     ) 
 }}
@@ -12,7 +11,7 @@ event_signatures as (
         value:"name"::string as event_name,
         value as event_info,
         {{ target.schema }}.event_info_to_keccak_event_signature_v2(value) as topic_zero,
-        row_number() over (partition by topic_zero order by event_name) as event_id,
+        
         'artemis' as source
     from {{ ref("dim_contract_abis") }}, lateral flatten(input => abi) as f
     where value:"type" = 'event'
@@ -23,16 +22,35 @@ event_signatures as (
         value:"name"::string as event_name,
         value as event_info,
         {{ target.schema }}.event_info_to_keccak_event_signature_v2(value) as topic_zero,
-        row_number() over (partition by topic_zero order by event_name) as event_id,
         source
     from {{ source("DECODING", "dim_all_abis") }}, lateral flatten(input => abi) as f
     where value:"type" = 'event'
+)
+, event_signatures_with_row_id as (
+    select
+        event_name,
+        event_info,
+        topic_zero,
+        source,
+        row_number() over (partition by topic_zero order by event_name) as row_id
+    from event_signatures
+)
+, event_signatures_with_index_number as (
+    select
+        event_name,
+        event_info,
+        topic_zero,
+        source,
+        row_id,
+        COUNT_IF(f.value:"indexed"::BOOLEAN = TRUE) AS indexed_topic_count
+    from event_signatures_with_row_id, LATERAL FLATTEN(input => event_info:"inputs") AS f
+    group by event_name, event_info, topic_zero, source, row_id
 )
 select 
     event_name,
     event_info,
     topic_zero,
+    indexed_topic_count,
     source
-from event_signatures
-where event_id = 1 and event_name not in ('AuthorizationCanceled', 'ValidatorEcdsaPublicKeyUpdated', 'ValidatorBlsPublicKeyUpdated', 'AuthorizationUsed', 'TransferComment') -- These events emit types currently not supported by the decode_evm_event_log function
-QUALIFY ROW_NUMBER() OVER (PARTITION BY topic_zero ORDER BY source = 'artemis' DESC) = 1
+from event_signatures_with_index_number
+QUALIFY ROW_NUMBER() OVER (PARTITION BY topic_zero, indexed_topic_count ORDER BY source = 'artemis' DESC) = 1


### PR DESCRIPTION
1. Update the decoder to use web3 py lib
2. We need to join on both the topiczero and the number of indexed topics

# Test
The new number of failed events is much lower that the previous decoders.
<img width="1155" alt="Screenshot 2025-06-24 at 7 25 03 PM" src="https://github.com/user-attachments/assets/67d7d851-2314-46cb-b00a-fd30f08ba6f5" />

Previously there were 381 logs we could not decode

<img width="1271" alt="Screenshot 2025-06-25 at 9 28 10 AM" src="https://github.com/user-attachments/assets/fa4c0da0-3d89-481e-988d-b22dce55456b" />

