### PR TITLE
Remove filter on last_updated in ez_github_repository_ecosystems

### DIFF
--- a/models/projects/developer/raw/ez_github_repository_ecosystems.sql
+++ b/models/projects/developer/raw/ez_github_repository_ecosystems.sql
@@ -18,5 +18,3 @@ select
     , symbol 
 from {{ source("STAGING", "core_ecosystemrepositories") }} as er
 left join {{ source("STAGING", "core_ecosystems") }} as ecosystems  on er.ecosystem_id = ecosystems.id
-where
-    last_updated <= {{ latest_developer_data_date() }}


### PR DESCRIPTION
## Context
- Remove filter on `last_updated` in ez_github_repository_ecosystems
- [x ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
<img width="770" height="213" alt="image" src="https://github.com/user-attachments/assets/e086d600-1c57-4ba8-8289-439df1440e1f" />

No longer excluding several repos that were recently updated (only 3 remain)
<img width="1312" height="582" alt="image" src="https://github.com/user-attachments/assets/697d76b6-e792-4519-8cdb-e911e4ba8454" />


- [x ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
