### PR TITLE
Temporarily handle dupes in ez_sui_metrics

### DIFF
--- a/models/projects/sui/core/ez_sui_metrics.sql
+++ b/models/projects/sui/core/ez_sui_metrics.sql
@@ -111,3 +111,4 @@ left join supply_data on fundamental_data.date = supply_data.date
 where true
 {{ ez_metrics_incremental('fundamental_data.date', backfill_date) }}
 and fundamental_data.date < to_date(sysdate())
+group by all


### PR DESCRIPTION
## Context
There is an issue with upstream data beginning on 7/24 leading to dupes being inserted into the table. Going to temporarily handle those with a `GROUP BY ALL` until mysten labs can resolve on their end. Also full refreshed the table locally to remove the existing dupes. 

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [ ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
