### PR TITLE
add tea to ez_metrics

### DIFF
--- a/models/__global__schema.yml
+++ b/models/__global__schema.yml
@@ -215,6 +215,8 @@ column_definitions:
       description: "The average number of transactions per second on a chain"
     - name: adjusted_dau
       description: "The number of adjusted daily active users on a chain"
+    - name: total_economic_activity
+      description: "The total value of all economic activity on a chain"
 
   developer_metrics:
     - name: weekly_commits_core_ecosystem

--- a/models/projects/arbitrum/core/__arbitrum__schema.yml
+++ b/models/projects/arbitrum/core/__arbitrum__schema.yml
@@ -82,7 +82,9 @@ column_definitions:
 
   circulating_supply_native: &circulating_supply_native
     name: circulating_supply_native
-    description: "The circulating supply of a token in native tokens"
+    description: "The circulating supply of a token, equal to the issued supply minus unvested tokens."
+    tags:
+      - artemis_gaap
 
   dau_over_100_balance: &dau_over_100_balance
     name: dau_over_100_balance
@@ -106,6 +108,12 @@ column_definitions:
     name: inflow
     description: "The amount (in USD) flowing into a chain"
 
+  issued_supply_native: &issued_supply_native
+    name: issued_supply_native
+    description: "The issued supply of a token, equal to the total supply minus foundation or DAO held tokens."
+    tags:
+      - artemis_gaap
+
   l1_fee_allocation: &l1_fee_allocation
     name: l1_fee_allocation
     description: "The total USD value of L1 cash flow on a chain"
@@ -125,6 +133,12 @@ column_definitions:
   market_cap: &market_cap
     name: market_cap
     description: "The market cap of a token in USD"
+    tags:
+      - artemis_gaap
+
+  max_supply_native: &max_supply_native
+    name: max_supply_native
+    description: "The maximum supply of a token, including any uncreated tokens, unvested tokens, foundation or DAO held tokens, and burned tokens."
     tags:
       - artemis_gaap
 
@@ -246,6 +260,16 @@ column_definitions:
     name: sybil_users
     description: "The number of sybil users on a chain"
 
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
+  total_supply_native: &total_supply_native
+    name: total_supply_native
+    description: "The total supply of a token, equal to the sum of all tokens created minus the sum of all tokens destroyed."
+    tags:
+      - artemis_gaap
+
   treasury_fee_allocation: &treasury_fee_allocation
     name: treasury_fee_allocation
     description: "Revenue allocated to the protocol's treasury for future use, including development, growth, or governance."
@@ -318,10 +342,12 @@ models:
       - *fdmc
       - *fees
       - *high_sleep_users
+      - *issued_supply_native
       - *l1_fee_allocation
       - *l1_fee_allocation_native
       - *low_sleep_users
       - *market_cap
+      - *max_supply_native
       - *new_users
       - *non_p2p_stablecoin_transfer_volume
       - *non_sybil_users
@@ -344,6 +370,8 @@ models:
       - *stablecoin_transfer_volume
       - *stablecoin_txns
       - *sybil_users
+      - *total_economic_activity
+      - *total_supply_native
       - *treasury_fee_allocation
       - *tvl
       - *weekly_commits_core_ecosystem
@@ -352,7 +380,24 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_arbitrum_metrics_by_subcategory
     description: "This table stores metrics for the ARBITRUM protocol"
     columns:
@@ -362,7 +407,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_arbitrum_metrics_by_category_v2
     description: "This table stores metrics for the ARBITRUM protocol"
     columns:
@@ -372,20 +434,71 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_arbitrum_metrics_by_chain
     description: "This table stores metrics for the ARBITRUM protocol"
     columns:
       - *inflow
       - *outflow
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_arbitrum_stablecoin_metrics_by_address_with_labels
     description: "This table stores metrics for the ARBITRUM protocol"
     columns:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_arbitrum_metrics_by_application_v2
     description: "This table stores metrics for the ARBITRUM protocol"
     columns:
