### PR TITLE
Akhill/optimism revenue supply

### DIFF
--- a/models/projects/optimism/core/__optimism__schema.yml
+++ b/models/projects/optimism/core/__optimism__schema.yml
@@ -72,6 +72,10 @@ column_definitions:
     name: chain_wau
     description: "Weekly unique users on a chain"
 
+  circulating_supply_native: &circulating_supply_native
+    name: circulating_supply_native
+    description: "The circulating supply of a token in native tokens"
+
   dau_over_100_balance: &dau_over_100_balance
     name: dau_over_100_balance
     description: "The number of users on a chain who have made over 100 transactions"
@@ -323,6 +327,7 @@ models:
       - *chain_spot_volume
       - *chain_txns
       - *chain_wau
+      - *circulating_supply_native
       - *dau_over_100_balance
       - *earnings
       - *fdmc

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -2,7 +2,7 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="ANALYTICS_XL",
+        snowflake_warehouse="optimism",
         database="optimism",
         schema="core",
         alias="ez_metrics",
@@ -63,6 +63,7 @@ with
         )
         select
             date, 
+            total_vested_supply, 
             (select total_insider_allocation from total_insider_allocation) - total_vested_supply AS total_unvested_supply
         from {{ ref("fact_optimism_all_supply_events") }}
     )
@@ -178,7 +179,6 @@ select
     , cumulative_mints_native AS total_supply_native
     , cumulative_mints_native - cumulative_burns_native - foundation_owned_supply_native AS issued_supply_native
     , cumulative_mints_native - cumulative_burns_native - foundation_owned_supply_native - total_unvested_supply AS circulating_supply_native
-
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -2,7 +2,7 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="ANALYTICS_XL",
+        snowflake_warehouse="OPTIMISM",
         database="optimism",
         schema="core",
         alias="ez_metrics",
