### PR TITLE
Add system program ID to skip list for solana transactions

### DIFF
--- a/models/staging/solana/fact_solana_transactions_v2.sql
+++ b/models/staging/solana/fact_solana_transactions_v2.sql
@@ -88,7 +88,8 @@ with
                 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr',
                 'Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo',
                 '11111111111111111111111111111111',
-                'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
+                'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                'Ed25519SigVerify111111111111111111111111111'
             )
         group by tx_id
     ),


### PR DESCRIPTION
# Description

Add system program ID to skip list for solana transactions. Discovered that the current skip list list doesn't include `Ed25519SigVerify111111111111111111111111111`, and it has been overriding the actual program id in the final `fact_solana_transactions_v2` table because it's a min_by(value:"programId"::string, index) as program_id and that program id comes before the actual program id.

# Tests

Need to backfill Solana transactions :(