### PR TITLE
Add stargate by token into duckdb

### DIFF
--- a/iceberg/models/ez_metrics/stargate/ez_stargate_metrics_by_token_iceberg.sql
+++ b/iceberg/models/ez_metrics/stargate/ez_stargate_metrics_by_token_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="STARGATE",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_TOKEN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, token'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM stargate.prod_core.ez_metrics_by_token

--- a/models/projects/stargate/core/__stargate__schema.yml
+++ b/models/projects/stargate/core/__stargate__schema.yml
@@ -34,7 +34,18 @@ column_definitions:
 
   circulating_supply_native: &circulating_supply_native
     name: circulating_supply_native
-    description: "The circulating supply of a token in native tokens"
+    description: "The circulating supply of a token, equal to the issued supply minus unvested tokens."
+    tags:
+      - artemis_gaap
+
+  date: &date
+    name: date
+    description: ""
+    tests:
+      - dbt_expectations.expect_column_to_exist
+      - not_null
+    tags:
+      - override
 
   fdmc: &fdmc
     name: fdmc
@@ -84,6 +95,15 @@ column_definitions:
     tags:
       - artemis_gaap
 
+  token: &token
+    name: token
+    description: ""
+    tests:
+      - dbt_expectations.expect_column_to_exist
+      - not_null
+    tags:
+      - override
+
   token_fee_allocation: &token_fee_allocation
     name: token_fee_allocation
     description: "The share of protocol revenue accrued to token holders of the protocol."
@@ -132,6 +152,7 @@ models:
       - *bridge_wau
       - *burns_native
       - *circulating_supply_native
+      - *date
       - *fdmc
       - *fees
       - *gross_emissions_native
@@ -150,6 +171,8 @@ models:
   - name: ez_stargate_metrics_by_token
     description: "This table stores metrics for the STARGATE protocol"
     columns:
+      - *date
+      - *token
       - *treasury
       - *treasury_native
 
@@ -158,6 +181,7 @@ models:
     columns:
       - *bridge_dau
       - *bridge_txns
+      - *date
       - *inflow
       - *outflow
       - *treasury


### PR DESCRIPTION
# Description

Adding stargate by token dimension type into duckdb so that we can query from DuckDB in the future for dimensiontypes by pool and token

# Tests

Ran `generate_schema.py` and `cd iceberg; dbt run -s ez_stargate_metrics_by_token_iceberg`