### PR TITLE
fix merge_exclude_columns

### DIFF
--- a/models/projects/aave/core/ez_aave_metrics.sql
+++ b/models/projects/aave/core/ez_aave_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/abstract/core/ez_abstract_metrics.sql
+++ b/models/projects/abstract/core/ez_abstract_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/acala/core/ez_acala_metrics.sql
+++ b/models/projects/acala/core/ez_acala_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/across/core/ez_across_metrics.sql
+++ b/models/projects/across/core/ez_across_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/aerodrome/core/ez_aerodrome_metrics.sql
+++ b/models/projects/aerodrome/core/ez_aerodrome_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/aeur/core/ez_aeur_metrics.sql
+++ b/models/projects/aeur/core/ez_aeur_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/aevo/core/ez_aevo_metrics.sql
+++ b/models/projects/aevo/core/ez_aevo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/akash/core/ez_akash_metrics.sql
+++ b/models/projects/akash/core/ez_akash_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/alex/core/ez_alex_metrics.sql
+++ b/models/projects/alex/core/ez_alex_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/algorand/core/ez_algorand_metrics.sql
+++ b/models/projects/algorand/core/ez_algorand_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/alphafi/core/ez_alphafi_metrics.sql
+++ b/models/projects/alphafi/core/ez_alphafi_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/angle_usd/core/ez_angle_usd_metrics.sql
+++ b/models/projects/angle_usd/core/ez_angle_usd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/apex/core/ez_apex_metrics.sql
+++ b/models/projects/apex/core/ez_apex_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/aptos/core/ez_aptos_metrics.sql
+++ b/models/projects/aptos/core/ez_aptos_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/astar/core/ez_astar_metrics.sql
+++ b/models/projects/astar/core/ez_astar_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ausd/core/ez_ausd_metrics.sql
+++ b/models/projects/ausd/core/ez_ausd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -11,7 +11,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/avantis/core/ez_avantis_metrics.sql
+++ b/models/projects/avantis/core/ez_avantis_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/axelar/core/ez_axelar_metrics.sql
+++ b/models/projects/axelar/core/ez_axelar_metrics.sql
@@ -9,7 +9,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )

