### PR TITLE
Adding OFT address to remove supply from it

### DIFF
--- a/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
+++ b/models/metrics/stablecoins/contracts/fact_ethereum_stablecoin_premint_addresses.sql
@@ -66,5 +66,10 @@ from
             (
                 '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e',
                 '0x652aEa6B22310C89DCc506710CaD24d2Dba56B11'
+            ),
+            -- Ethena OFT address
+            (
+                '0x4c9EDD5852cd905f086C759E8383e09bff1E68B3',
+                '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34'
             )
     ) as results(contract_address, premint_address)


### PR DESCRIPTION
## Problem
USDe uses OFT to bridge token from one chain to another. Therefore, our numbers are inflated because we are not removing the balances in the OFT address that is locked up.

## Solution
Add to bridged addresses.

## Test
<img width="914" alt="image" src="https://github.com/user-attachments/assets/9bb3e978-76c9-43f7-a353-3604841d96ea" />
get the OFT address from
https://layerzeroscan.com/application/ethena

our current numbers : 5298607470.57
DFL numbers : 5096000000
This will account for the ~200M difference