@@ -395,4 +508,21 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/avalanche/core/__avalanche__schema.yml
+++ b/models/projects/avalanche/core/__avalanche__schema.yml
@@ -254,6 +254,10 @@ column_definitions:
     name: sybil_users
     description: "The number of sybil users on a chain"
 
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
   total_staked: &total_staked
     name: total_staked
     description: "The total amount of USD value staked on a chain"
@@ -315,7 +319,24 @@ models:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_avalanche_metrics_by_subcategory
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
@@ -325,7 +346,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_avalanche_metrics_by_application_v2
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
@@ -335,7 +373,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_avalanche_metrics_by_category_v2
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
@@ -345,13 +400,47 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_avalanche_metrics_by_chain
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
       - *inflow
       - *outflow
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_avalanche_metrics
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
@@ -403,6 +492,7 @@ models:
       - *stablecoin_transfer_volume
       - *stablecoin_txns
       - *sybil_users
+      - *total_economic_activity
       - *total_staked
       - *total_staked_native
       - *total_supply_native
@@ -413,9 +503,43 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: fact_avalanche_staking_metrics_by_type
     description: "This table stores metrics for the AVALANCHE protocol"
     columns:
       - *total_staked_native
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -53,6 +53,10 @@ with fundamental_data as (
     FROM {{ ref("dim_date_spine") }}
     WHERE date between '2014-04-13' AND to_date(sysdate()) -- Dev data goes back to 2014
 )
+, total_economic_activity as (
+    select date, total_economic_activity
+    from AVALANCHE.PROD_RAW.EZ_AVALANCHE_TEA
+)
 
 select
     staking_data.date
@@ -105,6 +109,7 @@ select
     , p2p_transfer_volume
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dune_dex_volumes_avalanche_c.dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
+    , total_economic_activity
 
     -- Cash Flow Metrics
     , case when fees is null then fees_native * price else fees end as chain_fees
@@ -167,4 +172,5 @@ left join bridge_volume_metrics on staking_data.date = bridge_volume_metrics.dat
 left join bridge_daa_metrics on staking_data.date = bridge_daa_metrics.date
 left join avalanche_c_dex_volumes as dune_dex_volumes_avalanche_c on staking_data.date = dune_dex_volumes_avalanche_c.date
 left join issued_supply_metrics on staking_data.date = issued_supply_metrics.date
+left join total_economic_activity on staking_data.date = total_economic_activity.date
 where staking_data.date < to_date(sysdate())

--- a/models/projects/ethereum/core/__ethereum__schema.yml
+++ b/models/projects/ethereum/core/__ethereum__schema.yml
@@ -130,6 +130,12 @@ column_definitions:
     name: dau_over_100_balance
     description: "The number of users on a chain who have made over 100 transactions"
 
+  earnings: &earnings
+    name: earnings
+    description: "The total earnings generated to tokenholders defined as revenue less expenses"
+    tags:
+      - artemis_gaap
+
   fdmc: &fdmc
     name: fdmc
     description: "The fully diluted market cap of a token in USD"
@@ -342,9 +348,19 @@ column_definitions:
     name: sybil_users
     description: "The number of sybil users on a chain"
 
+  token_incentives: &token_incentives
+    name: token_incentives
+    description: "The total token incentives paid by a protocol in its native token"
+    tags:
+      - artemis_gaap
+
   total_blocks_produced: &total_blocks_produced
     name: total_blocks_produced
     description: "The total number of blocks produced on a chain"
+
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
 
   total_staked: &total_staked
     name: total_staked
@@ -404,14 +420,48 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_ethereum_stablecoin_metrics_by_address_with_labels
     description: "This table stores metrics for the ETHEREUM protocol"
     columns:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_ethereum_metrics_by_application_v2
     description: "This table stores metrics for the ETHEREUM protocol"
     columns:
