### PR TITLE
Add latest github metrics data macro to ez table model

### DIFF
--- a/macros/metrics/get_github_metrics.sql
+++ b/macros/metrics/get_github_metrics.sql
@@ -22,6 +22,8 @@
     left join
         pc_dbt_db.prod.core_ecosystems as ecosystems
         on commits_core.ecosystem_id = ecosystems.id
-    where lower(ecosystem_name) = lower('{{ ecosystem }}')
+    where 
+        lower(ecosystem_name) = lower('{{ ecosystem }}')
+        AND commits_core.date <= {{ latest_developer_data_date() }}
     order by date desc
 {% endmacro %}


### PR DESCRIPTION
## Summary
- Set latest available date for Developer Metrics in ez tables to 2 Sundays ago given underlying changes in the github

## Testing

- [ x] `dbt build model_name+` screenshot (must include downstream models)
Ran compiled sql for `ez_cardano_metrics`, latest data available is 6/15 as expected
<img width="621" alt="image" src="https://github.com/user-attachments/assets/68859d4e-1b63-4d9a-a8bf-c84642bf208f" />
