### PR TITLE
dataquality/gmx historic pricing fix

### DIFF
--- a/models/staging/gmx/fact_arbitrum_historic_pricing.sql
+++ b/models/staging/gmx/fact_arbitrum_historic_pricing.sql
@@ -37,6 +37,7 @@ usdc_historic_prices as (
       FALSE AS is_native,
       FALSE AS is_imputed,
       FALSE AS is_deprecated,
+      FALSE AS is_verified,
       NULL AS ez_prices_hourly_id,
       CURRENT_TIMESTAMP() AS inserted_timestamp,
       CURRENT_TIMESTAMP() AS modified_timestamp,


### PR DESCRIPTION
Flipside arbitrum historic pricing changed schema's (added one column is_verified), throwing off the gmx daily job.

Added:
- added a schema change in fact_arbitrum_historic_pricing to re-enable the daily gmx job