--- a/models/projects/babylon/core/ez_babylon_metrics.sql
+++ b/models/projects/babylon/core/ez_babylon_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/balancer/core/ez_balancer_metrics.sql
+++ b/models/projects/balancer/core/ez_balancer_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bananagun/core/ez_bananagun_metrics.sql
+++ b/models/projects/bananagun/core/ez_bananagun_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/beam/core/ez_beam_metrics.sql
+++ b/models/projects/beam/core/ez_beam_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bedrock/core/ez_bedrock_metrics.sql
+++ b/models/projects/bedrock/core/ez_bedrock_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/believe/core/ez_believe_metrics.sql
+++ b/models/projects/believe/core/ez_believe_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/benqi/core/ez_benqi_metrics.sql
+++ b/models/projects/benqi/core/ez_benqi_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/berachain/core/ez_berachain_metrics.sql
+++ b/models/projects/berachain/core/ez_berachain_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bifrost/core/ez_bifrost_metrics.sql
+++ b/models/projects/bifrost/core/ez_bifrost_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
+++ b/models/projects/bitcoin/core/ez_bitcoin_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bitflow/core/ez_bitflow_metrics.sql
+++ b/models/projects/bitflow/core/ez_bitflow_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bitget/core/ez_bitget_metrics.sql
+++ b/models/projects/bitget/core/ez_bitget_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/blackrock/core/ez_blackrock_metrics.sql
+++ b/models/projects/blackrock/core/ez_blackrock_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/blast/core/ez_blast_metrics.sql
+++ b/models/projects/blast/core/ez_blast_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bluefin/core/ez_bluefin_metrics.sql
+++ b/models/projects/bluefin/core/ez_bluefin_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/blur/core/ez_blur_metrics.sql
+++ b/models/projects/blur/core/ez_blur_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bob/core/ez_bob_metrics.sql
+++ b/models/projects/bob/core/ez_bob_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/boba/core/ez_boba_metrics.sql
+++ b/models/projects/boba/core/ez_boba_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bold/core/ez_bold_metrics.sql
+++ b/models/projects/bold/core/ez_bold_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/brla/core/ez_brla_metrics.sql
+++ b/models/projects/brla/core/ez_brla_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bsc/core/ez_bsc_metrics.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/bucket/core/ez_bucket_metrics.sql
+++ b/models/projects/bucket/core/ez_bucket_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/buidl/core/ez_buidl_metrics.sql
+++ b/models/projects/buidl/core/ez_buidl_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/busd/core/ez_busd_metrics.sql
+++ b/models/projects/busd/core/ez_busd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cardano/core/ez_cardano_metrics.sql
+++ b/models/projects/cardano/core/ez_cardano_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cctp/core/ez_cctp_metrics.sql
+++ b/models/projects/cctp/core/ez_cctp_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/celestia/core/ez_celestia_metrics.sql
+++ b/models/projects/celestia/core/ez_celestia_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cellana/core/ez_cellana_metrics.sql
+++ b/models/projects/cellana/core/ez_cellana_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/celo/core/ez_celo_metrics.sql
+++ b/models/projects/celo/core/ez_celo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/centrifuge/core/ez_centrifuge_metrics.sql
+++ b/models/projects/centrifuge/core/ez_centrifuge_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cetus/core/ez_cetus_metrics.sql
+++ b/models/projects/cetus/core/ez_cetus_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ceur/core/ez_ceur_metrics.sql
+++ b/models/projects/ceur/core/ez_ceur_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cgusd/core/ez_cgusd_metrics.sql
+++ b/models/projects/cgusd/core/ez_cgusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/chainlink/core/ez_chainlink_metrics.sql
+++ b/models/projects/chainlink/core/ez_chainlink_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/chiliz/core/ez_chiliz_metrics.sql
+++ b/models/projects/chiliz/core/ez_chiliz_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ckes/core/ez_ckes_metrics.sql
+++ b/models/projects/ckes/core/ez_ckes_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/coinbase/core/ez_coinbase_metrics.sql
+++ b/models/projects/coinbase/core/ez_coinbase_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/coindesk20/core/ez_coindesk20_metrics.sql
+++ b/models/projects/coindesk20/core/ez_coindesk20_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/compound/core/ez_compound_metrics.sql
+++ b/models/projects/compound/core/ez_compound_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/convex/core/ez_convex_metrics.sql
+++ b/models/projects/convex/core/ez_convex_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/corn/core/ez_corn_metrics.sql
+++ b/models/projects/corn/core/ez_corn_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cosmoshub/core/ez_cosmoshub_metrics.sql
+++ b/models/projects/cosmoshub/core/ez_cosmoshub_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/creal/core/ez_creal_metrics.sql
+++ b/models/projects/creal/core/ez_creal_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/crvusd/core/ez_crvusd_metrics.sql
+++ b/models/projects/crvusd/core/ez_crvusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/curve/core/ez_curve_metrics.sql
+++ b/models/projects/curve/core/ez_curve_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cusd/core/ez_cusd_metrics.sql
+++ b/models/projects/cusd/core/ez_cusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/cypher/core/ez_cypher_metrics.sql
+++ b/models/projects/cypher/core/ez_cypher_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dai/core/ez_dai_metrics.sql
+++ b/models/projects/dai/core/ez_dai_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/debridge/core/ez_debridge_metrics.sql
+++ b/models/projects/debridge/core/ez_debridge_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/deepbook/core/ez_deepbook_metrics.sql
+++ b/models/projects/deepbook/core/ez_deepbook_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/deusd/core/ez_deusd_metrics.sql
+++ b/models/projects/deusd/core/ez_deusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dexalot/core/ez_dexalot_metrics.sql
+++ b/models/projects/dexalot/core/ez_dexalot_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dfk/core/ez_dfk_metrics.sql
+++ b/models/projects/dfk/core/ez_dfk_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dimo/core/ez_dimo_metrics.sql
+++ b/models/projects/dimo/core/ez_dimo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dodo/core/ez_dodo_metrics.sql
+++ b/models/projects/dodo/core/ez_dodo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dola/core/ez_dola_metrics.sql
+++ b/models/projects/dola/core/ez_dola_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/drift/core/ez_drift_metrics.sql
+++ b/models/projects/drift/core/ez_drift_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dydx/core/ez_dydx_metrics.sql
+++ b/models/projects/dydx/core/ez_dydx_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/dydx_v4/core/ez_dydx_v4_metrics.sql
+++ b/models/projects/dydx_v4/core/ez_dydx_v4_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/econia/core/ez_econia_metrics.sql
+++ b/models/projects/econia/core/ez_econia_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eigenlayer/core/ez_eigenlayer_metrics.sql
+++ b/models/projects/eigenlayer/core/ez_eigenlayer_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eigenpie/core/ez_eigenpie_metrics.sql
+++ b/models/projects/eigenpie/core/ez_eigenpie_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/enzyme/core/ez_enzyme_metrics.sql
+++ b/models/projects/enzyme/core/ez_enzyme_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ethena/core/ez_ethena_metrics.sql
+++ b/models/projects/ethena/core/ez_ethena_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -14,7 +14,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/etherfi/core/ez_etherfi_metrics.sql
+++ b/models/projects/etherfi/core/ez_etherfi_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/euler/core/ez_euler_metrics.sql
+++ b/models/projects/euler/core/ez_euler_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eura/core/ez_eura_metrics.sql
+++ b/models/projects/eura/core/ez_eura_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eurc/core/ez_eurc_metrics.sql
+++ b/models/projects/eurc/core/ez_eurc_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eurs/core/ez_eurs_metrics.sql
+++ b/models/projects/eurs/core/ez_eurs_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/eurt/core/ez_eurt_metrics.sql
+++ b/models/projects/eurt/core/ez_eurt_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/exactly/core/ez_exactly_metrics.sql
+++ b/models/projects/exactly/core/ez_exactly_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/fantom/core/ez_fantom_metrics.sql
+++ b/models/projects/fantom/core/ez_fantom_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/fdusd/core/ez_fdusd_metrics.sql
+++ b/models/projects/fdusd/core/ez_fdusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/fedwire/core/ez_fedwire_metrics.sql
+++ b/models/projects/fedwire/core/ez_fedwire_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/flare/core/ez_flare_metrics.sql
+++ b/models/projects/flare/core/ez_flare_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/flexusd/core/ez_flexusd_metrics.sql
+++ b/models/projects/flexusd/core/ez_flexusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/flow/core/ez_flow_metrics.sql
+++ b/models/projects/flow/core/ez_flow_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/franklin_templeton/core/ez_franklin_templeton_metrics.sql
+++ b/models/projects/franklin_templeton/core/ez_franklin_templeton_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/frax/core/ez_frax_metrics.sql
+++ b/models/projects/frax/core/ez_frax_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/frax_usd/core/ez_frax_usd_metrics.sql
+++ b/models/projects/frax_usd/core/ez_frax_usd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/frequency/core/ez_frequency_metrics.sql
+++ b/models/projects/frequency/core/ez_frequency_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/frxusd/core/ez_frxusd_metrics.sql
+++ b/models/projects/frxusd/core/ez_frxusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/fuse/core/ez_fuse_metrics.sql
+++ b/models/projects/fuse/core/ez_fuse_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/fxusd/core/ez_fxusd_metrics.sql
+++ b/models/projects/fxusd/core/ez_fxusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/gains_network/core/ez_gains_network_metrics.sql
+++ b/models/projects/gains_network/core/ez_gains_network_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/geodnet/core/ez_geodnet_metrics.sql
+++ b/models/projects/geodnet/core/ez_geodnet_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/gho/core/ez_gho_metrics.sql
+++ b/models/projects/gho/core/ez_gho_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/glow/core/ez_glow_metrics.sql
+++ b/models/projects/glow/core/ez_glow_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/gmx/core/ez_gmx_metrics.sql
+++ b/models/projects/gmx/core/ez_gmx_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/gnosis/core/ez_gnosis_metrics.sql
+++ b/models/projects/gnosis/core/ez_gnosis_metrics.sql
@@ -9,7 +9,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )

