### PR TITLE
Example Slack Alert for Failed Docs Runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,14 +21,14 @@ jobs:
         with:
           python-version: '3.11'
 
-      # - name: Generate a Github App token
-      #   id: generate_token
-      #   uses: actions/create-github-app-token@v1
-      #   with:
-      #     app-id: ${{ secrets.ARTEMIS_CI_APP_ID }}
-      #     private-key: ${{ secrets.ARTEMIS_CI_APP_PRIVATE_KEY }}
-      #     owner: ${{ github.repository_owner }}
-      #     repositories: "artemis-xyz.github.io"
+      - name: Generate a Github App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.ARTEMIS_CI_APP_ID }}
+          private-key: ${{ secrets.ARTEMIS_CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: "artemis-xyz.github.io"
 
       - name: Init dbt
         uses: ./.github/actions/init-dbt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: docs
 on:
   push:
     branches: main
-  pull_request_target:
-    branches: main
 env:
   SYSTEM_SNOWFLAKE_USER: ${{ secrets.SYSTEM_SNOWFLAKE_USER }}
   SYSTEM_SNOWFLAKE_PASSWORD: ${{ secrets.SYSTEM_SNOWFLAKE_PASSWORD }}
@@ -62,14 +60,14 @@ jobs:
                   type: "mrkdwn"
                   text: "- <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failed Run>\n - <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|PR>\n - This PR was opened by `${{ github.event.pull_request.user.login }}`"
 
-      # - name: Push to Github Pages repo
-      #   uses: cpina/github-action-push-to-another-repository@v1.7.2
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ steps.generate_token.outputs.token }}
-      #   with:
-      #     source-directory: 'generated_dbt_docs'
-      #     target-directory: 'dbt'
-      #     destination-github-username: 'artemis-xyz'
-      #     destination-repository-name: 'artemis-xyz.github.io'
-      #     user-name: 'Artemis CI'
-      #     commit-message: 'update DBT docs'
+      - name: Push to Github Pages repo
+        uses: cpina/github-action-push-to-another-repository@v1.7.2
+        env:
+          API_TOKEN_GITHUB: ${{ steps.generate_token.outputs.token }}
+        with:
+          source-directory: 'generated_dbt_docs'
+          target-directory: 'dbt'
+          destination-github-username: 'artemis-xyz'
+          destination-repository-name: 'artemis-xyz.github.io'
+          user-name: 'Artemis CI'
+          commit-message: 'update DBT docs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,33 @@ jobs:
         uses: ./.github/actions/init-dbt
 
       - name: Generate docs
+        id: generateDocs
         run: |
+          exit 1
           dbt deps
           dbt docs generate --threads 16 --target prod
           git diff
           mkdir generated_dbt_docs
           mv "target/index.html" "target/manifest.json" "target/catalog.json" "target/partial_parse.msgpack" generated_dbt_docs
+
+      - name: Send Slack Alert
+        if: failure() && steps.generateDocs.outcome == 'failure'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: C03KWK6G7ME
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: "🚨🚨🚨 DBT Deploy FAILURE 🚨🚨🚨"
+                  emoji: true
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "- <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failed Run>\n - <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|PR>\n - This PR was opened by `${{ github.event.pull_request.user.login }}`"
 
       - name: Push to Github Pages repo
         uses: cpina/github-action-push-to-another-repository@v1.7.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 on:
   push:
     branches: main
+  pull_request_target:
+    branches: main
 env:
   SYSTEM_SNOWFLAKE_USER: ${{ secrets.SYSTEM_SNOWFLAKE_USER }}
   SYSTEM_SNOWFLAKE_PASSWORD: ${{ secrets.SYSTEM_SNOWFLAKE_PASSWORD }}
@@ -19,14 +21,14 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Generate a Github App token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.ARTEMIS_CI_APP_ID }}
-          private-key: ${{ secrets.ARTEMIS_CI_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: "artemis-xyz.github.io"
+      # - name: Generate a Github App token
+      #   id: generate_token
+      #   uses: actions/create-github-app-token@v1
+      #   with:
+      #     app-id: ${{ secrets.ARTEMIS_CI_APP_ID }}
+      #     private-key: ${{ secrets.ARTEMIS_CI_APP_PRIVATE_KEY }}
+      #     owner: ${{ github.repository_owner }}
+      #     repositories: "artemis-xyz.github.io"
 
       - name: Init dbt
         uses: ./.github/actions/init-dbt
@@ -60,14 +62,14 @@ jobs:
                   type: "mrkdwn"
                   text: "- <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Failed Run>\n - <${{ github.event.pull_request.html_url || github.event.head_commit.url }}|PR>\n - This PR was opened by `${{ github.event.pull_request.user.login }}`"
 
-      - name: Push to Github Pages repo
-        uses: cpina/github-action-push-to-another-repository@v1.7.2
-        env:
-          API_TOKEN_GITHUB: ${{ steps.generate_token.outputs.token }}
-        with:
-          source-directory: 'generated_dbt_docs'
-          target-directory: 'dbt'
-          destination-github-username: 'artemis-xyz'
-          destination-repository-name: 'artemis-xyz.github.io'
-          user-name: 'Artemis CI'
-          commit-message: 'update DBT docs'
+      # - name: Push to Github Pages repo
+      #   uses: cpina/github-action-push-to-another-repository@v1.7.2
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ steps.generate_token.outputs.token }}
+      #   with:
+      #     source-directory: 'generated_dbt_docs'
+      #     target-directory: 'dbt'
+      #     destination-github-username: 'artemis-xyz'
+      #     destination-repository-name: 'artemis-xyz.github.io'
+      #     user-name: 'Artemis CI'
+      #     commit-message: 'update DBT docs'


### PR DESCRIPTION
## Context
[ Write 1-3 sentences describing what you did and why here ]
- Add slack alerts for failed runs of the `generateDocs` workflow. Intentionally cause it to fail...will revert the `exit 1` in a fast follow PR
- [x] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [ ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
