### PR TITLE
lowercase ca addresses and tweak jup ez metrics table

### DIFF
--- a/macros/address_balances/forward_filled_address_balances.sql
+++ b/macros/address_balances/forward_filled_address_balances.sql
@@ -29,7 +29,7 @@ with
                 when ab.contract_address = 'native_token' and '{{chain}}' = 'base' then 'eip155:8453:native'
                 when ab.contract_address = 'native_token' and '{{chain}}' = 'optimism' then 'eip155:10:native'
                 when ab.contract_address = 'native_token' and '{{chain}}' = 'solana' then 'solana:5eykt4usfv8p8njdtrepy1vzqkqzkvdp:native'
-                else ab.contract_address
+                else lower(ab.contract_address)
             end as contract_address
             , block_timestamp
             {%if chain == 'solana' %} -- note Solana balances are already decimals adjusted

--- a/models/projects/jupiter/core/ez_jupiter_metrics.sql
+++ b/models/projects/jupiter/core/ez_jupiter_metrics.sql
@@ -78,7 +78,7 @@ select
 , perps_tvl as (
     select
         date,
-            sum(balance) as perps_tvl
+            sum(balance) as perp_tvl
         from {{ ref("fact_jupiter_perps_tvl") }}
         where balance > 2 and balance is not null
         and contract_address not ilike '%solana%' -- Perps holds WSOL not SOL, but there's a bug in the balances table that includes both WSOL and SOL
@@ -87,10 +87,20 @@ select
 , lst_tvl as (
     select
         date,
+        sum(balance) as lst_tvl,
         sum(balance_native) as lst_tvl_native
     from {{ ref("fact_jupiter_lst_tvl") }}
     where balance_native > 2 and balance_native is not null
     group by date
+)
+, tvl as (
+    select
+        date,
+        perp_tvl,
+        lst_tvl,
+        coalesce(perp_tvl, 0) + (coalesce(lst_tvl, 0)) as tvl
+    from perps_tvl
+    left join lst_tvl using (date)
 )
 , market_metrics as ({{ get_coingecko_metrics("jupiter-exchange-solana") }}
 )
@@ -140,9 +150,9 @@ select
     , all_trade_metrics.unique_traders as perp_dau -- perps specific metric
     , all_trade_metrics.aggregator_unique_traders as aggregator_dau -- aggregator specific metric
     , aggregator_dau + perp_dau as dau -- necessary for OL index pipeline
-    , pt.perps_tvl
-    , lst.lst_tvl_native * sp.price as lst_tvl
-    , pt.perps_tvl + (lst.lst_tvl_native * sp.price) as tvl
+    , tvl.perp_tvl
+    , tvl.lst_tvl
+    , tvl.tvl
 
     -- Cashflow Metrics
     , all_trade_metrics.perp_fees
@@ -175,6 +185,5 @@ left join market_metrics using (date)
 left join aggregator_volume_data using (date)
 left join all_trade_metrics using (date)
 left join daily_supply_data using (date)
-left join perps_tvl pt using (date)
-left join lst_tvl lst using (date)
+left join tvl using (date)
 left join solana_price sp using (date)


### PR DESCRIPTION
## Context
Fixed forward_filled_address_balances macro to account for newly lowercased Solana token mints. Objective was to fix Jupiter TVL but this also fixes Meteora TVL and Orca treasury data.

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="1706" height="470" alt="CleanShot 2025-07-22 at 17 45 08@2x" src="https://github.com/user-attachments/assets/a2b378b0-6fc0-44b7-9077-5842d71ecbd0" />

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other

**Jupiter Before (data ends June 16th, and begins in 2024)**
<img width="2046" height="1046" alt="CleanShot 2025-07-22 at 17 49 16@2x" src="https://github.com/user-attachments/assets/a8f2e73c-e97e-43a1-80fc-bb01d434f03a" />

**Jupiter After**


**Meteora Before**
<img width="2076" height="942" alt="CleanShot 2025-07-22 at 17 47 37@2x" src="https://github.com/user-attachments/assets/2fa6ae6e-323b-4d60-a655-b73da770e58c" />

**Meteora After**


**Orca Before**
<img width="2266" height="822" alt="CleanShot 2025-07-22 at 17 48 32@2x" src="https://github.com/user-attachments/assets/40c5d3cf-4b87-48b5-8f47-89f2195dae48" />

**Orca After**