@@ -421,7 +471,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_ethereum_metrics_by_category_v2
     description: "This table stores metrics for the ETHEREUM protocol"
     columns:
@@ -431,7 +498,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_ethereum_metrics
     description: "This table stores metrics for the ETHEREUM protocol"
     columns:
@@ -463,6 +547,7 @@ models:
       - *cumulative_etf_flow_native
       - *da_dau
       - *dau_over_100_balance
+      - *earnings
       - *fdmc
       - *fees
       - *gross_emissions
@@ -506,7 +591,9 @@ models:
       - *stablecoin_txns
       - *submitters
       - *sybil_users
+      - *token_incentives
       - *total_blocks_produced
+      - *total_economic_activity
       - *total_staked
       - *total_staked_native
       - *tvl
@@ -516,4 +603,21 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -63,6 +63,11 @@ with
         select date, issued_supply, circulating_supply
         from {{ ref("fact_ethereum_eth_supply_estimated") }}
     )
+    , total_economic_activity as (
+        select date, total_economic_activity
+        from ETHEREUM.PROD_RAW.EZ_ETHEREUM_TEA
+    )
+
 select
     fundamental_data.date
     , fundamental_data.chain
@@ -131,6 +136,7 @@ select
     , avg_cost_per_mib
     , submitters as da_dau
     , dune_dex_volumes_ethereum.dex_volumes AS chain_spot_volume
+    , total_economic_activity
 
     -- Cashflow metrics
     , fees as chain_fees
@@ -203,4 +209,5 @@ left join ethereum_dex_volumes as dune_dex_volumes_ethereum on fundamental_data.
 left join block_rewards_data on fundamental_data.date = block_rewards_data.date
 left join eth_supply on fundamental_data.date = eth_supply.date
 left join adjusted_dau_metrics on fundamental_data.date = adjusted_dau_metrics.date
+left join total_economic_activity on fundamental_data.date = total_economic_activity.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/near/core/__near__schema.yml
+++ b/models/projects/near/core/__near__schema.yml
@@ -142,6 +142,10 @@ column_definitions:
     name: sybil_users
     description: "The number of sybil users on a chain"
 
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
   tvl: &tvl
     name: tvl
     description: "The total value locked in a protocol"
@@ -215,6 +219,7 @@ models:
       - *returning_users
       - *revenue
       - *submitters
+      - *total_economic_activity
       - *tvl
       - *weekly_commits_core_ecosystem
       - *weekly_commits_sub_ecosystem
@@ -222,7 +227,24 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_near_metrics_by_application_v2
     description: "This table stores metrics for the NEAR protocol"
     columns:
@@ -232,7 +254,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_near_metrics_by_subcategory
     description: "This table stores metrics for the NEAR protocol"
     columns:
@@ -242,7 +281,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_near_metrics_by_category_v2
     description: "This table stores metrics for the NEAR protocol"
     columns:
@@ -252,4 +308,21 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/near/core/ez_near_metrics.sql
+++ b/models/projects/near/core/ez_near_metrics.sql
@@ -27,6 +27,10 @@ with
     near_dex_volumes as (
         select date, volume_usd as dex_volumes
         from {{ ref("fact_near_dex_volumes") }}
+    ),
+    total_economic_activity as (
+        select date, total_economic_activity
+        from NEAR.PROD_RAW.EZ_NEAR_TEA
     )
 
 select
@@ -59,6 +63,7 @@ select
     , new_users
     , low_sleep_users
     , high_sleep_users
+    , total_economic_activity
     -- Cashflow Metrics
     , case when fees is null then fees_native * price else fees end as chain_fees
     , fees_native as ecosystem_revenue_native
@@ -95,4 +100,5 @@ left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join da_metrics on fundamental_data.date = da_metrics.date
 left join near_dex_volumes on fundamental_data.date = near_dex_volumes.date
