### PR TITLE
add revenue to datahub

### DIFF
--- a/models/common/ez_protocol_datahub.sql
+++ b/models/common/ez_protocol_datahub.sql
@@ -15,6 +15,7 @@ select
     txns,
     volume,
     fees,
+    revenue,
     tvl,
     price,
     market_cap,

--- a/models/common/ez_protocol_datahub_by_chain.sql
+++ b/models/common/ez_protocol_datahub_by_chain.sql
@@ -16,6 +16,7 @@ select
     txns,
     volume,
     fees,
+    revenue,
     tvl,
     price,
     market_cap,

--- a/models/data_hubs/fact_protocol_datahub_by_chain_gold.sql
+++ b/models/data_hubs/fact_protocol_datahub_by_chain_gold.sql
@@ -11,6 +11,7 @@ SELECT
     txns::number as txns,
     volume::number as volume,
     fees::number as fees,
+    revenue::number as revenue,
     tvl::number as tvl,
     price::float as price,
     market_cap::number as market_cap,

--- a/models/data_hubs/fact_protocol_datahub_gold.sql
+++ b/models/data_hubs/fact_protocol_datahub_gold.sql
@@ -10,6 +10,7 @@ SELECT
     txns::number as txns,
     volume::number as volume,
     fees::number as fees,
+    revenue::number as revenue,
     tvl::number as tvl,
     price::float as price,
     market_cap::number as market_cap,


### PR DESCRIPTION
### Context
Adding revenue to datahub to make it a more powerful tool.

## Testing

- [ ] `dbt build model_name+` screenshot (must include downstream models)
Job to create the silver table runs:
![CleanShot 2025-07-06 at 18 55 40@2x](https://github.com/user-attachments/assets/697fc587-d8d7-4f24-897d-25c734260e64)

Downstream gold and ez tables run:
![CleanShot 2025-07-06 at 18 56 08@2x](https://github.com/user-attachments/assets/8513df34-e29c-43d1-b0c7-326e0ec26c91)



- [ ] Successful RETL screenshot
N/A

- [ ] Ran make generate schema for changed assets
N/A

- [ ] Screenshots of changed data **in local frontend**
N/A

Revenue by app by month - interesting to see the evolution and diversification of revenue-generating apps:
![CleanShot 2025-07-06 at 19 00 02@2x](https://github.com/user-attachments/assets/b40a9c56-5783-417e-beb9-bd88bf6fcfb6)

About 47% of entries have non-null revenue.
![CleanShot 2025-07-06 at 18 57 12@2x](https://github.com/user-attachments/assets/06f49ea2-0278-4ca6-82c4-72605d7519cb)


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