@@ -65,14 +65,10 @@ with
         from {{ ref("fact_optimism_mints_burns") }}
     )
     , unvested_supply as (
-        with total_insider_allocation as (
-            select sum(amount) as total_insider_allocation
-            from {{ref("fact_optimism_insider_unlocks")}}
-        )
         select
             date, 
             total_vested_supply, 
-            (select total_insider_allocation from total_insider_allocation) - total_vested_supply AS total_unvested_supply
+            1545523296 - total_vested_supply AS total_unvested_supply
         from {{ ref("fact_optimism_all_supply_events") }}
     )
     , owned_supply as (
@@ -188,6 +184,8 @@ select
     , cumulative_mints_native AS total_supply_native
     , cumulative_mints_native - cumulative_burns_native - foundation_owned_supply_native AS issued_supply_native
     , cumulative_mints_native - cumulative_burns_native - foundation_owned_supply_native - total_unvested_supply AS circulating_supply_native
+    , total_unvested_supply
+    , foundation_owned_supply_native
 from fundamental_data
 left join price_data on fundamental_data.date = price_data.date
 left join defillama_data on fundamental_data.date = defillama_data.date

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -2,7 +2,7 @@
 {{
     config(
         materialized="table",
-        snowflake_warehouse="optimism",
+        snowflake_warehouse="ANALYTICS_XL",
         database="optimism",
         schema="core",
         alias="ez_metrics",
@@ -50,9 +50,10 @@ with
     , revenue_share as (
         select
             date, 
-            revenue_share_native,
-            revenue_share
+            sum(revenue_share_native) as revenue_share_native,
+            sum(revenue_share) as revenue_share
         from {{ ref("fact_optimism_revenue_share") }}
+        group by 1
     )
     , mints_burns as (
         select

--- a/models/projects/optimism/raw/supply_metrics/dim_optimism_owned_addresses.sql
+++ b/models/projects/optimism/raw/supply_metrics/dim_optimism_owned_addresses.sql
@@ -14,5 +14,11 @@ from (values
     ('0x2A82Ae142b2e62Cb7D10b55E323ACB1Cab663a26'), -- OP Treasury Address for Foundation Allocated Budget
     ('0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'), -- OP Treasury Address for Foundation Approved Budget
     ('0x19793c7824Be70ec58BB673CA42D2779d12581BE'), -- OP Foundation Grants Wallet
-    ('0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F') -- OP Foundation Locked Grants Wallet
+    ('0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F'), -- OP Foundation Locked Grants Wallet
+    ('0x44A2CaD21c3FC84652C7675d8cdB2e871BC06cf4'), -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
+    ('0x19793c7824Be70ec58BB673CA42D2779d12581BE'), -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
+    ('0xb3C2f9fC2727078EC3A2255410e83BA5B62c5B5f'), -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
+    ('0xAcf32F4e1260636cf1e3066c060C74AD52fE4E9e'), -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
+    ('0xE74B1b7d78c180Ff937B464e544D0701038ACBF0'), -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
+    ('0x9a69d97a451643a0Bb4462476942D2bC844431cE') -- Wallet that receives large amounts of OP from the Foundation periodically for internal use or off-ramping
 ) as v(address)

--- a/models/projects/optimism/raw/supply_metrics/dim_optimism_owned_addresses.sql
+++ b/models/projects/optimism/raw/supply_metrics/dim_optimism_owned_addresses.sql
@@ -1,0 +1,18 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM",
+        database="optimism",
+        schema="raw",
+        alias="dim_optimism_owned_addresses",
+    )
+}}
+
+select address
+-- Source: https://community.optimism.io/welcome/faq/dashboard-trackers
+from (values
+    ('0x2A82Ae142b2e62Cb7D10b55E323ACB1Cab663a26'), -- OP Treasury Address for Foundation Allocated Budget
+    ('0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0'), -- OP Treasury Address for Foundation Approved Budget
+    ('0x19793c7824Be70ec58BB673CA42D2779d12581BE'), -- OP Foundation Grants Wallet
+    ('0xE4553b743E74dA3424Ac51f8C1E586fd43aE226F') -- OP Foundation Locked Grants Wallet
+) as v(address)

--- a/models/projects/optimism/raw/supply_metrics/fact_optimism_all_supply_events.sql
+++ b/models/projects/optimism/raw/supply_metrics/fact_optimism_all_supply_events.sql
@@ -85,7 +85,12 @@ cumulative_supply AS (
             COALESCE(investor_unlocks_supply, 0) + 
             COALESCE(base_grant_supply, 0) + 
             COALESCE(private_sale_supply, 0)
-        ) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_circulating_supply
+        ) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_circulating_supply, 
+
+        SUM( 
+            COALESCE(core_contributor_unlocks_supply, 0) + 
+            COALESCE(investor_unlocks_supply, 0)
+        ) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total_vested_supply
     FROM aggregated_events
 )
 

