### PR TITLE
Add order_id to hyperliquid trades model unique_key

### DIFF
--- a/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
+++ b/models/projects/hyperliquid/raw/fact_hyperliquid_trades.sql
@@ -5,7 +5,7 @@
         database="hyperliquid",
         schema="raw",
         alias="fact_hyperliquid_trades",
-        unique_key=["transaction_hash", "trade_id"],
+        unique_key=["transaction_hash", "trade_id", "order_id"],
     )
 }}
 select 


### PR DESCRIPTION
## Context
- Fix granularity for `fact_hyperliquid_trades` table
- [ x] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
<img width="734" height="184" alt="image" src="https://github.com/user-attachments/assets/ef58c935-699b-4759-a9be-b255db9eea08" />
Granularity should also have `order_id`, not just `transcation_hash, trade_id`
<img width="767" height="203" alt="image" src="https://github.com/user-attachments/assets/0db359d5-c924-403c-aa41-c7beaf9a193a" />
<img width="752" height="203" alt="image" src="https://github.com/user-attachments/assets/f547b750-e3a6-425a-af95-d0a4c0d0c9aa" />


- [ x] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
