### PR TITLE
kav/stride_metric_deprecation

### DIFF
--- a/models/projects/stride/core/__stride__schema.yml
+++ b/models/projects/stride/core/__stride__schema.yml
@@ -69,6 +69,10 @@ column_definitions:
     tags:
       - override
 
+  lst_tvl: &lst_tvl
+    name: lst_tvl
+    description: "The total value locked in a liquid staking protocol"
+
   market_cap: &market_cap
     name: market_cap
     description: "The market cap of a token in USD"
@@ -136,30 +140,10 @@ column_definitions:
     tags:
       - artemis_gaap
 
-  treasury_fee_allocation: &treasury_fee_allocation
-    name: treasury_fee_allocation
-    description: "Revenue allocated to the protocol's treasury for future use, including development, growth, or governance, equivalent to 10% of staking yield generated."
-    tags:
-      - artemis_gaap
-      - override
-
   tvl: &tvl
     name: tvl
     description: "The total value locked in Stride"
     tags:
-      - override
-
-  tvl_net_change: &tvl_net_change
-    name: tvl_net_change
-    description: "The net change in the total value locked in Stride"
-    tags:
-      - override
-
-  validator_fee_allocation: &validator_fee_allocation
-    name: validator_fee_allocation
-    description: "Gas fees on the Stride chain that accrue to the network's validators for securing the network."
-    tags:
-      - artemis_gaap
       - override
 
   yield_generated: &yield_generated
@@ -182,6 +166,7 @@ models:
       - *fees
       - *high_sleep_users
       - *low_sleep_users
+      - *lst_tvl
       - *market_cap
       - *new_users
       - *non_sybil_users
@@ -193,12 +178,8 @@ models:
       - *token_turnover_circulating
       - *token_turnover_fdv
       - *token_volume
-      - *treasury_fee_allocation
       - *tvl
-      - *tvl_net_change
-      - *validator_fee_allocation
       - *yield_generated
-
   - name: ez_stride_metrics_by_chain
     description: "This table stores metrics for the STRIDE protocol"
     columns:
@@ -210,17 +191,10 @@ models:
       - *chain_wau
       - *earnings
       - *fees
-      - *high_sleep_users
-      - *low_sleep_users
-      - *new_users
+      - *lst_tvl
       - *non_sybil_users
-      - *returning_users
       - *revenue
       - *service_fee_allocation
       - *sybil_users
-      - *treasury_fee_allocation
       - *tvl
-      - *tvl_net_change
-      - *validator_fee_allocation
       - *yield_generated
-

--- a/models/projects/stride/core/ez_stride_metrics.sql
+++ b/models/projects/stride/core/ez_stride_metrics.sql
@@ -15,59 +15,52 @@ with
     market_data as ({{ get_coingecko_metrics("stride") }})
 
 select
-    fundamental_data.date,
-    'stride' as app,
-    'DeFi' as category,
+    fundamental_data.date
+    , 'stride' as app
+    , 'DeFi' as category
     
-    --Old metrics needed for compatibility
-    fundamental_data.txns,
-    fundamental_data.dau,
-    fundamental_data.wau,
-    fundamental_data.mau,
-    fundamental_data.fees_native AS gas_fees_native,
-    fundamental_data.fees_usd AS gas_fees_usd,
-    fundamental_data.avg_txn_fee,
-    fundamental_data.total_staking_yield_usd,
-    fundamental_data.total_supply_side_revenue_usd,
-    fundamental_data.protocol_revenue_usd AS fees,
-    fundamental_data.protocol_revenue_usd AS revenue,
-    fundamental_data.operating_expenses_usd,
-    fundamental_data.protocol_earnings_usd AS earnings
-
-    --Standardized Metrics
-    --Market Metrics
+    --Market Data
     , market_data.price
     , market_data.market_cap
     , market_data.fdmc
     , market_data.token_volume
 
-    --Chain Usage Metrics
+    --Chain Data
     , fundamental_data.dau as chain_dau
     , fundamental_data.wau as chain_wau
     , fundamental_data.mau as chain_mau
-    , fundamental_data.txns as chain_txns
     , fundamental_data.returning_users as returning_users
     , fundamental_data.new_users as new_users
     , fundamental_data.low_sleep_users as low_sleep_users
     , fundamental_data.high_sleep_users as high_sleep_users
     , fundamental_data.sybil_users as sybil_users
     , fundamental_data.non_sybil_users as non_sybil_users
-    , fundamental_data.tvl as tvl
-    , fundamental_data.tvl_net_change as tvl_net_change
+    , fundamental_data.txns as chain_txns
     , fundamental_data.tvl as lst_tvl
-    , fundamental_data.tvl_net_change as lst_tvl_net_change
+    , fundamental_data.tvl as tvl
 
-    --Cashflow Metrics
+    -- Fee Data
+    , fundamental_data.avg_txn_fee
+    , fundamental_data.fees_native as chain_fees_native
     , fundamental_data.fees_usd as chain_fees
     , fundamental_data.total_staking_yield_usd as yield_generated
