### PR TITLE
Fix view sql in ez_optimism_bridge_transfers

### DIFF
--- a/models/projects/optimism/raw/ez_optimism_bridge_transfers.sql
+++ b/models/projects/optimism/raw/ez_optimism_bridge_transfers.sql
@@ -11,11 +11,11 @@
 
 select 
     block_timestamp,
-    tx_hash as ethereum_tx_hash,
+    transaction_hash as ethereum_tx_hash,
     event_index,
     depositor as source_address,
     recipient as destination_address,
-    amount,
+    amount_native as amount,
     token_address as ethereum_token_address,
     source_chain,
     destination_chain


### PR DESCRIPTION
## Summary
<img width="770" alt="image" src="https://github.com/user-attachments/assets/acaef483-4c46-42a0-ba11-f2f86ea7f8bf" />

Upstream column names  in `fact_optimism_bridge_transfers` are `transaction_hash` and `amount_native` 
<img width="381" alt="image" src="https://github.com/user-attachments/assets/065ef69a-bb6a-4c93-9ffc-51ddb2a9a550" />


## Test Plan
- Ran compiled sql
<img width="770" alt="image" src="https://github.com/user-attachments/assets/310f0cb4-47bb-45ec-b31b-46c201415621" />
