### PR TITLE
refactor tron p2p models and eoa tracking

### DIFF
--- a/macros/contracts/distinct_contract_addresses.sql
+++ b/macros/contracts/distinct_contract_addresses.sql
@@ -98,7 +98,15 @@
                 and block_timestamp >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
             {% endif %}
         group by contract_address
-
+    {% elif chain == "tron" %}
+        select min(datetime) as block_timestamp, trx_contract_address as contract_address
+        from sonarx_tron.tron_share.transactions 
+        where contract_type = 'CreateSmartContract'
+            and trx_contract_address is not null
+            {% if is_incremental() %}
+                and datetime >= (select dateadd('day', -3, max(block_timestamp)) from {{ this }})
+            {% endif %}
+        group by contract_address
     {% else %}
         select min(block_timestamp) as block_timestamp, to_address as contract_address, min(type) as type --Contracts can be redeployed at the same addresses with CREATE2
         from {{ chain }}_flipside.core.fact_traces

--- a/macros/p2p/p2p_native_transfers.sql
+++ b/macros/p2p/p2p_native_transfers.sql
@@ -14,12 +14,68 @@
             prices as ({{ get_coingecko_price_with_latest("ethereum") }}),
         {% endif %}
         
-            {% if chain == "tron" %}
-                distinct_peer_address as (
-                    select address
-                    from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
-                ), 
-                transfers as (
+        {% if chain == "solana" %}
+            distinct_peer_address as (
+                select address
+                from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
+            ),
+            transfers as (
+                select 
+                    t2.block_timestamp,
+                    t1.block_id as block_number,
+                    t1.tx_id as tx_hash,
+                    t1.index,
+                    t1.tx_from as from_address,
+                    t1.tx_to as to_address,
+                    t1.amount
+                from solana_flipside.core.fact_transfers t1
+                inner join solana_flipside.core.fact_blocks t2 using(block_id)
+                inner join distinct_peer_address t3 on lower(t1.tx_to) = lower(t3.address)
+                inner join distinct_peer_address t4 on lower(t1.tx_from) = lower(t4.address)
+                where mint = 'So11111111111111111111111111111111111111112'
+                    and t1.tx_from != t1.tx_to
+                    and lower(t1.tx_from) != lower('1nc1nerator11111111111111111111111111111111') -- Burn address of solana
+                    and lower(t1.tx_to) != lower('1nc1nerator11111111111111111111111111111111')
+                    {% if is_incremental() %} 
+                        and block_timestamp >= (
+                            select dateadd('day', -3, max(block_timestamp))
+                            from {{ this }}
+                        )       
+                    {% endif %}
+            )
+        {% elif chain == "near" %}
+            distinct_peer_address as (
+                select address
+                from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
+            ), 
+            transfers as (
+                select 
+                    block_timestamp,
+                    block_id as block_number,
+                    tx_hash,
+                    ez_token_transfers_id as index,
+                    from_address,
+                    to_address,
+                    amount_raw_precise / 1E24 as amount
+                from near_flipside.core.ez_token_transfers t1
+                inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
+                inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
+                where from_address != to_address and transfer_type = 'native'
+                    and from_address is not null and to_address is not null
+                    {% if is_incremental() %} 
+                        and block_timestamp >= (
+                            select dateadd('day', -3, max(block_timestamp))
+                            from {{ this }}
+                        )       
+                    {% endif %}
+            )
+        {% else %}
+            distinct_contracts as (
+                select contract_address
+                from {{ ref("dim_" ~ chain ~ "_contract_addresses") }}
+            ), 
+            transfers as (
+                {% if chain == "tron" %}
                     select 
                         block_timestamp,
                         block_number,
@@ -29,79 +85,18 @@
                         to_address,
                         amount
                     from tron_allium.assets.trx_token_transfers t1
-                    inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
-                    inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
                     where to_address != from_address 
                         and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq') -- Burn address of tron
                         and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+                        and not lower(to_address) in (select lower(contract_address) from distinct_contracts)
+                        and not lower(from_address) in (select lower(contract_address) from distinct_contracts)
                         {% if is_incremental() %} 
                             and block_timestamp >= (
                                 select dateadd('day', -3, max(block_timestamp))
                                 from {{ this }}
                             )       
                         {% endif %}
-                )
-            {% elif chain == "solana" %}
-                distinct_peer_address as (
-                    select address
-                    from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
-                ), 
-                transfers as (
-                    select 
-                        t2.block_timestamp,
-                        t1.block_id as block_number,
-                        t1.tx_id as tx_hash,
-                        t1.index,
-                        t1.tx_from as from_address,
-                        t1.tx_to as to_address,
-                        t1.amount
-                    from solana_flipside.core.fact_transfers t1
-                    inner join solana_flipside.core.fact_blocks t2 using(block_id)
-                    inner join distinct_peer_address t3 on lower(t1.tx_to) = lower(t3.address)
-                    inner join distinct_peer_address t4 on lower(t1.tx_from) = lower(t4.address)
-                    where mint = 'So11111111111111111111111111111111111111112'
-                        and t1.tx_from != t1.tx_to
-                        and lower(t1.tx_from) != lower('1nc1nerator11111111111111111111111111111111') -- Burn address of solana
-                        and lower(t1.tx_to) != lower('1nc1nerator11111111111111111111111111111111')
-                        {% if is_incremental() %} 
-                            and block_timestamp >= (
-                                select dateadd('day', -3, max(block_timestamp))
-                                from {{ this }}
-                            )       
-                        {% endif %}
-                )
-            {% elif chain == "near" %}
-                distinct_peer_address as (
-                    select address
-                    from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
-                ), 
-                transfers as (
-                    select 
-                        block_timestamp,
-                        block_id as block_number,
-                        tx_hash,
-                        ez_token_transfers_id as index,
-                        from_address,
-                        to_address,
-                        amount_raw_precise / 1E24 as amount
-                    from near_flipside.core.ez_token_transfers t1
-                    inner join distinct_peer_address t2 on lower(t1.to_address) = lower(t2.address)
-                    inner join distinct_peer_address t3 on lower(t1.from_address) = lower(t3.address)
-                    where from_address != to_address and transfer_type = 'native'
-                        and from_address is not null and to_address is not null
-                        {% if is_incremental() %} 
-                            and block_timestamp >= (
-                                select dateadd('day', -3, max(block_timestamp))
-                                from {{ this }}
-                            )       
-                        {% endif %}
-                )
-            {% else %}
-                distinct_contracts as (
-                    select contract_address
-                    from {{ ref("dim_" ~ chain ~ "_contract_addresses") }}
-                ), 
-                transfers as (
+                {% else %}
                     select 
                         block_timestamp,
                         block_number,
@@ -122,8 +117,9 @@
                                 from {{ this }}
                             )
                         {% endif %}
-                )
-            {% endif %}
+                {% endif %}
+            )
+        {% endif %}
     select 
         t1.block_timestamp,
         t1.block_number,

