### PR TITLE
Fix incremental logic in fact_hyperliquid_trades

### DIFF
--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -32,5 +32,5 @@ from {{ source('SNOWPIPE_DB', 'FACT_HYPERLIQUID_TRADES') }}
 where
     1=1 
     {% if is_incremental() %}
-    AND last_updated <= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
+    AND _load_timestamp_utc <= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
     {% endif %}

--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         materialized="incremental",
-        snowflake_warehouse="HYPERLIQUID",
+        snowflake_warehouse="ANALYTICS_XL",
         database="hyperliquid",
         schema="raw",
         alias="fact_hyperliquid_trades",
@@ -32,5 +32,5 @@ from {{ source('SNOWPIPE_DB', 'FACT_HYPERLIQUID_TRADES') }}
 where
     1=1 
     {% if is_incremental() %}
-    AND _load_timestamp_utc >= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
+    AND trade_timestamp > (SELECT MAX(trade_timestamp) FROM {{ this }})
     {% endif %}

--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -32,5 +32,5 @@ from {{ source('SNOWPIPE_DB', 'FACT_HYPERLIQUID_TRADES') }}
 where
     1=1 
     {% if is_incremental() %}
-    AND _load_timestamp_utc <= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
+    AND _load_timestamp_utc >= (SELECT MAX(_load_timestamp_utc) FROM {{ this }})
     {% endif %}

--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -1,7 +1,7 @@
 {{ 
     config(
         materialized="incremental",
-        snowflake_warehouse="ANALYTICS_XL",
+        snowflake_warehouse="HYPERLIQUID",
         database="hyperliquid",
         schema="raw",
         alias="fact_hyperliquid_trades",


### PR DESCRIPTION
## Context
- Fix incremental logic for `fact_hyperliquid_trades`
- [x ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
full refreshed model, then did incremental run
<img width="787" height="171" alt="image" src="https://github.com/user-attachments/assets/3f4f3ea4-8870-4b78-806b-f0c77b08e86c" />

- [x ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