--- a/models/projects/gnosispay/core/ez_gnosispay_metrics.sql
+++ b/models/projects/gnosispay/core/ez_gnosispay_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/goldfinch/core/ez_goldfinch_metrics.sql
+++ b/models/projects/goldfinch/core/ez_goldfinch_metrics.sql
@@ -9,7 +9,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )

--- a/models/projects/grass/core/ez_grass_metrics.sql
+++ b/models/projects/grass/core/ez_grass_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/gusd/core/ez_gusd_metrics.sql
+++ b/models/projects/gusd/core/ez_gusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/haedal/core/ez_haedal_metrics.sql
+++ b/models/projects/haedal/core/ez_haedal_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/hashnote/core/ez_hashnote_metrics.sql
+++ b/models/projects/hashnote/core/ez_hashnote_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/hedera/core/ez_hedera_metrics.sql
+++ b/models/projects/hedera/core/ez_hedera_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/helium/core/ez_helium_metrics.sql
+++ b/models/projects/helium/core/ez_helium_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/hivemapper/core/ez_hivemapper_metrics.sql
+++ b/models/projects/hivemapper/core/ez_hivemapper_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/holdstation/core/ez_holdstation_metrics.sql
+++ b/models/projects/holdstation/core/ez_holdstation_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/holyheld/core/ez_holyheld_metrics.sql
+++ b/models/projects/holyheld/core/ez_holyheld_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/hydration/core/ez_hydration_metrics.sql
+++ b/models/projects/hydration/core/ez_hydration_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
+++ b/models/projects/hyperliquid/core/ez_hyperliquid_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/idrt/core/ez_idrt_metrics.sql
+++ b/models/projects/idrt/core/ez_idrt_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/idrx/core/ez_idrx_metrics.sql
+++ b/models/projects/idrx/core/ez_idrx_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/immutable_x/core/ez_immutable_x_metrics.sql
+++ b/models/projects/immutable_x/core/ez_immutable_x_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/injective/core/ez_injective_metrics.sql
+++ b/models/projects/injective/core/ez_injective_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ink/core/ez_ink_metrics.sql
+++ b/models/projects/ink/core/ez_ink_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/internet_computer/core/ez_internet_computer_metrics.sql
+++ b/models/projects/internet_computer/core/ez_internet_computer_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/iotex/core/ez_iotex_metrics.sql
+++ b/models/projects/iotex/core/ez_iotex_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/jito/core/ez_jito_metrics.sql
+++ b/models/projects/jito/core/ez_jito_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/jupiter/core/ez_jupiter_metrics.sql
+++ b/models/projects/jupiter/core/ez_jupiter_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/kai/core/ez_kai_metrics.sql
+++ b/models/projects/kai/core/ez_kai_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/kaia/core/ez_kaia_metrics.sql
+++ b/models/projects/kaia/core/ez_kaia_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/kaiching/core/ez_kaiching_metrics.sql
+++ b/models/projects/kaiching/core/ez_kaiching_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     ) 