-    , chain_fees + yield_generated as ecosystem_revenue
-    , (yield_generated * .1) as treasury_fee_allocation
-    , (yield_generated * .9) as service_fee_allocation
-    , chain_fees as validator_fee_allocation
+    , (fundamental_data.total_staking_yield_usd * .1) as staking_reward_fees
+    , chain_fees + staking_reward_fees as fees
+
+    -- Fee allocations
+    , (fundamental_data.total_staking_yield_usd * .08) as burn_fee_allocation
+    , (fundamental_data.total_staking_yield_usd * .02) as service_fee_allocation
+
+    -- Financial Statement Metrics
+    , fundamental_data.total_supply_side_revenue_usd
+    , fundamental_data.protocol_revenue_usd * 0.8 as revenue
+    , 0 as operating_expenses_usd
+    , fundamental_data.protocol_revenue_usd * 0.8  AS earnings
 
     -- Other Metrics
     , market_data.token_turnover_circulating
     , market_data.token_turnover_fdv
+
 from fundamental_data
 left join market_data on fundamental_data.date = market_data.date
 where fundamental_data.date < to_date(sysdate())

--- a/models/projects/stride/core/ez_stride_metrics_by_chain.sql
+++ b/models/projects/stride/core/ez_stride_metrics_by_chain.sql
@@ -13,36 +13,12 @@ with
     fundamental_data as (select * EXCLUDE date, TO_TIMESTAMP_NTZ(date) AS date from {{ source('PROD_LANDING', 'ez_stride_metrics') }})
 
 select
-    fundamental_data.date,
-    'stride' as app,
-    'DeFi' as category,
-    fundamental_data.chain,
+    fundamental_data.date
+    , 'stride' as app
+    , 'DeFi' as category
+    , fundamental_data.chain
     
-    --Old metrics needed for compatibility
-    fundamental_data.txns,
-    fundamental_data.dau,
-    fundamental_data.wau,
-    fundamental_data.mau,
-    fundamental_data.tvl,
-    fundamental_data.tvl_net_change,
-    fundamental_data.fees_native AS gas_fees_native,
-    fundamental_data.fees_usd AS gas_fees_usd,
-    fundamental_data.avg_txn_fee,
-    fundamental_data.returning_users,
-    fundamental_data.new_users,
-    fundamental_data.low_sleep_users,
-    fundamental_data.high_sleep_users,
-    fundamental_data.sybil_users,
-    fundamental_data.non_sybil_users,
-    fundamental_data.total_staking_yield_usd,
-    fundamental_data.total_supply_side_revenue_usd,
-    fundamental_data.protocol_revenue_usd AS revenue,
-    fundamental_data.operating_expenses_usd,
-    fundamental_data.protocol_earnings_usd AS earnings
-
-    --Standardized Metrics
-    
-    --Chain Usage Metrics
+    --Chain Data
     , fundamental_data.dau as chain_dau
     , fundamental_data.wau as chain_wau
     , fundamental_data.mau as chain_mau
@@ -51,16 +27,28 @@ select
     , fundamental_data.new_users as chain_new_users
     , fundamental_data.low_sleep_users as chain_low_sleep_users
     , fundamental_data.avg_txn_fee as chain_avg_txn_fee
+    , fundamental_data.sybil_users
+    , fundamental_data.non_sybil_users
     , fundamental_data.tvl as lst_tvl
-    , fundamental_data.tvl_net_change as lst_tvl_net_change
-
+    , fundamental_data.tvl as tvl
     
-    --Cashflow Metrics
-    , fundamental_data.fees_usd as chain_fees
+    --Fee Data
+    , fundamental_data.avg_txn_fee
+    , fundamental_data.fees_native AS chain_fees_native
+    , fundamental_data.fees_usd AS chain_fees
     , fundamental_data.total_staking_yield_usd as yield_generated
-    , chain_fees + fundamental_data.protocol_revenue_usd AS fees
-    , (yield_generated * .1) as treasury_fee_allocation
-    , (yield_generated * .9) as service_fee_allocation
-    , chain_fees as validator_fee_allocation    
+    , (fundamental_data.total_staking_yield_usd * .1) as staking_reward_fees
+    , chain_fees + staking_reward_fees as fees
+
+    --Fee Allocations
+    , (fundamental_data.total_staking_yield_usd * .08) as burn_fee_allocation
+    , (fundamental_data.total_staking_yield_usd * .02) as service_fee_allocation
+
+    --Financial Statement Metrics
+    , fundamental_data.total_supply_side_revenue_usd
+    , fundamental_data.protocol_revenue_usd * 0.8 as revenue
+    , 0 as operating_expenses_usd
+    , fundamental_data.protocol_revenue_usd * 0.8  AS earnings
+
     
 from fundamental_data


### PR DESCRIPTION
## Context
Stride metric deprecation and cleanup
- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
- [ ] `dbt build model_name+` screenshot (must include downstream models)
<img width="1016" height="227" alt="Screenshot 2025-07-23 at 3 23 04 PM" src="https://github.com/user-attachments/assets/7caed067-39b2-442b-893b-95f930ccf4d3" />
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
<img width="1016" height="144" alt="image" src="https://github.com/user-attachments/assets/26e5b6db-d920-4f92-b8cc-aeccf6e41c30" />
- [ ] Screenshots of changed data **in local frontend**

Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
[stride.pdf](https://github.com/user-attachments/files/21394050/stride.pdf)
