### PR TITLE
c911: Updating token transfers macro

### DIFF
--- a/macros/standardization/token_transfer_events.sql
+++ b/macros/standardization/token_transfer_events.sql
@@ -54,8 +54,8 @@ select
     , transaction_index
     , event_index
     , token_transfers.contract_address
-    , from_address
-    , to_address
+    , lower(from_address) as from_address
+    , lower(to_address) as to_address
     , amount_raw
     , amount_raw / pow(10, contract_addresses.decimals) as amount_native
     , amount_native * prices.price as amount


### PR DESCRIPTION
1. All upstream tables assume that the addresses are the same case. This breaks a lot of our upstream logic and we need to force the to and the from address to be lowercase