### PR TITLE
Add trx_owner_address to Tron EOA macro

### DIFF
--- a/macros/wallets/distinct_eoa_addresses.sql
+++ b/macros/wallets/distinct_eoa_addresses.sql
@@ -1,6 +1,6 @@
 {% macro distinct_eoa_addresses(chain) %}
     {% if chain == "tron" %}
-        select trx_from_address as address, 'eoa' as address_type, max(datetime) as last_updated_at
+        select COALESCE(trx_from_address, trx_owner_address) as address, 'eoa' as address_type, max(datetime) as last_updated_at
         from sonarx_tron.tron_share.transactions
         where trx_from_address is not null 
         {% if is_incremental() %}


### PR DESCRIPTION
## Context
There was a discrepancy in the number of `from_address`s comparing Tron SonarX data to Allium data which was resulting in lower P2P transfer volumes.

It turns out it is because SonarX splits out the `trx_from_address` and `trx_owner_address` (both are "from" addresses) so we need to account for the `trx_owner_address` in the `distinct_eoa_addresses` macro. After accounting for both it matches with Allium pretty closely.

<img width="1310" height="450" alt="Screenshot 2025-07-16 at 9 46 49 PM" src="https://github.com/user-attachments/assets/44e9e641-a560-4c17-961b-ad8e3ad1e486" />

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)
<img width="835" height="253" alt="Screenshot 2025-07-16 at 10 10 46 PM" src="https://github.com/user-attachments/assets/af5af503-cbda-4eb4-93b3-ccd15269a13a" />

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