--- a/models/projects/kamino/core/ez_kamino_metrics.sql
+++ b/models/projects/kamino/core/ez_kamino_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/kelp_dao/core/ez_kelp_dao_metrics.sql
+++ b/models/projects/kelp_dao/core/ez_kelp_dao_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ktx_finance/core/ez_ktx_finance_metrics.sql
+++ b/models/projects/ktx_finance/core/ez_ktx_finance_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/layerzero/core/ez_layerzero_metrics.sql
+++ b/models/projects/layerzero/core/ez_layerzero_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/leo/core/ez_leo_metrics.sql
+++ b/models/projects/leo/core/ez_leo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/level_finance/core/ez_level_finance_metrics.sql
+++ b/models/projects/level_finance/core/ez_level_finance_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/lido/core/ez_lido_metrics.sql
+++ b/models/projects/lido/core/ez_lido_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/lifinity/core/ez_lifinity_metrics.sql
+++ b/models/projects/lifinity/core/ez_lifinity_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/linea/core/ez_linea_metrics.sql
+++ b/models/projects/linea/core/ez_linea_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/liquidswap/core/ez_liquidswap_metrics.sql
+++ b/models/projects/liquidswap/core/ez_liquidswap_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/liquity/core/ez_liquity_metrics.sql
+++ b/models/projects/liquity/core/ez_liquity_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/lisusd/core/ez_lisusd_metrics.sql
+++ b/models/projects/lisusd/core/ez_lisusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/litecoin/core/ez_litecoin_metrics.sql
+++ b/models/projects/litecoin/core/ez_litecoin_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/livepeer/ez_livepeer_metrics.sql
+++ b/models/projects/livepeer/ez_livepeer_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/lusd/core/ez_lusd_metrics.sql
+++ b/models/projects/lusd/core/ez_lusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/lvlusd/core/ez_lvlusd_metrics.sql
+++ b/models/projects/lvlusd/core/ez_lvlusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/magiceden/core/ez_magiceden_metrics.sql
+++ b/models/projects/magiceden/core/ez_magiceden_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/maker/core/ez_maker_metrics.sql
+++ b/models/projects/maker/core/ez_maker_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/manta/core/ez_manta_metrics.sql
+++ b/models/projects/manta/core/ez_manta_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/mantle/core/ez_mantle_metrics.sql
+++ b/models/projects/mantle/core/ez_mantle_metrics.sql
@@ -10,7 +10,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )

