### PR TITLE
Add EtherFi buybacks

### DIFF
--- a/models/projects/etherfi/core/__etherfi__schema.yml
+++ b/models/projects/etherfi/core/__etherfi__schema.yml
@@ -8,6 +8,10 @@ column_definitions:
     name: burns_native
     description: "The amount of native tokens burned"
 
+  buybacks: &buybacks
+    name: buybacks
+    description: "The amount tokens actually bought back by the protocol (USD)."
+
   equity_fee_allocation: &equity_fee_allocation
     name: equity_fee_allocation
     description: "Revenue distributed to EtherFi and Seven Seas teams. Calculated as 2% annually on EtherFi Liquid AUM."
@@ -19,6 +23,10 @@ column_definitions:
     description: "The fully diluted market cap of a token in USD"
     tags:
       - artemis_gaap
+
+  lrt_tvl: &lrt_tvl
+    name: lrt_tvl
+    description: "The total value locked in a liquid restaking protocol"
 
   market_cap: &market_cap
     name: market_cap
@@ -74,6 +82,7 @@ models:
   - name: ez_etherfi_metrics_by_chain
     description: "This table stores metrics for the ETHERFI protocol"
     columns:
+      - *lrt_tvl
       - *tvl
       - *tvl_native
 
@@ -81,8 +90,10 @@ models:
     description: "This table stores metrics for the ETHERFI protocol"
     columns:
       - *burns_native
+      - *buybacks
       - *equity_fee_allocation
       - *fdmc
+      - *lrt_tvl
       - *market_cap
       - *net_supply_change_native
       - *premine_unlocks_native

--- a/models/projects/etherfi/core/ez_etherfi_metrics.sql
+++ b/models/projects/etherfi/core/ez_etherfi_metrics.sql
@@ -58,6 +58,14 @@ with restaked_eth_metrics as (
     {{get_coingecko_metrics('ether-fi')}}
 )
 
+, buybacks as (
+    select
+        date
+        , ethfi_bought
+        , cumulative_ethfi_bought
+    from {{ ref('fact_etherfi_buybacks') }}
+)
+
 SELECT
     date_spine.date
     , 'etherfi' as app
@@ -78,6 +86,8 @@ SELECT
     , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
     , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
     , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
+    , buybacks.ethfi_bought as buybacks
+    , buybacks.cumulative_ethfi_bought as cumulative_buybacks
 
     --Cash Flow Metrics
     , coalesce(liquidity_pool_fees.fees_usd, 0) as liquidity_pool_fees
@@ -104,5 +114,6 @@ left join auction_fees using(date)
 left join defillama_tvl using(date)
 left join daily_supply_data using(date)
 left join market_metrics using(date)
+left join buybacks using(date)
 where date < to_date(sysdate())
 

--- a/models/projects/etherfi/core/ez_etherfi_metrics.sql
+++ b/models/projects/etherfi/core/ez_etherfi_metrics.sql
@@ -86,8 +86,8 @@ SELECT
     , restaked_eth_metrics.amount_restaked_usd as lrt_tvl
     , restaked_eth_metrics.num_restaked_eth_net_change as lrt_tvl_native_net_change
     , restaked_eth_metrics.amount_restaked_usd_net_change as lrt_tvl_net_change
-    , buybacks.ethfi_bought as buybacks
-    , buybacks.cumulative_ethfi_bought as cumulative_buybacks
+    , coalesce(buybacks.ethfi_bought, 0) as buyback
+    , coalesce(buybacks.cumulative_ethfi_bought, 0) as cumulative_buyback
 
     --Cash Flow Metrics
     , coalesce(liquidity_pool_fees.fees_usd, 0) as liquidity_pool_fees

--- a/models/staging/etherfi/__etherfi__source.yml
+++ b/models/staging/etherfi/__etherfi__source.yml
@@ -4,6 +4,7 @@ sources:
     database: LANDING_DATABASE
     tables:
       - name: raw_etherfi_restaked_eth_count
+      - name: raw_etherfi_buybacks
   - name: MANUAL_STATIC_TABLES
     schema: PROD
     database: PC_DBT_DB

--- a/models/staging/etherfi/fact_etherfi_buybacks.sql
+++ b/models/staging/etherfi/fact_etherfi_buybacks.sql
@@ -1,0 +1,33 @@
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="ETHERFI",
+    )
+}}
+
+{{
+    config(
+        materialized="table",
+        snowflake_warehouse="VIRTUALS",
+    )
+}}
+
+with
+    max_extraction as (
+        select max(extraction_date) as max_date
+        from {{ source("PROD_LANDING", "raw_etherfi_buybacks") }}
+        
+    ),
+    latest_data as (
+        select parse_json(source_json) as data
+        from {{ source("PROD_LANDING", "raw_etherfi_buybacks") }}
+        where extraction_date = (select max_date from max_extraction)
+    )
+select
+    to_date(to_timestamp_ntz(replace(f.value:hour::string, ' UTC', ''))) as date
+    , f.value:cum_ethfi_bought::number as cumulative_ethfi_bought
+    , f.value:ethfi_bought::number as ethfi_bought
+    , 'etherfi' as app
+    , 'ethereum' as chain
+    , 'DeFi' as category
+from latest_data, lateral flatten(input => data) f


### PR DESCRIPTION
## Context
[ Write 1-3 sentences describing what you did and why here ]

- [] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="981" height="267" alt="image" src="https://github.com/user-attachments/assets/d02be9f9-9c42-46a2-a55f-ceb9f46c6d2b" />

- [x] Successful RETL screenshot
<img width="1161" height="274" alt="image" src="https://github.com/user-attachments/assets/dc194d0a-5f61-4e91-9e11-40ad582aa0b7" />

- [x] Ran make generate schema for changed assets
<img width="992" height="378" alt="image" src="https://github.com/user-attachments/assets/d0d01faa-edc8-477d-b931-724dfd8a4b14" />

- [x] Screenshots of changed data **in local frontend**
<img width="1470" height="735" alt="image" src="https://github.com/user-attachments/assets/8c3c6bef-2eeb-47c6-8558-542efa7a6eb5" />

Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
Add a new metric for EtherFi (buybacks) - ask from customer's request
EtherFi's buybacks (https://etherfi.gitbook.io/gov/ethfi-buyback-program)
pipe it from backend into ez_metrics tables (backend PR - https://github.com/Artemis-xyz/gokustats-back-end/pull/3996)