+left join total_economic_activity on fundamental_data.date = total_economic_activity.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/optimism/core/__optimism__schema.yml
+++ b/models/projects/optimism/core/__optimism__schema.yml
@@ -74,7 +74,9 @@ column_definitions:
 
   circulating_supply_native: &circulating_supply_native
     name: circulating_supply_native
-    description: "The circulating supply of a token in native tokens"
+    description: "The circulating supply of a token, equal to the issued supply minus unvested tokens."
+    tags:
+      - artemis_gaap
 
   dau_over_100_balance: &dau_over_100_balance
     name: dau_over_100_balance
@@ -104,6 +106,12 @@ column_definitions:
     name: inflow
     description: "The amount (in USD) flowing into a chain"
 
+  issued_supply_native: &issued_supply_native
+    name: issued_supply_native
+    description: "The issued supply of a token, equal to the total supply minus foundation or DAO held tokens."
+    tags:
+      - artemis_gaap
+
   l1_fee_allocation: &l1_fee_allocation
     name: l1_fee_allocation
     description: "The total USD value of L1 cash flow on a chain"
@@ -124,6 +132,12 @@ column_definitions:
   market_cap: &market_cap
     name: market_cap
     description: "The market cap of a token in USD"
+    tags:
+      - artemis_gaap
+
+  max_supply_native: &max_supply_native
+    name: max_supply_native
+    description: "The maximum supply of a token, including any uncreated tokens, unvested tokens, foundation or DAO held tokens, and burned tokens."
     tags:
       - artemis_gaap
 
@@ -251,6 +265,16 @@ column_definitions:
     tags:
       - artemis_gaap
 
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
+  total_supply_native: &total_supply_native
+    name: total_supply_native
+    description: "The total supply of a token, equal to the sum of all tokens created minus the sum of all tokens destroyed."
+    tags:
+      - artemis_gaap
+
   treasury_fee_allocation: &treasury_fee_allocation
     name: treasury_fee_allocation
     description: "Revenue allocated to the protocol's treasury for future use, including development, growth, or governance. Supply side: fees paid to squencer - fees paied to l1 (L2 Revenue)"
@@ -308,7 +332,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_optimism_metrics
     description: "This table stores metrics for the OPTIMISM protocol"
     columns:
@@ -333,10 +374,12 @@ models:
       - *fdmc
       - *fees
       - *high_sleep_users
+      - *issued_supply_native
       - *l1_fee_allocation
       - *l1_fee_allocation_native
       - *low_sleep_users
       - *market_cap
+      - *max_supply_native
       - *new_users
       - *non_p2p_stablecoin_transfer_volume
       - *non_sybil_users
@@ -360,6 +403,8 @@ models:
       - *stablecoin_txns
       - *sybil_users
       - *token_incentives
+      - *total_economic_activity
+      - *total_supply_native
       - *treasury_fee_allocation
       - *tvl
       - *weekly_commits_core_ecosystem
@@ -368,7 +413,24 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_optimism_metrics_by_category_v2
     description: "This table stores metrics for the OPTIMISM protocol"
     columns:
@@ -378,7 +440,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_optimism_metrics_by_subcategory
     description: "This table stores metrics for the OPTIMISM protocol"
     columns:
@@ -388,17 +467,68 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_optimism_metrics_by_chain
     description: "This table stores metrics for the OPTIMISM protocol"
     columns:
       - *inflow
       - *outflow
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_optimism_stablecoin_metrics_by_address_with_labels
     description: "This table stores metrics for the OPTIMISM protocol"
     columns:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -78,6 +78,10 @@ with
         from {{ ref("fact_optimism_owned_supply") }}
         where contract_address = '0x4200000000000000000000000000000000000042'
     )