--- a/models/projects/maple/core/ez_maple_metrics.sql
+++ b/models/projects/maple/core/ez_maple_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/marinade/core/ez_marinade_metrics.sql
+++ b/models/projects/marinade/core/ez_marinade_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/mento/core/ez_mento_metrics.sql
+++ b/models/projects/mento/core/ez_mento_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/metaplex/core/ez_metaplex_metrics.sql
+++ b/models/projects/metaplex/core/ez_metaplex_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/meteora/core/ez_meteora_metrics.sql
+++ b/models/projects/meteora/core/ez_meteora_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/metis/core/ez_metis_metrics.sql
+++ b/models/projects/metis/core/ez_metis_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/mim/core/ez_mim_metrics.sql
+++ b/models/projects/mim/core/ez_mim_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/momentum/core/ez_momentum_metrics.sql
+++ b/models/projects/momentum/core/ez_momentum_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/moonbeam/core/ez_moonbeam_metrics.sql
+++ b/models/projects/moonbeam/core/ez_moonbeam_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/moonwell/core/ez_moonwell_metrics.sql
+++ b/models/projects/moonwell/core/ez_moonwell_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/morpho/core/ez_morpho_metrics.sql
+++ b/models/projects/morpho/core/ez_morpho_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/movement/core/ez_movement_metrics.sql
+++ b/models/projects/movement/core/ez_movement_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/multiversx/core/ez_multiversx_metrics.sql
+++ b/models/projects/multiversx/core/ez_multiversx_metrics.sql
@@ -9,7 +9,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )

--- a/models/projects/mux/core/ez_mux_metrics.sql
+++ b/models/projects/mux/core/ez_mux_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/mythos/core/ez_mythos_metrics.sql
+++ b/models/projects/mythos/core/ez_mythos_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/navi/core/ez_navi_metrics.sql
+++ b/models/projects/navi/core/ez_navi_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/near/core/ez_near_metrics.sql
+++ b/models/projects/near/core/ez_near_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/neuroweb/core/ez_neuroweb_metrics.sql
+++ b/models/projects/neuroweb/core/ez_neuroweb_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/nova/core/ez_nova_metrics.sql
+++ b/models/projects/nova/core/ez_nova_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ondo/core/ez_ondo_metrics.sql
+++ b/models/projects/ondo/core/ez_ondo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/openeden/core/ez_openeden_metrics.sql
+++ b/models/projects/openeden/core/ez_openeden_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/orca/core/ez_orca_metrics.sql
+++ b/models/projects/orca/core/ez_orca_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/osmosis/core/ez_osmosis_metrics.sql
+++ b/models/projects/osmosis/core/ez_osmosis_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/ostium/core/ez_ostium_metrics.sql
+++ b/models/projects/ostium/core/ez_ostium_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/outerlands/core/ez_outerlands_metrics.sql
+++ b/models/projects/outerlands/core/ez_outerlands_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/pancakeswap/core/ez_pancakeswap_metrics.sql
+++ b/models/projects/pancakeswap/core/ez_pancakeswap_metrics.sql
@@ -4,7 +4,7 @@
         incremental_strategy="merge",
         unique_key=["date"],
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         on_schema_change="append_new_columns",
         full_refresh=false,
         snowflake_warehouse="PANCAKESWAP_SM",

--- a/models/projects/paxos/core/ez_paxos_metrics.sql
+++ b/models/projects/paxos/core/ez_paxos_metrics.sql
@@ -4,7 +4,7 @@
         incremental_strategy = 'merge',
         unique_key = ["date"],
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         on_schema_change = "append_new_columns",
         full_refresh = false,
         database = 'paxos',

--- a/models/projects/paypal/core/ez_paypal_metrics.sql
+++ b/models/projects/paypal/core/ez_paypal_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/pendle/core/ez_pendle_metrics.sql
+++ b/models/projects/pendle/core/ez_pendle_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics.sql
+++ b/models/projects/perpetual_protocol/core/ez_perpetual_protocol_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"],
     )

--- a/models/projects/pharaoh/core/ez_pharaoh_metrics.sql
+++ b/models/projects/pharaoh/core/ez_pharaoh_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var('backfill_columns', []),
-        merge_exclude_columns=['created_on'] | reject('in', var('backfill_columns', [])) | list,
+        merge_exclude_columns=['created_on'] if not var('backfill_columns', []) else none,
         full_refresh=false,
         tags=['ez_metrics']
     )

