### PR TITLE
add withdraw and deposit transfers for aptos

### DIFF
--- a/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
@@ -1,0 +1,66 @@
+{{
+    config(
+        materialized="incremental",
+        unique_key=["transaction_hash", "transfer_index", "transfer_event"],
+        snowflake_warehouse="APTOS_LG",
+    )
+}}
+
+with deposit_events AS (
+    select 
+        block_number
+        , tx_hash
+        , block_timestamp
+        , event_index
+        , account_address
+        , amount
+        , token_address
+        , transfer_event
+    from aptos_flipside.core.fact_transfers
+    where transfer_event = 'DepositEvent'
+        {% if is_incremental() %}
+            and block_timestamp > (select dateadd('day', -3, max(transaction_timestamp)) from {{ this }})
+        {% endif %}
+)
+
+, withdraw_events AS (
+    select 
+        block_number
+        , tx_hash
+        , block_timestamp
+        , event_index
+        , account_address
+        , amount
+        , token_address
+        , transfer_event
+    from aptos_flipside.core.fact_transfers
+    where transfer_event = 'WithdrawEvent'
+        {% if is_incremental() %}
+            and block_timestamp > (select dateadd('day', -3, max(transaction_timestamp)) from {{ this }})
+        {% endif %}
+)
+
+, unioned AS (
+    select * from deposit_events
+    union all
+    select * from withdraw_events
+)
+
+select
+    block_timestamp as transaction_timestamp
+    , DATE(block_timestamp) as date_day
+    , block_number
+    , event_index as transfer_index
+    , transfer_event
+    , tx_hash as transaction_hash
+    , account_address
+    , amount
+    , case 
+        when substr(ca.chain_agnostic_id, 0, 7) = 'eip155:' then lower(ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '')) 
+        else ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '') 
+    end as asset_id
+    , 'aptos' as chain_name
+    , ca.chain_agnostic_id as chain_id
+from unioned
+left join {{ ref("chain_agnostic_ids") }} ca
+    on 'aptos' = ca.chain

--- a/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
@@ -54,7 +54,7 @@ select
     , transfer_event
     , tx_hash as transaction_hash
     , account_address
-    , amount
+    , amount AS amount_asset
     , case 
         when substr(ca.chain_agnostic_id, 0, 7) = 'eip155:' then lower(ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '')) 
         else ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '') 


### PR DESCRIPTION
## Context
Adding a model to `standard_8d737a18` breaking down aptos transfers into raw deposit and withdrawal events per Tether's request. Will then replicate this to their S3. 

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)
<img width="933" height="260" alt="Screenshot 2025-07-14 at 4 09 06 PM" src="https://github.com/user-attachments/assets/0aa81687-2d3f-45b3-a28d-719de9eb4a51" />

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
