### PR TITLE
fix rev column on solana ez_metrics

### DIFF
--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -112,7 +112,7 @@ select
     , base_fee_native * price AS base_fee
     , vote_tx_fee_native
     , vote_tx_fee_native * price AS vote_tx_fee
-    , chain_fees + jito_tips.tip_fees as rev -- Blockworks' REV
+    , chain_fees + COALESCE(jito_tips.tip_fees, 0) as rev -- Blockworks' REV
     
 
     -- Financial Statement Metrics


### PR DESCRIPTION
## Context
Fixing REV column calculation on Solana ez_metrics. Adding a coalesce so REV reflects the entire fee history, not just when jito_tips were available. Previously REV was ending on 2022-10-20 due to the cutoff from jito_tips data. Now it will reflect fees prior to this date (going back to 2021-04-20). 

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="819" height="531" alt="Screenshot 2025-07-16 at 5 37 13 PM" src="https://github.com/user-attachments/assets/95b13270-3ba0-4f8d-9706-e36b8ddec9b9" />


- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
