### PR TITLE
add gross_emissions to avalanche ez_metrics

### DIFF
--- a/models/projects/avalanche/core/__avalanche__schema.yml
+++ b/models/projects/avalanche/core/__avalanche__schema.yml
@@ -90,6 +90,10 @@ column_definitions:
     name: emissions_native
     description: "The amount of native tokens emitted"
 
+  gross_emissions: &gross_emissions
+    name: gross_emissions
+    description: "The amount of native tokens emitted in USD"
+
   fdmc: &fdmc
     name: fdmc
     description: "The fully diluted market cap of a token in USD"
@@ -344,6 +348,7 @@ models:
       - *chain_wau
       - *dau_over_100_balance
       - *emissions_native
+      - *gross_emissions
       - *fdmc
       - *ecosystem_revenue
       - *ecosystem_revenue_native

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -100,6 +100,7 @@ select
     , case when fees is null then fees_native * price else fees end as burned_fee_allocation
     -- Supply Metrics
     , issuance AS emissions_native
+    , issuance * price AS gross_emissions
     -- Developer Metrics
     , weekly_commits_core_ecosystem
     , weekly_commits_sub_ecosystem


### PR DESCRIPTION
## Summary
Adding `gross_emissions` column to `avalanche_ez_metrics` which is `issuance` * `price`

## Testing
- [X] `dbt build model_name+` screenshot (must include downstream models)

![Screenshot 2025-06-26 at 3 05 48 PM](https://github.com/user-attachments/assets/1e023f21-bfd2-4dc0-921b-ce3e0e9524c1)

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
