### PR TITLE
Add aave, morpho, uniswap dimension type tables to duckdb

### DIFF
--- a/iceberg/models/ez_metrics/aave/ez_aave_metrics_by_chain_iceberg.sql
+++ b/iceberg/models/ez_metrics/aave/ez_aave_metrics_by_chain_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="AAVE",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_CHAIN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, chain'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM aave.prod_core.ez_metrics_by_chain

--- a/iceberg/models/ez_metrics/aave/ez_aave_metrics_by_token_iceberg.sql
+++ b/iceberg/models/ez_metrics/aave/ez_aave_metrics_by_token_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="AAVE",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_TOKEN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, token'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM aave.prod_core.ez_metrics_by_token

--- a/iceberg/models/ez_metrics/morpho/ez_morpho_metrics_by_chain_iceberg.sql
+++ b/iceberg/models/ez_metrics/morpho/ez_morpho_metrics_by_chain_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="MORPHO",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_CHAIN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, chain'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM morpho.prod_core.ez_metrics_by_chain

--- a/iceberg/models/ez_metrics/uniswap/ez_uniswap_metrics_by_chain_iceberg.sql
+++ b/iceberg/models/ez_metrics/uniswap/ez_uniswap_metrics_by_chain_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="UNISWAP",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_CHAIN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, chain'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM uniswap.prod_core.ez_metrics_by_chain

--- a/iceberg/models/ez_metrics/uniswap/ez_uniswap_metrics_by_token_iceberg.sql
+++ b/iceberg/models/ez_metrics/uniswap/ez_uniswap_metrics_by_token_iceberg.sql
@@ -1,0 +1,19 @@
+{{
+    config(
+        materialized="table",
+        table_format="iceberg",
+        database="ARTEMIS_ICEBERG",
+        schema="UNISWAP",
+        external_volume="ICEBERG_EXTERNAL_VOLUME_INTERNAL",
+        alias="EZ_METRICS_BY_TOKEN",
+        post_hook = "{{ merge_tags_dict({
+            'duckdb': 'true',
+            'order_by': 'date, token'
+        }) }}"
+    )
+}}
+
+SELECT
+    * EXCLUDE(DATE),
+    DATE::TIMESTAMP_NTZ(6) AS DATE
+FROM uniswap.prod_core.ez_metrics_by_token


### PR DESCRIPTION
# Description

Add Aave, Morpho, and Uniswap dimension type tables by chain and token to duckdb. This is in service of: https://www.notion.so/artemisxyz/Deep-Dive-Project-Page-23746f0265b480099b7bd351808f1613

# Tests

Ran all tables locally.