### PR TITLE
Akhil/solana dex volumes fix

### DIFF
--- a/models/staging/solana/fact_solana_dex_volumes.sql
+++ b/models/staging/solana/fact_solana_dex_volumes.sql
@@ -1,7 +1,7 @@
 -- This query is used to calculate the daily volume of dex swaps on Solana.
 -- It excludes marginfi flash loans and is used to calculate the daily volume of dex swaps on Solana.
 
-{{ config(materialized="table", snowflake_warehouse="ANALYTICS_XL") }}
+{{ config(materialized="table", snowflake_warehouse="SOLANA") }}
 
 WITH raydium_volume AS (
     WITH all_marginfi_flash_loans AS (

--- a/models/staging/solana/fact_solana_dex_volumes.sql
+++ b/models/staging/solana/fact_solana_dex_volumes.sql
@@ -171,22 +171,16 @@ jupiter_volume as (
 
 SELECT
     COALESCE(raydium.date, orca.date, other.date, pump_fun.date, lifinity.date, pumpswap.date, meteora.date, jupiter.date) AS date, 
-    COALESCE(raydium.trading_volume, 0) AS raydium_volume, 
-    COALESCE(orca.trading_volume, 0) AS orca_volume, 
-    COALESCE(other.trading_volume, 0) AS other_volume, 
-    COALESCE(pump_fun.trading_volume, 0) AS pump_fun_volume, 
-    COALESCE(lifinity.trading_volume, 0) AS lifinity_volume, 
-    COALESCE(pumpswap.trading_volume, 0) AS pumpswap_volume, 
-    COALESCE(meteora.trading_volume, 0) AS meteora_volume, 
-    COALESCE(jupiter.trading_volume, 0) AS jupiter_volume, 
-    COALESCE(raydium.trading_volume, 0) + 
-    COALESCE(orca.trading_volume, 0) + 
-    COALESCE(other.trading_volume, 0) + 
-    COALESCE(pump_fun.trading_volume, 0) + 
-    COALESCE(lifinity.trading_volume, 0) + 
-    COALESCE(pumpswap.trading_volume, 0) + 
-    COALESCE(meteora.trading_volume, 0) + 
-    COALESCE(jupiter.trading_volume, 0) AS daily_volume_usd
+    SUM(
+        COALESCE(raydium.trading_volume, 0) + 
+        COALESCE(orca.trading_volume, 0) + 
+        COALESCE(other.trading_volume, 0) + 
+        COALESCE(pump_fun.trading_volume, 0) + 
+        COALESCE(lifinity.trading_volume, 0) + 
+        COALESCE(pumpswap.trading_volume, 0) + 
+        COALESCE(meteora.trading_volume, 0) + 
+        COALESCE(jupiter.trading_volume, 0)
+    ) AS daily_volume_usd
 FROM raydium_volume AS raydium
 FULL JOIN orca_volume AS orca
     ON raydium.date = orca.date
@@ -202,3 +196,4 @@ FULL JOIN meteora_volume AS meteora
     ON raydium.date = meteora.date
 FULL JOIN jupiter_volume AS jupiter
     ON raydium.date = jupiter.date
+GROUP BY 1

--- a/models/staging/solana/fact_solana_dex_volumes.sql
+++ b/models/staging/solana/fact_solana_dex_volumes.sql
@@ -1,137 +1,204 @@
 -- This query is used to calculate the daily volume of dex swaps on Solana.
 -- It excludes marginfi flash loans and is used to calculate the daily volume of dex swaps on Solana.
 
-{{ config(materialized="table", snowflake_warehouse="SOLANA") }}
+{{ config(materialized="table", snowflake_warehouse="ANALYTICS_XL") }}
 
-with scaled_down_volume as (
-    select
-        date_trunc('day', block_timestamp) as date, 
-        sum(
-            case
-                when swap_from_amount_usd is not null and swap_to_amount_usd is not null then swap_to_amount_usd
-                else coalesce(swap_from_amount_usd, swap_to_amount_usd)
-            end
-        ) as trading_volume
-    from solana_flipside.defi.ez_dex_swaps
-    where
-        greatest(
-            coalesce(swap_from_amount_usd, 0),
-            coalesce(swap_to_amount_usd, 0)
-        )
-        /
-        nullif(
-            least(
-                coalesce(swap_from_amount_usd, 0),
-                coalesce(swap_to_amount_usd, 0)
-            ),
-            0
-        ) < 50 
-        and swap_program in (
-            'raydium constant product market maker',
-            'raydium concentrated liquidity',
-            'Raydium Liquidity Pool V4',
-            'raydium liquidity pool program id v5',
-            'meteora dlmm pools program', 
-            'meteora pools program',
-            'phoenix'
-        )
-    group by date
-    order by date asc
+WITH raydium_volume AS (
+    WITH all_marginfi_flash_loans AS (
+        SELECT *
+        FROM solana_flipside.core.ez_events_decoded
+        WHERE program_id = 'MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA' and event_type = 'lendingAccountStartFlashloan'
+    )
+
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS date, 
+        SUM(
+            CASE
+                WHEN swap_from_amount_usd IS NOT NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                ELSE COALESCE(swap_from_amount_usd, swap_to_amount_usd)
+            END
+        ) AS trading_volume
+    FROM solana_flipside.defi.ez_dex_swaps
+    WHERE
+    CASE
+        WHEN swap_to_amount_usd IS NOT NULL AND swap_from_amount_usd IS NOT NULL AND swap_from_amount_usd > 0 THEN swap_to_amount_usd / swap_from_amount_usd BETWEEN 0.6 AND 1.6
+        ELSE COALESCE(swap_to_amount_usd, swap_from_amount_usd) < 10000000  
+    END 
+    AND swap_program IN (
+        'raydium constant product market maker',
+        'raydium concentrated liquidity',
+        'Raydium Liquidity Pool V4',
+        'raydium liquidity pool program id v5'
+    )
+    AND tx_id NOT IN (SELECT tx_id FROM all_marginfi_flash_loans)
+    GROUP BY 1
+), 
+
+orca_volume AS (
+    WITH all_marginfi_flash_loans AS (
+        SELECT *
+        FROM solana_flipside.core.ez_events_decoded
+        WHERE program_id = 'MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA' and event_type = 'lendingAccountStartFlashloan'
+    )
+
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS date, 
+        SUM(
+            CASE
+                WHEN swap_from_amount_usd IS NOT NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                ELSE COALESCE(swap_from_amount_usd, swap_to_amount_usd)
+            END
+        ) AS trading_volume
+    FROM solana_flipside.defi.ez_dex_swaps
+    WHERE
+    CASE
+        WHEN swap_to_amount_usd IS NOT NULL AND swap_from_amount_usd IS NOT NULL AND swap_from_amount_usd > 0 THEN swap_to_amount_usd / swap_from_amount_usd BETWEEN 0.6 AND 1.6
+        ELSE COALESCE(swap_to_amount_usd, swap_from_amount_usd) < 10000000  
+    END 
+    AND swap_program IN (
+        'orca token swap',
+        'ORCA Token Swap V2',
+        'orca whirlpool program'
+    )
+    AND tx_id NOT IN (SELECT tx_id FROM all_marginfi_flash_loans)
+    GROUP BY 1
+), 
+
+other_volume AS (
+    WITH all_marginfi_flash_loans AS (
+        SELECT *
+        FROM solana_flipside.core.ez_events_decoded
+        WHERE program_id = 'MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA' and event_type = 'lendingAccountStartFlashloan'
+    )
+
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS date, 
+        SUM(
+            CASE
+                WHEN swap_from_amount_usd IS NOT NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                ELSE COALESCE(swap_from_amount_usd, swap_to_amount_usd)
+            END
+        ) AS trading_volume
+    FROM solana_flipside.defi.ez_dex_swaps
+    WHERE
+    CASE
+        WHEN swap_to_amount_usd IS NOT NULL AND swap_from_amount_usd IS NOT NULL AND swap_from_amount_usd > 0 THEN swap_to_amount_usd / swap_from_amount_usd BETWEEN 0.6 AND 1.6
+        ELSE COALESCE(swap_to_amount_usd, swap_from_amount_usd) < 10000000  
+    END 
+    AND swap_program IN (
+        'Saber Stable Swap',
+        'phoenix',
+        'stepn swap',
+        'bonkswap'
+    )
+    AND tx_id NOT IN (SELECT tx_id FROM all_marginfi_flash_loans)
+    GROUP BY 1
 ), 
 
 pump_fun_volume as (
-    select
-        date_trunc('day', block_timestamp) as date, 
-        sum(
-            case
-                when swap_from_amount_usd is not null and swap_to_amount_usd is not null then swap_to_amount_usd
-                else coalesce(swap_from_amount_usd, swap_to_amount_usd)
-            end
-        ) as trading_volume
-    from solana_flipside.defi.ez_dex_swaps
-    where swap_program = 'pump.fun'
-    group by date
-    order by date asc
-), 
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS date, 
+        SUM(
+            CASE
+                WHEN swap_from_amount_usd IS NOT NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                ELSE COALESCE(swap_from_amount_usd, swap_to_amount_usd)
+            END
+        ) AS trading_volume
+    FROM solana_flipside.defi.ez_dex_swaps
+    WHERE swap_program IN ('pump.fun')
+    GROUP BY 1
+    ORDER BY 1 ASC
+),  
 
-excluded_marginfi_volume as (
-    with all_marginfi_flash_loans as (
-        select *
-        from solana_flipside.core.ez_events_decoded
-        where program_id = 'MFv2hWf31Z9kbCa1snEPYctwafyhdvnV7FZnsebVacA' and event_type = 'lendingAccountStartFlashloan'
-    )
-    
-    select
-        date_trunc('day', block_timestamp) as date, 
-        sum(
-            case
-                when swap_from_amount_usd is not null and swap_to_amount_usd is not null then swap_to_amount_usd
-                else coalesce(swap_from_amount_usd, swap_to_amount_usd)
-            end
-        ) as trading_volume
-        
-    from solana_flipside.defi.ez_dex_swaps
-    where tx_id not in (select tx_id from all_marginfi_flash_loans) 
-        and greatest(
-                coalesce(swap_from_amount_usd, 0),
-                coalesce(swap_to_amount_usd, 0)
+pumpswap_volume as (
+    WITH included_pump_txs AS (
+        SELECT DISTINCT tx_id
+        FROM SOLANA_FLIPSIDE.CORE.EZ_EVENTS_DECODED e,
+        LATERAL FLATTEN(input => e.decoded_instruction:accounts) AS flattened
+        WHERE
+        LOWER(e.program_id) = LOWER('pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA')
+        AND flattened.value:name::STRING = 'quote_mint'
+        AND (e.decoded_instruction:name = 'sell' OR e.decoded_instruction:name = 'buy')
+        AND LOWER(flattened.value:pubkey::STRING) IN (LOWER('So11111111111111111111111111111111111111112'), 
+                                                LOWER('mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So'),
+                                                LOWER('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+                                                LOWER('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB'),
+                                                LOWER('DEkqHyPN7GMRJ5cArtQFAWefqbZb33Hyf6s5iCwjEonT')
             )
-            /
-            nullif(
-                least(
-                    coalesce(swap_from_amount_usd, 0),
-                    coalesce(swap_to_amount_usd, 0)
-                ),
-                0
-            ) < 50 
-        and swap_program not in (
-            'raydium constant product market maker',
-            'raydium concentrated liquidity',
-            'Raydium Liquidity Pool V4',
-            'raydium liquidity pool program id v5', 
-            'meteora dlmm pools program', 
-            'meteora pools program',
-            'phoenix', 
-            'pump.fun', 
-            'orca token swap', 
-            'ORCA Token Swap V2', 
-            'orca whirlpool program'
-        )
-    group by date
-    order by date asc 
-), 
+    ) 
 
-orca_volume as (
-    select 
-        date,
-        trading_volume
-    from orca.prod_core.ez_metrics
-    order by date asc
+    SELECT
+        DATE_TRUNC('day', block_timestamp) AS date, 
+        SUM(
+            CASE
+                WHEN swap_from_amount_usd IS NOT NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                WHEN swap_from_amount_usd IS NULL AND swap_to_amount_usd IS NOT NULL THEN swap_to_amount_usd
+                WHEN swap_to_amount_usd IS NULL AND swap_from_amount_usd IS NOT NULL THEN swap_from_amount_usd
+                ELSE 0
+            END
+        ) AS trading_volume
+    FROM solana_flipside.defi.ez_dex_swaps AS ez
+    INNER JOIN included_pump_txs AS ipt 
+        ON LOWER(ez.tx_id) = LOWER(ipt.tx_id)
+    WHERE swap_program IN ('pumpswap')
+    GROUP BY 1
+    ORDER BY 1 DESC
 ), 
 
 lifinity_volume as (
-    select
+    SELECT
         date, 
-        daily_volume as trading_volume
-    from pc_dbt_db.prod.fact_lifinity_dex_volumes   
-    order by date asc
+        daily_volume AS trading_volume
+    FROM pc_dbt_db.prod.fact_lifinity_dex_volumes   
+    ORDER BY 1 ASC
+), 
+
+meteora_volume as (
+    SELECT
+        date, 
+        spot_volume AS trading_volume
+    FROM meteora.prod_core.ez_metrics
+    ORDER BY 1 ASC
+), 
+
+jupiter_volume as (
+    SELECT
+        date, 
+        trading_volume + aggregator_volume_overall AS trading_volume
+    FROM jupiter.prod_core.ez_metrics
+    ORDER BY 1 ASC
 )
 
-select
-    coalesce(sd.date, pump.date, margin.date, orca.date, lifinity.date) as date, 
-    sum((coalesce(sd.trading_volume,0) + 
-        coalesce(pump.trading_volume,0) + 
-        coalesce(margin.trading_volume,0) + 
-        coalesce(orca.trading_volume,0) + 
-        coalesce(lifinity.trading_volume,0))) as daily_volume_usd
-from scaled_down_volume as sd
-full join pump_fun_volume as pump
-    on sd.date = pump.date
-full join excluded_marginfi_volume as margin
-    on sd.date = margin.date
-full join orca_volume as orca
-    on sd.date = orca.date
-full join lifinity_volume as lifinity
-    on sd.date = lifinity.date
-group by 1
-order by date asc
+SELECT
+    COALESCE(raydium.date, orca.date, other.date, pump_fun.date, lifinity.date, pumpswap.date, meteora.date, jupiter.date) AS date, 
+    COALESCE(raydium.trading_volume, 0) AS raydium_volume, 
+    COALESCE(orca.trading_volume, 0) AS orca_volume, 
+    COALESCE(other.trading_volume, 0) AS other_volume, 
+    COALESCE(pump_fun.trading_volume, 0) AS pump_fun_volume, 
+    COALESCE(lifinity.trading_volume, 0) AS lifinity_volume, 
+    COALESCE(pumpswap.trading_volume, 0) AS pumpswap_volume, 
+    COALESCE(meteora.trading_volume, 0) AS meteora_volume, 
+    COALESCE(jupiter.trading_volume, 0) AS jupiter_volume, 
+    COALESCE(raydium.trading_volume, 0) + 
+    COALESCE(orca.trading_volume, 0) + 
+    COALESCE(other.trading_volume, 0) + 
+    COALESCE(pump_fun.trading_volume, 0) + 
+    COALESCE(lifinity.trading_volume, 0) + 
+    COALESCE(pumpswap.trading_volume, 0) + 
+    COALESCE(meteora.trading_volume, 0) + 
+    COALESCE(jupiter.trading_volume, 0) AS daily_volume_usd
+FROM raydium_volume AS raydium
+FULL JOIN orca_volume AS orca
+    ON raydium.date = orca.date
+FULL JOIN other_volume AS other
+    ON raydium.date = other.date
+FULL JOIN pump_fun_volume AS pump_fun
+    ON raydium.date = pump_fun.date
+FULL JOIN lifinity_volume AS lifinity
+    ON raydium.date = lifinity.date
+FULL JOIN pumpswap_volume AS pumpswap
+    ON raydium.date = pumpswap.date
+FULL JOIN meteora_volume AS meteora
+    ON raydium.date = meteora.date
+FULL JOIN jupiter_volume AS jupiter
+    ON raydium.date = jupiter.date


### PR DESCRIPTION
## Context
[ Write 1-3 sentences describing what you did and why here ]

Filtered Pumpswap volumes by only including trades where the fees are paid in SOL, mSOL, USDT, USDC, or USDe. We're also pulling Jupiter and Meteora volume directly from our EZ Metrics tables instead of external data sources for more accurate volume data. 

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

<img width="1040" height="313" alt="Screenshot 2025-07-14 at 4 55 48 PM" src="https://github.com/user-attachments/assets/93246d65-b846-4350-9752-16a7c57dbeca" />
<img width="1040" height="313" alt="Screenshot 2025-07-14 at 4 58 03 PM" src="https://github.com/user-attachments/assets/4f288d8d-a7ec-4042-be81-dfe5cea8f17f" />

- [X] Successful RETL screenshot

<img width="1040" height="313" alt="Screenshot 2025-07-14 at 4 59 12 PM" src="https://github.com/user-attachments/assets/acbd5a77-aaf0-4a36-bd7b-86d90db9a628" />

- [X] Ran make generate schema for changed assets
- [X] Screenshots of changed data **in local frontend**

<img width="1512" height="869" alt="Screenshot 2025-07-14 at 5 37 00 PM" src="https://github.com/user-attachments/assets/2db917b2-d28d-4404-9a6f-3c9b3862ce37" />


Tick the following only after PR has been approved and before it is merged: 
- [X] Added clear and concise metric definitions + methodology to the admin dashboard

> Summation of volumes on Raydium, Orca, Bonk, Stepn, Phoenix, Saber, Pump, Pumpswap, Lifinity, Meteora, and Jupiter. 

> MarginFi flash loans were filtered out. Only trades with the fees paid in SOL, mSOL, USDC, USDT and USDe on Pumpswap were included.

- [X] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

> Added a filter for Pumpswap where only trades whose fees were paid in SOL, mSOL, USDT, USDC, or USDe were included.

## Other