--- a/models/projects/plume/core/ez_plume_metrics.sql
+++ b/models/projects/plume/core/ez_plume_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/polkadot/core/ez_polkadot_metrics.sql
+++ b/models/projects/polkadot/core/ez_polkadot_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
+++ b/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/polymarket/core/ez_polymarket_metrics.sql
+++ b/models/projects/polymarket/core/ez_polymarket_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/puffer_finance/core/ez_puffer_finance_metrics.sql
+++ b/models/projects/puffer_finance/core/ez_puffer_finance_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/pumpfun/core/ez_pumpfun_metrics.sql
+++ b/models/projects/pumpfun/core/ez_pumpfun_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/pyth/core/ez_pyth_metrics.sql
+++ b/models/projects/pyth/core/ez_pyth_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/pyusd/core/ez_pyusd_metrics.sql
+++ b/models/projects/pyusd/core/ez_pyusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/quickswap/core/ez_quickswap_metrics.sql
+++ b/models/projects/quickswap/core/ez_quickswap_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/rabbit_x/core/ez_rabbit_x_metrics.sql
+++ b/models/projects/rabbit_x/core/ez_rabbit_x_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/radiant/core/ez_radiant_metrics.sql
+++ b/models/projects/radiant/core/ez_radiant_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/rainbow_bridge/core/ez_rainbow_bridge_metrics.sql
+++ b/models/projects/rainbow_bridge/core/ez_rainbow_bridge_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/raydium/core/ez_raydium_metrics.sql
+++ b/models/projects/raydium/core/ez_raydium_metrics.sql
@@ -9,7 +9,7 @@
         incremental_strategy="merge",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/ref_finance/core/ez_ref_finance_metrics.sql
+++ b/models/projects/ref_finance/core/ez_ref_finance_metrics.sql
@@ -9,7 +9,7 @@
         incremental_strategy = 'merge',
         on_schema_change = 'append_new_columns',
         merge_update_columns = var('backfill_columns', []),
-        merge_exclude_columns = ['created_on'] | reject('in', var('backfill_columns', [])) | list,
+        merge_exclude_columns=['created_on'] if not var('backfill_columns', []) else none,
         full_refresh = false,
         tags = ['ez_metrics']
     )

--- a/models/projects/remittance/core/ez_remittance_metrics.sql
+++ b/models/projects/remittance/core/ez_remittance_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/render/core/ez_render_metrics.sql
+++ b/models/projects/render/core/ez_render_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics.sql
+++ b/models/projects/renzo_protocol/core/ez_renzo_protocol_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/reserve/core/ez_reserve_metrics.sql
+++ b/models/projects/reserve/core/ez_reserve_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/ripple/core/ez_ripple_metrics.sql
+++ b/models/projects/ripple/core/ez_ripple_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/rlusd/core/ez_rlusd_metrics.sql
+++ b/models/projects/rlusd/core/ez_rlusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/rocketpool/core/ez_rocketpool_metrics.sql
+++ b/models/projects/rocketpool/core/ez_rocketpool_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/ronin/core/ez_ronin_metrics.sql
+++ b/models/projects/ronin/core/ez_ronin_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/s_usd/core/ez_s_usd_metrics.sql
+++ b/models/projects/s_usd/core/ez_s_usd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/saber/core/ez_saber_metrics.sql
+++ b/models/projects/saber/core/ez_saber_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/safe/core/ez_safe_metrics.sql
+++ b/models/projects/safe/core/ez_safe_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/scallop/core/ez_scallop_metrics.sql
+++ b/models/projects/scallop/core/ez_scallop_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/scroll/core/ez_scroll_metrics.sql
+++ b/models/projects/scroll/core/ez_scroll_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/seamless/core/ez_seamless_metrics.sql
+++ b/models/projects/seamless/core/ez_seamless_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/sei/core/ez_sei_metrics.sql
+++ b/models/projects/sei/core/ez_sei_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -10,7 +10,7 @@
         incremental_strategy="merge",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/soneium/core/ez_soneium_metrics.sql
