### PR TITLE
amend aptos withdraw deposit transfers model

### DIFF
--- a/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
+++ b/models/staging/standard_8d737a18/fact_aptos_stablecoin_withdraw_deposit_transfers_8d737a18.sql
@@ -47,20 +47,30 @@ with deposit_events AS (
 )
 
 select
-    block_timestamp as transaction_timestamp
-    , DATE(block_timestamp) as date_day
-    , block_number
-    , event_index as transfer_index
-    , transfer_event
-    , tx_hash as transaction_hash
-    , account_address
-    , amount AS amount_asset
+    u.block_timestamp as transaction_timestamp
+    , DATE(u.block_timestamp) as date_day
+    , u.block_number
+    , u.event_index as transfer_index
+    , transactions.version AS transaction_position
+    , u.transfer_event
+    , u.tx_hash as transaction_hash
+    , u.account_address
+    , u.amount / pow(10, contracts.num_decimals) AS amount_asset
     , case 
-        when substr(ca.chain_agnostic_id, 0, 7) = 'eip155:' then lower(ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '')) 
-        else ca.chain_agnostic_id || ':' || replace(replace(token_address, '0x', ''), '0:', '') 
+        when substr(ca.chain_agnostic_id, 0, 7) = 'eip155:' then lower(ca.chain_agnostic_id || ':' || replace(replace(u.token_address, '0x', ''), '0:', '')) 
+        else ca.chain_agnostic_id || ':' || replace(replace(u.token_address, '0x', ''), '0:', '') 
     end as asset_id
+    , contracts.symbol AS asset_symbol
     , 'aptos' as chain_name
     , ca.chain_agnostic_id as chain_id
-from unioned
+from unioned u
+join {{ref("fact_aptos_stablecoin_contracts")}} contracts
+        on lower(u.token_address) = lower(contracts.contract_address)
 left join {{ ref("chain_agnostic_ids") }} ca
     on 'aptos' = ca.chain
+left join aptos_flipside.core.fact_transactions transactions
+    on u.tx_hash = transactions.tx_hash
+where lower(u.token_address) in (
+    select lower(contract_address)
+    from {{ref("fact_aptos_stablecoin_contracts")}}
+)


### PR DESCRIPTION
## Context
Amending withdraw deposit model per Leo's request, including the below changes:
- limiting to stablecoins (inner join on stablecoin_contracts table)
- adding asset_symbol
- amending amount_asset to account for decimals
- adding transaction_position column

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)
<img width="1021" height="228" alt="Screenshot 2025-07-22 at 4 23 59 PM" src="https://github.com/user-attachments/assets/f6fad48f-6baa-4e27-9594-88993efe1f5a" />

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
