### PR TITLE
Add Hyperliquid Node Fills

### DIFF
--- a/models/dimensions/contracts/__contracts__sources.yml
+++ b/models/dimensions/contracts/__contracts__sources.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: SNOWPIPE_DB
+    schema: PUBLIC
+    database: SNOWPIPE_DB
+    tables:
+      - name: FACT_ARTEMIS_ABIS

--- a/models/dimensions/contracts/dim_contract_abis.sql
+++ b/models/dimensions/contracts/dim_contract_abis.sql
@@ -6,7 +6,7 @@ select
     , chain
     , null as abi_type
     , parquet_raw as abi
-from SNOWPIPE_DB.PUBLIC.FACT_ARTEMIS_ABIS 
+from {{ source('SNOWPIPE_DB', 'FACT_ARTEMIS_ABIS') }}
 union all
 select null as contract_address, null as chain, 'ERC20_Standard' as abi_type, parse_json('[
   {

--- a/models/projects/hyperliquid/raw/__hyperliquid__sources.yml
+++ b/models/projects/hyperliquid/raw/__hyperliquid__sources.yml
@@ -1,0 +1,6 @@
+sources:
+  - name: SNOWPIPE_DB
+    schema: PUBLIC
+    database: SNOWPIPE_DB
+    tables:
+      - name: FACT_HYPERLIQUID_TRADES

--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -1,0 +1,36 @@
+{{ 
+    config(
+        materialized="incremental",
+        snowflake_warehouse="HYPERLIQUID",
+        database="hyperliquid",
+        schema="raw",
+        alias="fact_hyperliquid_trades",
+        unique_key=["transaction_hash", "trade_id"],
+    )
+}}
+select 
+    DATE(TO_TIMESTAMP(parquet_raw:time::BIGINT/1000)) AS date,
+    TO_TIMESTAMP(parquet_raw:time::BIGINT/1000) as trade_timestamp,
+    parquet_raw:transaction_hash::VARCHAR as transaction_hash,
+    parquet_raw:hash::VARCHAR as hash,
+    parquet_raw:coin::VARCHAR as coin,
+    parquet_raw:feeToken::VARCHAR as fee_token,
+    parquet_raw:fee::FLOAT as fee,
+    parquet_raw:dir::VARCHAR AS direction,
+    parquet_raw:closedPnl::FLOAT as closed_pnl,
+    parquet_raw:crossed::BOOLEAN as crossed,
+    parquet_raw:tid::BIGINT as trade_id,
+    parquet_raw:oid::BIGINT as order_id,
+    parquet_raw:cloid::VARCHAR AS client_order_id,
+    -- BID vs. ASK
+    parquet_raw:side::VARCHAR as side,
+    parquet_raw:startPosition::FLOAT as start_position,
+    parquet_raw:px::FLOAT as price,
+    parquet_raw:sz::FLOAT as size,
+    _load_timestamp_utc as _load_timestamp_utc
+from {{ source('SNOWPIPE_DB', 'FACT_HYPERLIQUID_TRADES') }}
+where
+    1=1 
+    {% if is_incremental() %}
+    AND last_updated <= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
+    {% endif %}


### PR DESCRIPTION
## Context
- Added Hyperliquid raw node fills data
- Added source macro calls for references to `SNOWPIPE_DB`
- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

<img width="758" height="257" alt="image" src="https://github.com/user-attachments/assets/82602292-2cd0-45d8-bb51-b8627c1697bb" />

Validated that table granularity is what we should expect
<img width="951" height="573" alt="image" src="https://github.com/user-attachments/assets/21a73389-72d0-45ea-8d4c-fa551493a7d0" />

- [x ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