+    , total_economic_activity as (
+        select date, total_economic_activity
+        from OPTIMISM.PROD_RAW.EZ_OPTIMISM_TEA
+    )
 
 select
     coalesce(
@@ -139,6 +143,7 @@ select
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dune_dex_volumes_optimism.dex_volumes, 0) + coalesce(nft_trading_volume, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
     , dune_dex_volumes_optimism.dex_volumes AS chain_spot_volume
+    , total_economic_activity
 
     -- Cashflow Metrics
     , fees AS chain_fees
@@ -205,4 +210,5 @@ left join revenue_share on fundamental_data.date = revenue_share.date
 left join mints_burns on fundamental_data.date = mints_burns.date
 left join unvested_supply on fundamental_data.date = unvested_supply.date
 left join owned_supply on fundamental_data.date = owned_supply.date
+left join total_economic_activity on fundamental_data.date = total_economic_activity.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/solana/core/__solana__schema.yml
+++ b/models/projects/solana/core/__solana__schema.yml
@@ -88,6 +88,12 @@ column_definitions:
     tags:
       - artemis_gaap
 
+  earnings: &earnings
+    name: earnings
+    description: "The total earnings generated to tokenholders defined as revenue less expenses"
+    tags:
+      - artemis_gaap
+
   fdmc: &fdmc
     name: fdmc
     description: "The fully diluted market cap of a token in USD"
@@ -252,6 +258,16 @@ column_definitions:
     name: sybil_users
     description: "The number of sybil users on a chain"
 
+  token_incentives: &token_incentives
+    name: token_incentives
+    description: "The total token incentives paid by a protocol in its native token"
+    tags:
+      - artemis_gaap
+
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
   total_staked: &total_staked
     name: total_staked
     description: "The total amount of USD value staked on a chain"
@@ -322,14 +338,48 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_solana_stablecoin_metrics_by_address_with_labels
     description: "This table stores metrics for the SOLANA protocol"
     columns:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_solana_metrics
     description: "This table stores metrics for the SOLANA protocol"
     columns:
@@ -349,6 +399,7 @@ models:
       - *chain_txns
       - *chain_wau
       - *circulating_supply_native
+      - *earnings
       - *fdmc
       - *fees
       - *gross_emissions
@@ -376,6 +427,8 @@ models:
       - *stablecoin_total_supply
       - *stablecoin_transfer_volume
       - *stablecoin_txns
+      - *token_incentives
+      - *total_economic_activity
       - *total_staked
       - *total_staked_native
       - *tvl
@@ -387,7 +440,24 @@ models:
       - *weekly_contracts_deployed
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_solana_metrics_by_category_v2
     description: "This table stores metrics for the SOLANA protocol"
     columns:
@@ -397,7 +467,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_solana_metrics_by_application_v2
     description: "This table stores metrics for the SOLANA protocol"
     columns:
@@ -407,4 +494,21 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/tron/core/__tron__schema.yml
+++ b/models/projects/tron/core/__tron__schema.yml
@@ -74,7 +74,9 @@ column_definitions:
 
   circulating_supply_native: &circulating_supply_native
     name: circulating_supply_native
-    description: "The circulating supply of a token in native tokens"
+    description: "The circulating supply of a token, equal to the issued supply minus unvested tokens."
+    tags:
+      - artemis_gaap
 
   earnings: &earnings
     name: earnings
@@ -96,6 +98,12 @@ column_definitions:
     name: high_sleep_users
     description: "The number of high sleep users on a chain"
 
+  issued_supply_native: &issued_supply_native
+    name: issued_supply_native
+    description: "The issued supply of a token, equal to the total supply minus foundation or DAO held tokens."
+    tags:
+      - artemis_gaap
+
   low_sleep_users: &low_sleep_users
     name: low_sleep_users
     description: "The number of low sleep users on a chain"
@@ -103,6 +111,12 @@ column_definitions:
   market_cap: &market_cap
     name: market_cap
     description: "The market cap of a token in USD"
+    tags:
+      - artemis_gaap
+
+  max_supply_native: &max_supply_native
+    name: max_supply_native
+    description: "The maximum supply of a token, including any uncreated tokens, unvested tokens, foundation or DAO held tokens, and burned tokens."
     tags:
       - artemis_gaap
 
@@ -226,6 +240,16 @@ column_definitions:
     tags:
       - artemis_gaap
 
+  total_economic_activity: &total_economic_activity
+    name: total_economic_activity
+    description: "The total value of all economic activity on a chain"
+
+  total_supply_native: &total_supply_native
+    name: total_supply_native
+    description: "The total supply of a token, equal to the sum of all tokens created minus the sum of all tokens destroyed."
+    tags:
+      - artemis_gaap
+
   tvl: &tvl
     name: tvl
     description: "The total value locked in a protocol"
@@ -261,7 +285,24 @@ models:
       - *artemis_stablecoin_transfer_volume
       - *p2p_stablecoin_transfer_volume
       - *stablecoin_transfer_volume
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_tron_metrics_by_category_v2
     description: "This table stores metrics for the TRON protocol"
     columns:
@@ -271,7 +312,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_tron_metrics
     description: "This table stores metrics for the TRON protocol"
     columns:
@@ -293,7 +351,9 @@ models:
       - *earnings
       - *fdmc
       - *fees
+      - *issued_supply_native
       - *market_cap
+      - *max_supply_native
       - *new_users
       - *non_p2p_stablecoin_transfer_volume
       - *p2p_native_transfer_volume
@@ -315,12 +375,31 @@ models:
       - *stablecoin_transfer_volume
       - *stablecoin_txns
       - *token_incentives
+      - *total_economic_activity
+      - *total_supply_native
       - *tvl
       - *weekly_commits_core_ecosystem
       - *weekly_commits_sub_ecosystem
       - *weekly_developers_core_ecosystem
       - *weekly_developers_sub_ecosystem
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_tron_metrics_by_subcategory
     description: "This table stores metrics for the TRON protocol"
     columns:
@@ -330,7 +409,24 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format
   - name: ez_tron_metrics_by_application_v2
     description: "This table stores metrics for the TRON protocol"
     columns:
@@ -340,4 +436,21 @@ models:
       - *non_sybil_users
       - *returning_users
       - *sybil_users
-
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns: ["chain", "date"]
+          description: Ensures that each chain and date combination is unique
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: Ensures that the date column contains at least one record from the last 2 days
+      - not_null:
+          column_name: chain
+          description: Ensures that the chain column is not null
+      - not_null:
+          column_name: date
+          description: Ensures that the date column is not null
+      - dbt_utils.expression_is_true:
+          expression: "date = cast(date as date)"
+          description: Ensures that the date column is properly typed as DATE with yyyy-mm-dd format

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -34,6 +34,10 @@ with fundamental_data as (
         floating_supply as circulating_supply_native,
     from {{ ref("fact_tron_issued_supply_and_float") }}
 )
+, total_economic_activity as (
+    select date, total_economic_activity
+    from TRON.PROD_RAW.EZ_TRON_TEA
+)
 
 select
     coalesce(
@@ -79,6 +83,7 @@ select
     , dex_volumes AS chain_spot_volume
     , coalesce(artemis_stablecoin_transfer_volume, 0) - coalesce(stablecoin_data.p2p_stablecoin_transfer_volume, 0) as non_p2p_stablecoin_transfer_volume
     , coalesce(dex_volumes, 0) + coalesce(p2p_transfer_volume, 0) as settlement_volume
+    , total_economic_activity
 
     -- Cash Flow Metrics
     , fees as chain_fees
@@ -130,4 +135,5 @@ left join p2p_metrics on fundamental_data.date = p2p_metrics.date
 left join rolling_metrics on fundamental_data.date = rolling_metrics.date
 left join token_incentives on fundamental_data.date = token_incentives.date
 left join issued_supply_metrics on fundamental_data.date = issued_supply_metrics.date
+left join total_economic_activity on fundamental_data.date = total_economic_activity.date
 where fundamental_data.date < to_date(sysdate())


### PR DESCRIPTION
## Context
Adding a new metric TEA (total economic activity) to global schema and `ez_metrics` tables for the below chains:
- Arbitrum
- Avalanche
- Ethereum
- Near
- Optimism
- Solana
- Tron

Total Economic Activity (TEA) is a new metric we created to measure the size and economic activity of blockchains. It is designed to be flexible and widely applicable to all blockchains regardless of their niche use cases and user patterns. It consists of Chain Fees (including gas fees, blob fees, and MEV), Settlement Volume (Dex Volumes, NFT Volumes and P2P Transfer Volumes), and Application Fees. 

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

Arbitrum:
<img width="812" height="391" alt="Screenshot 2025-07-15 at 5 42 08 PM" src="https://github.com/user-attachments/assets/dc2062ba-2199-4d72-9edd-1dc62a0b1d1c" />
Tron:
<img width="844" height="549" alt="Screenshot 2025-07-15 at 7 28 19 PM" src="https://github.com/user-attachments/assets/424254f1-cb54-4232-bb92-668a94e9eb06" />
Solana:
<img width="928" height="566" alt="Screenshot 2025-07-15 at 7 05 02 PM" src="https://github.com/user-attachments/assets/d9e264d9-7191-45d5-901e-266f6be2e1af" />
Near:
<img width="938" height="588" alt="Screenshot 2025-07-15 at 6 53 41 PM" src="https://github.com/user-attachments/assets/a487a996-597a-4bf9-8e72-6d5d8545a62e" />
Optimism:
<img width="812" height="577" alt="Screenshot 2025-07-15 at 6 38 07 PM" src="https://github.com/user-attachments/assets/7ffb5745-02c2-4b85-819b-2593248bc9dc" />
Ethereum:
<img width="814" height="573" alt="Screenshot 2025-07-15 at 6 25 48 PM" src="https://github.com/user-attachments/assets/1e45edb1-9cd1-4b3b-9ab7-cea83e003b56" />
Avalanche:
<img width="811" height="574" alt="Screenshot 2025-07-15 at 6 08 35 PM" src="https://github.com/user-attachments/assets/08485fb4-0068-4c87-b6e8-76b3a9abb23b" />

- [X] Successful RETL screenshot
- [X] Ran make generate schema for changed assets
- [X] Screenshots of changed data **in local frontend**
NOTE: Data is not appearing on charts because local frontend is hitting the prod FastAPI backend and I am not setup on that repo yet. Still waiting on access to 1pass for creds but in the meantime for the sake of time I wanted to get this merged so I can begin creating the terminal chart images for the report. 

Ethereum:
<img width="1894" height="933" alt="ethereum" src="https://github.com/user-attachments/assets/72c30c10-0a90-40b3-bf79-26bc1b5a1d32" />

Solana:
<img width="1895" height="935" alt="solana" src="https://github.com/user-attachments/assets/a2ef2155-f856-4415-8571-317c0a7907b7" />

Tron:
<img width="1904" height="942" alt="tron" src="https://github.com/user-attachments/assets/5316c728-698e-44ad-a36b-0c821c5845f9" />

Arbitrum:
<img width="1895" height="927" alt="arbitrum" src="https://github.com/user-attachments/assets/0f798871-65ad-4245-a46a-db8d9b7b6896" />

Near:
<img width="1892" height="934" alt="near" src="https://github.com/user-attachments/assets/f2afde01-f4bd-42a5-bc59-c4e9f0e902de" />

Avalanche:
<img width="1904" height="933" alt="avalanche" src="https://github.com/user-attachments/assets/000753ff-be36-4a0f-af8f-dab0f0a15cb6" />

Optimism:
<img width="1903" height="926" alt="optimism" src="https://github.com/user-attachments/assets/1c8050e9-d020-4465-8975-26c747e45357" />


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