+++ b/models/projects/soneium/core/ez_soneium_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/sonic/core/ez_sonic_metrics.sql
+++ b/models/projects/sonic/core/ez_sonic_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/sonne/core/ez_sonne_metrics.sql
+++ b/models/projects/sonne/core/ez_sonne_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/spark/core/ez_spark_metrics.sql
+++ b/models/projects/spark/core/ez_spark_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/spiko/core/ez_spiko_metrics.sql
+++ b/models/projects/spiko/core/ez_spiko_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stacks/core/ez_stacks_metrics.sql
+++ b/models/projects/stacks/core/ez_stacks_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stader/core/ez_stader_metrics.sql
+++ b/models/projects/stader/core/ez_stader_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stakewise/core/ez_stakewise_metrics.sql
+++ b/models/projects/stakewise/core/ez_stakewise_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stargate/core/ez_stargate_metrics.sql
+++ b/models/projects/stargate/core/ez_stargate_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/starknet/core/ez_starknet_metrics.sql
+++ b/models/projects/starknet/core/ez_starknet_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stellar/core/ez_stellar_metrics.sql
+++ b/models/projects/stellar/core/ez_stellar_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stellaswap/core/ez_stellaswap_metrics.sql
+++ b/models/projects/stellaswap/core/ez_stellaswap_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/story/core/ez_story_metrics.sql
+++ b/models/projects/story/core/ez_story_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/stride/core/ez_stride_metrics.sql
+++ b/models/projects/stride/core/ez_stride_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/sui/core/ez_sui_metrics.sql
+++ b/models/projects/sui/core/ez_sui_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/suilend/core/ez_suilend_metrics.sql
+++ b/models/projects/suilend/core/ez_suilend_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/superstate/core/ez_superstate_metrics.sql
+++ b/models/projects/superstate/core/ez_superstate_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/susd/core/ez_susd_metrics.sql
+++ b/models/projects/susd/core/ez_susd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/sushiswap/core/ez_sushiswap_metrics.sql
+++ b/models/projects/sushiswap/core/ez_sushiswap_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/swell/core/ez_swell_metrics.sql
+++ b/models/projects/swell/core/ez_swell_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/synapse/core/ez_synapse_metrics.sql
+++ b/models/projects/synapse/core/ez_synapse_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/synthetix/core/ez_synthetix_metrics.sql
+++ b/models/projects/synthetix/core/ez_synthetix_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/syrup/core/ez_syrup_metrics.sql
+++ b/models/projects/syrup/core/ez_syrup_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/tether/core/ez_tether_metrics.sql
+++ b/models/projects/tether/core/ez_tether_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/thorchain/core/ez_thorchain_metrics.sql
+++ b/models/projects/thorchain/core/ez_thorchain_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/ton/core/ez_ton_metrics.sql
+++ b/models/projects/ton/core/ez_ton_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
+++ b/models/projects/trader_joe/core/ez_trader_joe_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/tryb/core/ez_tryb_metrics.sql
+++ b/models/projects/tryb/core/ez_tryb_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/tusd/core/ez_tusd_metrics.sql
+++ b/models/projects/tusd/core/ez_tusd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/unichain/core/ez_unichain_metrics.sql
+++ b/models/projects/unichain/core/ez_unichain_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/uniswap/core/ez_uniswap_metrics.sql
+++ b/models/projects/uniswap/core/ez_uniswap_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usd0/core/ez_usd0_metrics.sql
+++ b/models/projects/usd0/core/ez_usd0_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usd1/core/ez_usd1_metrics.sql
+++ b/models/projects/usd1/core/ez_usd1_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usd3/core/ez_usd3_metrics.sql
+++ b/models/projects/usd3/core/ez_usd3_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usd_star/core/ez_usd_star_metrics.sql
+++ b/models/projects/usd_star/core/ez_usd_star_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usda/core/ez_usda_metrics.sql
+++ b/models/projects/usda/core/ez_usda_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdc/core/ez_usdc_metrics.sql
+++ b/models/projects/usdc/core/ez_usdc_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdd/core/ez_usdd_metrics.sql
+++ b/models/projects/usdd/core/ez_usdd_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usde/core/ez_usde_metrics.sql
+++ b/models/projects/usde/core/ez_usde_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdf/core/ez_usdf_metrics.sql
+++ b/models/projects/usdf/core/ez_usdf_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdfalcon/core/ez_usdfalcon_metrics.sql
+++ b/models/projects/usdfalcon/core/ez_usdfalcon_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdg/core/ez_usdg_metrics.sql
+++ b/models/projects/usdg/core/ez_usdg_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdglo/core/ez_usdglo_metrics.sql
+++ b/models/projects/usdglo/core/ez_usdglo_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdp/core/ez_usdp_metrics.sql
+++ b/models/projects/usdp/core/ez_usdp_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usds/core/ez_usds_metrics.sql
+++ b/models/projects/usds/core/ez_usds_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdt/core/ez_usdt_metrics.sql
+++ b/models/projects/usdt/core/ez_usdt_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdt0/core/ez_usdt0_metrics.sql
+++ b/models/projects/usdt0/core/ez_usdt0_metrics.sql
@@ -8,7 +8,7 @@
     unique_key="date",
     on_schema_change="append_new_columns",
     merge_update_columns=var("backfill_columns", []),
-    merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+    merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
     full_refresh=false,
     tags=["ez_metrics"]
 ) }}

