### PR TITLE
Fix Hyperliquid -ve Circulating Supply Values

### DIFF
--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
@@ -63,6 +63,7 @@ with trading_volume_data as (
         , foundation_owned
         , issued_supply
         , unvested_tokens
+        , net_supply_change_native
         , circulating_supply
     from {{ref('fact_hyperliquid_supply_data')}}
 )
@@ -173,7 +174,7 @@ select
     , coalesce(emissions_native, 0) as emissions_native
     , coalesce(premine_unlocks_native, 0) as premine_unlocks_native
     , coalesce(daily_burns_native, 0) as burns_native
-    , coalesce(emissions_native, 0) + coalesce(premine_unlocks_native, 0) - coalesce(burns_native, 0) as net_supply_change_native
+    , coalesce(hyperliquid_api_supply_data.net_supply_change_native, 0) as net_supply_change_native
     , coalesce(hyperliquid_api_supply_data.total_supply, 0) as total_supply_native
     , coalesce(hyperliquid_api_supply_data.issued_supply, 0) as issued_supply_native
     , coalesce(hyperliquid_api_supply_data.circulating_supply, 0) as circulating_supply_native

--- a/models/staging/hyperliquid/fact_hyperliquid_supply_data.sql
+++ b/models/staging/hyperliquid/fact_hyperliquid_supply_data.sql
@@ -18,13 +18,20 @@ with hyperliquid_genesis as (
 )
 
 , unvested_tokens as (
-    select
-        date(extraction_date) as date
-        , sum(try_to_decimal(f.value[1]::string)) as unvested_tokens
-    from {{ source('PROD_LANDING', 'raw_hyperliquid_supply_data') }},
-        lateral flatten(input => source_json:nonCirculatingUserBalances) as f
-    where f.value[0] = '0x43e9abea1910387c4292bca4b94de81462f8a251'
-    group by date(extraction_date)
+    select 
+        date
+        , sum(unvested) as unvested_tokens
+    from (
+        select 
+            date(extraction_date) as date
+            , f.value[0] as address
+            , max_by(try_to_decimal(f.value[1]::string), extraction_date) as unvested
+        from {{ source('PROD_LANDING', 'raw_hyperliquid_supply_data') }} t
+            , lateral flatten(input => t.source_json:nonCirculatingUserBalances) f
+        where f.value[0] = '0x43e9abea1910387c4292bca4b94de81462f8a251'
+        group by 1, 2
+    ) tmp
+    group by date
 )
 
 , dead_tokens as (
@@ -32,7 +39,7 @@ with hyperliquid_genesis as (
         date(extraction_date) as date
         , sum(try_to_decimal(f.value[1]::string)) as dead_tokens
     from {{ source('PROD_LANDING', 'raw_hyperliquid_supply_data') }}
-        lateral flatten(input => source_json:nonCirculatingUserBalances) as f
+        , lateral flatten(input => source_json:nonCirculatingUserBalances) as f
     where f.value[0] in ('0x0000000000000000000000000000000000000000', '0x000000000000000000000000000000000000dead')
     group by date(extraction_date)
 )
@@ -50,16 +57,23 @@ with hyperliquid_genesis as (
 
 , foundation_owned as (
     select
-        date(extraction_date) as date
-        , sum(try_to_decimal(f.value[1]::string)) as foundation_owned
-    from {{ source('PROD_LANDING', 'raw_hyperliquid_supply_data') }} supply,
-        lateral flatten(input => source_json:genesis.userBalances) as f
-    where f.value[0] in (
-        '0xd57ecca444a9acb7208d286be439de12dd09de5d', 
-        '0xa20fcfa0507fe762011962cc581b95bbbc3bbdba', 
-        '0xffffffffffffffffffffffffffffffffffffffff'
-    )
-    group by date(extraction_date)
+        date
+        , sum(balance) as foundation_owned
+    from (
+        select
+            date(extraction_date) as date
+            , f.value[0] as address
+            , max_by(try_to_decimal(f.value[1]::string), extraction_date) as balance
+        from {{ source('PROD_LANDING', 'raw_hyperliquid_supply_data') }} t
+            , lateral flatten(input => t.source_json:genesis.userBalances) f
+        where f.value[0] in (
+            '0xd57ecca444a9acb7208d286be439de12dd09de5d', 
+            '0xa20fcfa0507fe762011962cc581b95bbbc3bbdba', 
+            '0xffffffffffffffffffffffffffffffffffffffff'
+        )
+        group by 1, 2
+    ) tmp
+    group by date
 )
 
 , burn_tokens as (
@@ -100,10 +114,10 @@ with hyperliquid_genesis as (
 
 , date_spine as (
     select
-            date
-        from {{ ref("dim_date_spine") }}
-        -- '2024-11-29' is the hyperliquid genesis date
-        where date < to_date(sysdate()) and date >= '2024-11-29'
+        date
+    from {{ ref("dim_date_spine") }}
+    -- '2024-11-29' is the hyperliquid genesis date
+    where date < to_date(sysdate()) and date >= '2024-11-29'
 )
 
 , date_spine_with_supply_data as (
@@ -156,6 +170,13 @@ with hyperliquid_genesis as (
     from with_backfill
 )
 
+, final_with_net_change as (
+    select
+        *
+        , circulating_supply - lag(circulating_supply) over (order by date) as net_supply_change_native
+    from final_backfill
+)
+
 select
     date
     , max_supply
@@ -165,6 +186,7 @@ select
     , foundation_owned
     , issued_supply
     , unvested_tokens
+    , net_supply_change_native
     , circulating_supply
-from final_backfill
+from final_with_net_change
 order by date desc


### PR DESCRIPTION
## Context
[ Write 1-3 sentences describing what you did and why here ]

- [x] Internal only (check this box this PR should not appear in external facing docs/changelog)



## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="987" height="298" alt="image" src="https://github.com/user-attachments/assets/53169543-d922-41f2-8e5e-3f269c483d7c" />

- [x] Successful RETL screenshot
<img width="1159" height="314" alt="image" src="https://github.com/user-attachments/assets/45f4d0c4-8c8d-4da0-a820-efbab971dda8" />

- [x] Ran make generate schema for changed assets
<img width="1013" height="400" alt="image" src="https://github.com/user-attachments/assets/26f391f0-b51d-4d76-8491-88f16612d36b" />

- [x] Screenshots of changed data **in local frontend**
<img width="1062" height="713" alt="image" src="https://github.com/user-attachments/assets/7b4d06ff-5f5d-45a7-b943-b294b810bc63" />


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
Fixed Hyperliquid Circulating Supply as there -ve values in the dataset.

Reason being: on `2025-06-27` we actually ran the job twice, hence the foundation_balances and unvested_tokens doubled due to the sum aggregation. 

This result in circulating_supply_native being -ve. Hence, the fix is to do a inner select statement with max_by before summing up in the CTE.