--- a/models/projects/optimism/raw/supply_metrics/fact_optimism_mints_burns.sql
+++ b/models/projects/optimism/raw/supply_metrics/fact_optimism_mints_burns.sql
@@ -1,0 +1,20 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM",
+        database="optimism",
+        schema="raw",
+        alias="fact_optimism_mints_burns",
+    )
+}}
+
+SELECT
+    date(block_timestamp) as date,
+    SUM(CASE WHEN LOWER(from_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as mints_native,
+    SUM(CASE WHEN LOWER(to_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as burns_native,
+    SUM(mints_native) OVER (ORDER BY date(block_timestamp) ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_mints_native,
+    SUM(burns_native) OVER (ORDER BY date(block_timestamp) ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_burns_native,
+FROM {{ source("OPTIMISM_FLIPSIDE", "ez_token_transfers") }}
+WHERE LOWER(contract_address) = LOWER('0x4200000000000000000000000000000000000042')
+GROUP BY 1
+ORDER BY 1

--- a/models/projects/optimism/raw/supply_metrics/fact_optimism_mints_burns.sql
+++ b/models/projects/optimism/raw/supply_metrics/fact_optimism_mints_burns.sql
@@ -8,13 +8,29 @@
     )
 }}
 
+WITH date_spine AS (
+    SELECT date
+    FROM {{ ref("dim_date_spine") }}
+    WHERE date >= '2022-04-26'
+    AND date < sysdate()
+)
+
+, mints_burns AS (
+    SELECT
+        date(block_timestamp) as date,
+        SUM(CASE WHEN LOWER(from_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as mints_native,
+        SUM(CASE WHEN LOWER(to_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as burns_native
+    FROM {{ source("OPTIMISM_FLIPSIDE", "ez_token_transfers") }}
+    WHERE LOWER(contract_address) = LOWER('0x4200000000000000000000000000000000000042')
+    GROUP BY 1
+)
+
 SELECT
-    date(block_timestamp) as date,
-    SUM(CASE WHEN LOWER(from_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as mints_native,
-    SUM(CASE WHEN LOWER(to_address) = '0x0000000000000000000000000000000000000000' THEN amount ELSE 0 END) as burns_native,
-    SUM(mints_native) OVER (ORDER BY date(block_timestamp) ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_mints_native,
-    SUM(burns_native) OVER (ORDER BY date(block_timestamp) ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_burns_native,
-FROM {{ source("OPTIMISM_FLIPSIDE", "ez_token_transfers") }}
-WHERE LOWER(contract_address) = LOWER('0x4200000000000000000000000000000000000042')
-GROUP BY 1
+    date,
+    COALESCE(mints_native, 0) as mints_native,
+    COALESCE(burns_native, 0) as burns_native,
+    SUM(COALESCE(mints_native, 0)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_mints_native,
+    SUM(COALESCE(burns_native, 0)) OVER (ORDER BY date ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumulative_burns_native
+FROM date_spine
+LEFT JOIN mints_burns USING (date)
 ORDER BY 1

--- a/models/projects/optimism/raw/supply_metrics/fact_optimism_owned_supply.sql
+++ b/models/projects/optimism/raw/supply_metrics/fact_optimism_owned_supply.sql
@@ -1,0 +1,17 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM",
+        database="optimism",
+        schema="raw",
+        alias="fact_optimism_owned_supply",
+    )
+}}
+
+
+{{get_entity_historical_balance(
+    chain='optimism',
+    table_name='dim_optimism_owned_addresses',
+    address_column='address',
+    earliest_date='2022-04-26'
+)}}

--- a/models/staging/optimism/fact_optimism_revenue_share.sql
+++ b/models/staging/optimism/fact_optimism_revenue_share.sql
@@ -1,0 +1,40 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="OPTIMISM"
+    )
+}}
+
+SELECT
+    block_timestamp, 
+    'base' AS chain, 
+    contract_address, 
+    tx_hash, 
+    decoded_log:_paidToOptimism::number/1e18 AS optimismFeeShare
+FROM base_flipside.core.ez_decoded_event_logs
+WHERE event_name = 'FeesDisbursed'
+
+UNION ALL 
+
+SELECT 
+    block_timestamp, 
+    'ethereum' AS chain, 
+    contract_address, 
+    tx_hash, 
+    decoded_log:amount::number/1e18 AS optimismFeeShare
+FROM ethereum_flipside.core.ez_decoded_event_logs
+WHERE LOWER(decoded_log:to::string) IN (LOWER('0xa3d596eafab6b13ab18d40fae1a962700c84adea'), 
+                                        LOWER('0x391716d440c151c42cdf1c95c1d83a5427bca52c')
+                                        )
+    AND event_name = 'ETHBridgeFinalized'
+
+UNION ALL
+
+SELECT
+    block_timestamp, 
+    'unichain' AS chain, 
+    contract_address, 
+    transaction_hash, 
+    decoded_log:reflectionFee::number/1e18 AS optimismFeeShare  
+FROM PC_DBT_DB.PROD.FACT_UNICHAIN_DECODED_EVENTS
+WHERE event_name = 'FeesDistributed'

--- a/models/staging/optimism/fact_optimism_revenue_share.sql
+++ b/models/staging/optimism/fact_optimism_revenue_share.sql
@@ -5,36 +5,49 @@
     )
 }}
 
+WITH revenue_share AS (
+    SELECT
+        block_timestamp, 
+        'base' AS chain, 
+        contract_address, 
+        tx_hash, 
+        decoded_log:_paidToOptimism::number/1e18 AS optimismFeeShare
+    FROM base_flipside.core.ez_decoded_event_logs
+    WHERE event_name = 'FeesDisbursed'
+
+    UNION ALL 
+
+    SELECT 
+        block_timestamp, 
+        'ethereum' AS chain, 
+        contract_address, 
+        tx_hash, 
+        decoded_log:amount::number/1e18 AS optimismFeeShare
+    FROM ethereum_flipside.core.ez_decoded_event_logs
+    WHERE LOWER(decoded_log:to::string) IN (LOWER('0xa3d596eafab6b13ab18d40fae1a962700c84adea'), 
+                                            LOWER('0x391716d440c151c42cdf1c95c1d83a5427bca52c')
+                                            )
+        AND event_name = 'ETHBridgeFinalized'
+
+    UNION ALL
+
+    SELECT
+        block_timestamp, 
+        'unichain' AS chain, 
+        contract_address, 
+        transaction_hash, 
+        decoded_log:reflectionFee::number/1e18 AS optimismFeeShare  
+    FROM PC_DBT_DB.PROD.FACT_UNICHAIN_DECODED_EVENTS
+    WHERE event_name = 'FeesDistributed'
+)
+, eth_prices AS ({{get_coingecko_price_with_latest("ethereum")}})
+
 SELECT
-    block_timestamp, 
-    'base' AS chain, 
-    contract_address, 
-    tx_hash, 
-    decoded_log:_paidToOptimism::number/1e18 AS optimismFeeShare
-FROM base_flipside.core.ez_decoded_event_logs
-WHERE event_name = 'FeesDisbursed'
-
-UNION ALL 
-
-SELECT 
-    block_timestamp, 
-    'ethereum' AS chain, 
-    contract_address, 
-    tx_hash, 
-    decoded_log:amount::number/1e18 AS optimismFeeShare
-FROM ethereum_flipside.core.ez_decoded_event_logs
-WHERE LOWER(decoded_log:to::string) IN (LOWER('0xa3d596eafab6b13ab18d40fae1a962700c84adea'), 
-                                        LOWER('0x391716d440c151c42cdf1c95c1d83a5427bca52c')
-                                        )
-    AND event_name = 'ETHBridgeFinalized'
-
-UNION ALL
-
-SELECT
-    block_timestamp, 
-    'unichain' AS chain, 
-    contract_address, 
-    transaction_hash, 
-    decoded_log:reflectionFee::number/1e18 AS optimismFeeShare  
-FROM PC_DBT_DB.PROD.FACT_UNICHAIN_DECODED_EVENTS
-WHERE event_name = 'FeesDistributed'
+    date(block_timestamp) as date,
+    chain,
+    contract_address,
+    tx_hash,
+    optimismFeeShare AS revenue_share_native,
+    optimismFeeShare * eth_prices.price AS revenue_share
+FROM revenue_share
+left join eth_prices on date(block_timestamp) = eth_prices.date


### PR DESCRIPTION
## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

<img width="1449" alt="Screenshot 2025-06-27 at 8 27 46 PM" src="https://github.com/user-attachments/assets/ecd00812-5192-46bb-83ca-b7dbebdb3fe0" />
<img width="1449" alt="Screenshot 2025-06-27 at 8 27 51 PM" src="https://github.com/user-attachments/assets/8b269834-85e1-4c08-b9eb-4cd1db778935" />
<img width="1449" alt="Screenshot 2025-06-27 at 8 28 11 PM" src="https://github.com/user-attachments/assets/12a8f556-cc67-42a8-bf20-9cb085d0599d" />
<img width="1449" alt="Screenshot 2025-06-27 at 8 28 17 PM" src="https://github.com/user-attachments/assets/690f32c8-9df5-4afb-9d78-5e32f925aa76" />
<img width="1449" alt="Screenshot 2025-06-27 at 8 42 04 PM" src="https://github.com/user-attachments/assets/aeba6aab-9bd4-4045-bd95-e259a4d83d9f" />

- [X] Successful RETL screenshot

<img width="1459" alt="Screenshot 2025-06-27 at 8 59 30 PM" src="https://github.com/user-attachments/assets/c5494fcb-f8a8-4104-915d-f94611d1781e" />

- [X] Ran make generate schema for changed assets

<img width="1900" alt="Screenshot 2025-06-27 at 8 52 55 PM" src="https://github.com/user-attachments/assets/74545bce-ac87-43e3-a744-1bf9a3d6ba9c" />


- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [x] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other

Note about Optimism Circulating Supply: 

- Even though the circulating supply numbers are the same, there is a massive difference in methodologies which must be explained. 
- We calculate circulating supply as `max_supply - foundation_owned_supply - unvested_supply`. There are some burns, but it's negligible. 
- The `foundation_owned_supply` we calculate here come from addresses linked in Optimism's [docs](https://community.optimism.io/welcome/faq/dashboard-trackers), as well as some addresses with high $OP balances that have directly received $OP from the Foundation [address](0x2501c477D0A35545a387Aa4A3EEe4292A9a8B3F0) which is said to typically have internal operational transactions. 
- OP calculates circulating supply as `unrestricted_foundation_owned_supply + vested_supply + airdrops + RPGF`. [RPGF](https://community.optimism.io/citizens-house/how-retro-funding-works) is their public goods funding program.  
- On first glance, the major difference seems to arise from their inclusion of `unrestricted_foundation_owned_supply` while we exclude that from circulating supply, but the real difference is that the rest of our formula `max_supply - unvested_supply` includes the complete allocation of airdrops and RPGF, while OP's formula only includes a portion of that (see SS below). 

<img width="1320" alt="Screenshot 2025-06-27 at 11 26 24 PM" src="https://github.com/user-attachments/assets/405ef152-6049-44e7-b5e5-eb737805a0d0" />

- Ideally the allocation that's made to airdrops and RPGF is included in the foundation addresses whose balances we're excluding (about 2B in OP overall), but if you take the sum of the total OP allocation from the SS above and subtract the current `Airdrops + RPGF`, you get around 2.4B. 
- The 400M discrepancy can be put down to two probable causes: 
  - The Foundation address has sent $OP to over 400k different wallet addresses – tracking $OP to all these addresses and calculating balances is needlessly taxing
  - Coinbase, Binance and Gemini hold large amounts of $OP (some of the wallets have been transferred $OP directly from wallets that were in turn transferred $OP from the Foundation wallet) which could mean that some of the "locked" supply is held on CEXes which we can't account for. 

Note about Optimism Revenue: 

- In 2024, Optimism introduced a fee split [mechanism](https://optimism.mirror.xyz/ciJzgxmb_fJU8wgiqrEXG_XYnAkuBrdG1biVk0BseiU) for its Superchain ecosystem where Optimism-based chains (Base, Unichain, etc.) would share a portion of their revenue with Optimism that would go to the DAO. 
- Previously, revenue was only calculated as `L2 Base Fees + Operator Fees + Priority Fees`, but the revenue share meant further value accrual to the token holder
- The problem arises because the fee share on some days is many many times higher than the overall fees generated by OP Mainnet, which distorts figures. 
- In just one [transaction](https://optimism.mirror.xyz/ciJzgxmb_fJU8wgiqrEXG_XYnAkuBrdG1biVk0BseiU), the fee sharing wallet (taken from the Optimism draft [PR](https://github.com/ethereum-optimism/op-analytics/pull/1651) which has this file shown in the SS below) received about $8M in $ETH. 

<img width="1523" alt="Screenshot 2025-06-27 at 8 55 14 PM" src="https://github.com/user-attachments/assets/407e4e77-d94e-44dd-9ce0-979408cb938a" />

- There are many such cases, and the SS below shows how much greater revenue is for Optimism with the fee split

<img width="1532" alt="Screenshot 2025-06-27 at 8 50 02 PM" src="https://github.com/user-attachments/assets/ee3055ee-d798-4415-b35b-983cfc2f0f44" />