--- a/models/projects/usdtb/core/ez_usdtb_metrics.sql
+++ b/models/projects/usdtb/core/ez_usdtb_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdx/core/ez_usdx_metrics.sql
+++ b/models/projects/usdx/core/ez_usdx_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdy/core/ez_usdy_metrics.sql
+++ b/models/projects/usdy/core/ez_usdy_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usdz/core/ez_usdz_metrics.sql
+++ b/models/projects/usdz/core/ez_usdz_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usn/core/ez_usn_metrics.sql
+++ b/models/projects/usn/core/ez_usn_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usr/core/ez_usr_metrics.sql
+++ b/models/projects/usr/core/ez_usr_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/usual/core/ez_usual_metrics.sql
+++ b/models/projects/usual/core/ez_usual_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var('backfill_columns', []),
-        merge_exclude_columns=['created_on'] | reject('in', var('backfill_columns', [])) | list,
+        merge_exclude_columns=['created_on'] if not var('backfill_columns', []) else none,
         full_refresh=false,
         tags=['ez_metrics']
     )

--- a/models/projects/veax/core/ez_veax_metrics.sql
+++ b/models/projects/veax/core/ez_veax_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var('backfill_columns', []),
-        merge_exclude_columns=['created_on'] | reject('in', var('backfill_columns', [])) | list,
+        merge_exclude_columns=['created_on'] if not var('backfill_columns', []) else none,
         full_refresh=false,
         tags=['ez_metrics']
     )

--- a/models/projects/velodrome/core/ez_velodrome_metrics.sql
+++ b/models/projects/velodrome/core/ez_velodrome_metrics.sql
@@ -9,7 +9,7 @@
         unique_key='date',
         on_schema_change='append_new_columns',
         merge_update_columns=var('backfill_columns', []),
-        merge_exclude_columns=['created_on'] | reject('in', var('backfill_columns', [])) | list,
+        merge_exclude_columns=['created_on'] if not var('backfill_columns', []) else none,
         full_refresh=false,
         tags=['ez_metrics']
     )

--- a/models/projects/venus/core/ez_venus_metrics.sql
+++ b/models/projects/venus/core/ez_venus_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/vertex/core/ez_vertex_metrics.sql
+++ b/models/projects/vertex/core/ez_vertex_metrics.sql
@@ -15,7 +15,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
     )
 }}
 

--- a/models/projects/virtuals/core/ez_virtuals_metrics.sql
+++ b/models/projects/virtuals/core/ez_virtuals_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/visa/core/ez_visa_metrics.sql
+++ b/models/projects/visa/core/ez_visa_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/walrus/core/ez_walrus_metrics.sql
+++ b/models/projects/walrus/core/ez_walrus_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/wisdomtree/core/ez_wisdomtree_metrics.sql
+++ b/models/projects/wisdomtree/core/ez_wisdomtree_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/worldchain/core/ez_worldchain_metrics.sql
+++ b/models/projects/worldchain/core/ez_worldchain_metrics.sql
@@ -9,7 +9,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/wormhole/core/ez_wormhole_metrics.sql
+++ b/models/projects/wormhole/core/ez_wormhole_metrics.sql
@@ -8,7 +8,7 @@
     unique_key="date",
     on_schema_change="append_new_columns",
     merge_update_columns=var("backfill_columns", []),
-    merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+    merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
     full_refresh=false,
     tags=["ez_metrics"]
 ) }}

--- a/models/projects/zcash/core/ez_zcash_metrics.sql
+++ b/models/projects/zcash/core/ez_zcash_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/zksync/core/ez_zksync_metrics.sql
+++ b/models/projects/zksync/core/ez_zksync_metrics.sql
@@ -10,7 +10,7 @@
         unique_key="date",
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
-        merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list,
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
         full_refresh=false,
         tags=["ez_metrics"]
     )

--- a/models/projects/zora/core/ez_zora_metrics.sql
+++ b/models/projects/zora/core/ez_zora_metrics.sql
@@ -9,7 +9,7 @@
         , unique_key="date"
         , on_schema_change="append_new_columns"
         , merge_update_columns=var("backfill_columns", [])
-        , merge_exclude_columns=["created_on"] | reject('in', var("backfill_columns", [])) | list
+        , merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none
         , full_refresh=false
         , tags=["ez_metrics"]
     )


### PR DESCRIPTION
## Context
Issue when passing columns in the `backfill_column` var where we cannot have both `merge_exclude_columns` and `merge_update_columns` configs active at the same time. 

This change fixes so that `merge_exclude_columns` is active when no `backfill_column` var is passed (ie: when it is omitted to update all columns during a backfill for example), and when `backfill_column` is passed `merge_exclude_columns` is inactive as it is presumed that the specified columns need to be backfilled (even if `created_on` is passed).


- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)
Tested on drift where we first experienced the issue and all looks good. 
<img width="1536" height="295" alt="Screenshot 2025-07-28 at 2 55 12 PM" src="https://github.com/user-attachments/assets/2907af25-65ba-4677-9647-88fc72226a4e" />

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
