### PR TITLE
fix generate schema script

### DIFF
--- a/dbt_scripts/generate_schema.py
+++ b/dbt_scripts/generate_schema.py
@@ -41,6 +41,10 @@ def extract_sql_columns(sql_file_path):
     # Take the last SELECT statement
     select_clause = select_matches[-1]
 
+    # If the last select clause is from the incremental macro, use the second to last
+    if 'max(this.date)' in select_clause.lower() and len(select_matches) > 1:
+        select_clause = select_matches[-2]
+
     print("Processing SELECT clause:", select_clause)
 
     # Extract column names (handling various alias patterns)


### PR DESCRIPTION
## Context
Fixed generate schema macro. The new incremental logic in the ez tables inserts a select statement at the end of the model. The previous generate schema macro always grabbed the last select statement before parsing it to generate the schema. The new logic checks if the final select statement is from the incremental logic, and if so, it grabs the second to last select statement.

- [x] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

Before: script removes certain columns from schema since the SELECT clause it processes is `max(this.date)`. 
<img width="1160" height="284" alt="CleanShot 2025-07-26 at 15 43 26" src="https://github.com/user-attachments/assets/f0010cf6-087b-4abe-80e4-48f61680d02e" />

After, columns are added back as it now processes the correct SELECT clause:
<img width="1023" height="273" alt="CleanShot 2025-07-26 at 15 51 15" src="https://github.com/user-attachments/assets/fa271410-b67f-46a9-b47a-0be001d3b473" />



Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
