### PR TITLE
Bump up bsc address balances table

### DIFF
--- a/models/staging/bsc/fact_bsc_address_balances_by_token.sql
+++ b/models/staging/bsc/fact_bsc_address_balances_by_token.sql
@@ -5,7 +5,7 @@
     config(
         materialized="incremental",
         unique_key=["address", "contract_address", "block_timestamp"],
-        snowflake_warehouse="BALANCES_LG",
+        snowflake_warehouse="BALANCES_XL",
     )
 }}
 


### PR DESCRIPTION
# Description

Bsc address balances table took over 4 hours instead of ~2h 30m which caused downstream tables to encounter an auth error. Bumping up warehouse here.

# Tests

Started running locally