--- a/macros/p2p/p2p_stablecoin_transfers.sql
+++ b/macros/p2p/p2p_stablecoin_transfers.sql
@@ -6,7 +6,7 @@ with
     stablecoin_transfers as (
         select * from {{ ref("fact_" ~ chain ~ "_stablecoin_transfers") }}
     ),
-    {% if chain in ("tron", "solana", "near", "ton", "ripple", "hyperevm") %}
+    {% if chain in ("solana", "near", "ton", "ripple", "hyperevm") %}
          distinct_peer_address as (
             select address
             from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}

--- a/macros/p2p/p2p_token_transfers.sql
+++ b/macros/p2p/p2p_token_transfers.sql
@@ -1,35 +1,6 @@
 {% macro p2p_token_transfers(chain) %}
 with 
-    {% if chain == "tron" %}
-        distinct_peer_address as (
-            select address
-            from {{ ref("dim_" ~ chain ~ "_eoa_addresses") }}
-        ),
-        transfers as (
-            select 
-                block_timestamp,
-                block_number,
-                transaction_hash as tx_hash,
-                unique_id as index,
-                from_address,
-                to_address,
-                amount,
-                token_address,
-                usd_amount as amount_usd
-            from tron_allium.assets.trc20_token_transfers
-            inner join distinct_peer_address t2 on lower(to_address) = lower(t2.address)
-            inner join distinct_peer_address t3 on lower(from_address) = lower(t3.address)
-            where to_address != from_address 
-                and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
-                and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
-                {% if is_incremental() %} 
-                    and block_timestamp >= (
-                        select dateadd('day', -3, max(block_timestamp))
-                        from {{ this }}
-                    )
-                {% endif %}
-        )
-    {% elif chain == "solana" %}
+    {% if chain == "solana" %}
         token_prices as (
             select
                 hour::date as date,
@@ -113,28 +84,53 @@ with
             from {{ ref("dim_" ~ chain ~ "_contract_addresses") }}
         ), 
         transfers as (
-            select 
-                block_timestamp,
-                block_number,
-                tx_hash,
-                event_index as index,
-                from_address,
-                to_address,
-                amount_precise as amount,
-                contract_address as token_address,
-                amount_usd
-            from {{ chain }}_flipside.core.ez_token_transfers
-            where not to_address in (select contract_address from distinct_contracts)
-                and not from_address in (select contract_address from distinct_contracts)
-                and to_address != from_address 
-                and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
-                and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
-                {% if is_incremental() %} 
-                    and block_timestamp >= (
-                        select dateadd('day', -3, max(block_timestamp))
-                        from {{ this }}
-                    )
-                {% endif %}
+            {% if chain == "tron" %}
+                select 
+                    block_timestamp,
+                    block_number,
+                    transaction_hash as tx_hash,
+                    unique_id as index,
+                    from_address,
+                    to_address,
+                    amount,
+                    token_address,
+                    usd_amount as amount_usd
+                from tron_allium.assets.trc20_token_transfers
+                where to_address != from_address 
+                    and lower(to_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+                    and lower(from_address) != lower('TMerfyf1KwvKeszfVoLH3PEJH52fC2DENq')
+                    and not lower(to_address) in (select lower(contract_address) from distinct_contracts)
+                    and not lower(from_address) in (select lower(contract_address) from distinct_contracts)
+                    {% if is_incremental() %} 
+                        and block_timestamp >= (
+                            select dateadd('day', -3, max(block_timestamp))
+                            from {{ this }}
+                        )
+                    {% endif %}
+            {% else %}
+                select 
+                    block_timestamp,
+                    block_number,
+                    tx_hash,
+                    event_index as index,
+                    from_address,
+                    to_address,
+                    amount_precise as amount,
+                    contract_address as token_address,
+                    amount_usd
+                from {{ chain }}_flipside.core.ez_token_transfers
+                where not to_address in (select contract_address from distinct_contracts)
+                    and not from_address in (select contract_address from distinct_contracts)
+                    and to_address != from_address 
+                    and lower(from_address) != lower('0x0000000000000000000000000000000000000000')
+                    and lower(to_address) != lower('0x0000000000000000000000000000000000000000')
+                    {% if is_incremental() %} 
+                        and block_timestamp >= (
+                            select dateadd('day', -3, max(block_timestamp))
+                            from {{ this }}
+                        )
+                    {% endif %}
+            {% endif %}
         )
     {% endif %}
     select distinct

--- a/macros/stablecoins/stablecoin_metrics_automatic_labels.sql
+++ b/macros/stablecoins/stablecoin_metrics_automatic_labels.sql
@@ -191,7 +191,7 @@
                     else filtered_contracts.artemis_category_id 
                 end as artemis_category_id
                 , case 
-                    {% if chain not in ('solana', 'tron', 'near', 'ton', 'sui', 'ripple', 'hyperevm') %}
+                    {% if chain not in ('solana', 'near', 'ton', 'sui', 'ripple', 'hyperevm') %}
                         when 
                             from_address not in (select contract_address from {{ ref("dim_" ~ chain ~ "_contract_addresses")}}) 
                             then 1

--- a/models/dimensions/contracts/dim_tron_contract_addresses.sql
+++ b/models/dimensions/contracts/dim_tron_contract_addresses.sql
@@ -1,0 +1,9 @@
+{{ 
+    config(
+        materialized="incremental",
+        unique_key="contract_address",
+        snowflake_warehouse="TRON_LG"
+    )
+}}
+
+{{distinct_contract_addresses("tron")}}


### PR DESCRIPTION
## Context
Due to differences in sonarx transaction data, we're refactoring Tron EOA tracking by excluding contract addresses vs. the prior approach of tracking the from address. 

Adding a new dim_tron_contract_addresses model, and updating references to the old eoa models. 

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)
<img width="818" height="233" alt="Screenshot 2025-07-18 at 2 19 03 PM" src="https://github.com/user-attachments/assets/108d017a-5c91-49e7-88b3-2a97b5ba81fc" />

<img width="855" height="237" alt="Screenshot 2025-07-18 at 2 26 43 PM" src="https://github.com/user-attachments/assets/37f65947-6ace-4ce9-8feb-1036b5052047" />

<img width="883" height="246" alt="Screenshot 2025-07-18 at 3 04 52 PM" src="https://github.com/user-attachments/assets/a3fd5a9e-44ee-4ac3-965f-7ec7f8742153" />

<img width="879" height="235" alt="Screenshot 2025-07-18 at 3 08 41 PM" src="https://github.com/user-attachments/assets/864e922e-bbb3-4ed1-9795-99012f0893f0" />


## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
