### PR TITLE
Lido Metric Deprecation

### DIFF
--- a/models/projects/lido/core/__lido__schema.yml
+++ b/models/projects/lido/core/__lido__schema.yml
@@ -38,6 +38,10 @@ column_definitions:
     name: net_treasury_native
     description: "The native value of tokens in the protocol's treasury excluding the protocol's own tokens"
 
+  own_token_treasury: &own_token_treasury
+    name: own_token_treasury
+    description: "The USD value of the protocol's own tokens in the protocol treasury"
+
   own_token_treasury_native: &own_token_treasury_native
     name: own_token_treasury_native
     description: "The native value of the protocol's own tokens in the protocol treasury"
@@ -134,33 +138,12 @@ models:
   - name: ez_lido_metrics_by_token
     description: "This table stores metrics for the LIDO protocol"
     columns:
-      - *fees
       - *net_treasury_native
       - *own_token_treasury_native
       - *treasury_native
       - *tvl_native
       - *validator_fee_allocation_native
       - *yield_generated_native
-
-    tests:
-      - not_null:
-          column_name: date
-          description: "Ensures that the date column is not null"
-          severity: error
-      - dbt_utils.recency:
-          datepart: day
-          interval: 2
-          field: date
-          description: "Ensures that the date column contains at least one record from the last 2 days"
-          severity: error
-      - dbt_utils.expression_is_true:
-          expression: date = cast(date as date)
-          description: "Ensures that the date column is properly typed as DATE with yyyy-mm-dd format"
-          severity: error
-      - not_null:
-          column_name: token
-          description: "Ensures that the token column is not null for by_token tables"
-          severity: error
   - name: ez_lido_metrics
     description: "This table stores metrics for the LIDO protocol"
     columns:
@@ -170,6 +153,7 @@ models:
       - *lst_tvl
       - *market_cap
       - *net_treasury
+      - *own_token_treasury
       - *own_token_treasury_native
       - *price
       - *revenue
@@ -179,27 +163,10 @@ models:
       - *token_volume
       - *treasury
       - *treasury_fee_allocation
-      - *treasury_native
       - *tvl
       - *tvl_native
       - *validator_fee_allocation
       - *yield_generated
-
-    tests:
-      - not_null:
-          column_name: date
-          description: "Ensures that the date column is not null"
-          severity: error
-      - dbt_utils.recency:
-          datepart: day
-          interval: 2
-          field: date
-          description: "Ensures that the date column contains at least one record from the last 2 days"
-          severity: error
-      - dbt_utils.expression_is_true:
-          expression: date = cast(date as date)
-          description: "Ensures that the date column is properly typed as DATE with yyyy-mm-dd format"
-          severity: error
   - name: ez_lido_metrics_by_chain
     description: "This table stores metrics for the LIDO protocol"
     columns:
@@ -218,28 +185,7 @@ models:
       - *token_volume
       - *treasury
       - *treasury_fee_allocation
-      - *treasury_native
       - *tvl
       - *tvl_native
       - *validator_fee_allocation
       - *yield_generated
-
-    tests:
-      - not_null:
-          column_name: date
-          description: "Ensures that the date column is not null"
-          severity: error
-      - dbt_utils.recency:
-          datepart: day
-          interval: 2
-          field: date
-          description: "Ensures that the date column contains at least one record from the last 2 days"
-          severity: error
-      - dbt_utils.expression_is_true:
-          expression: date = cast(date as date)
-          description: "Ensures that the date column is properly typed as DATE with yyyy-mm-dd format"
-          severity: error
-      - not_null:
-          column_name: chain
-          description: "Ensures that the chain column is not null for by_chain tables"
-          severity: error

--- a/models/projects/lido/core/__lido__schema.yml
+++ b/models/projects/lido/core/__lido__schema.yml
@@ -144,6 +144,25 @@ models:
       - *tvl_native
       - *validator_fee_allocation_native
       - *yield_generated_native
+    tests:
+      - not_null:
+          column_name: date
+          description: "Ensures that the date column is not null"
+          severity: error
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: "Ensures that the date column contains at least one record from the last 2 days"
+          severity: error
+      - dbt_utils.expression_is_true:
+          expression: date = cast(date as date)
+          description: "Ensures that the date column is properly typed as DATE with yyyy-mm-dd format"
+          severity: error
+      - not_null:
+          column_name: token
+          description: "Ensures that the token column is not null for by_token tables"
+          severity: error
   - name: ez_lido_metrics
     description: "This table stores metrics for the LIDO protocol"
     columns:
@@ -189,3 +208,22 @@ models:
       - *tvl_native
       - *validator_fee_allocation
       - *yield_generated
+    tests:
+      - not_null:
+          column_name: date
+          description: "Ensures that the date column is not null"
+          severity: error
+      - dbt_utils.recency:
+          datepart: day
+          interval: 2
+          field: date
+          description: "Ensures that the date column contains at least one record from the last 2 days"
+          severity: error
+      - dbt_utils.expression_is_true:
+          expression: date = cast(date as date)
+          description: "Ensures that the date column is properly typed as DATE with yyyy-mm-dd format"
+          severity: error
+      - not_null:
+          column_name: chain
+          description: "Ensures that the chain column is not null for by_chain tables"
+          severity: error

--- a/models/projects/lido/core/ez_lido_metrics.sql
+++ b/models/projects/lido/core/ez_lido_metrics.sql
@@ -21,31 +21,31 @@ with
     fees_revenue_expenses as (
         SELECT
             date
-            , block_rewards
-            , mev_priority_fees
-            , total_staking_yield as yield_generated
-            , fees
-            , validator_fee_allocation
-            , treasury_fee_allocation
-            , protocol_revenue
-            , primary_supply_side_revenue
-            , secondary_supply_side_revenue
-            , total_supply_side_revenue
+            , coalesce(block_rewards, 0) as block_rewards
+            , coalesce(mev_priority_fees, 0) as mev_priority_fees
+            , coalesce(total_staking_yield, 0) as yield_generated
+            , coalesce(fees, 0) as fees
+            , coalesce(validator_fee_allocation, 0) as validator_fee_allocation
+            , coalesce(treasury_fee_allocation, 0) as treasury_fee_allocation
+            , coalesce(protocol_revenue, 0) as protocol_revenue
+            , coalesce(primary_supply_side_revenue, 0) as primary_supply_side_revenue
+            , coalesce(secondary_supply_side_revenue, 0) as secondary_supply_side_revenue
+            , coalesce(total_supply_side_revenue, 0) as total_supply_side_revenue
         FROM {{ ref('fact_lido_fees_revs_expenses') }}
     )
     , staked_eth_metrics as (
         select
             date
-            , num_staked_eth
-            , amount_staked_usd
-            , num_staked_eth_net_change
-            , amount_staked_usd_net_change
+            , coalesce(num_staked_eth, 0) as num_staked_eth
+            , coalesce(amount_staked_usd, 0) as amount_staked_usd
+            , coalesce(num_staked_eth_net_change, 0) as num_staked_eth_net_change
+            , coalesce(amount_staked_usd_net_change, 0) as amount_staked_usd_net_change
         from {{ ref('fact_lido_staked_eth_count_with_USD_and_change') }}
     )
     , treasury_cte as (
         SELECT
             date
-            , sum(usd_balance) as treasury_value
+            , coalesce(sum(usd_balance), 0) as treasury_value
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         GROUP BY 1
@@ -53,7 +53,7 @@ with
     , treasury_native_cte as (
         SELECT
             date
-            , sum(native_balance) as treasury_native
+            , coalesce(sum(native_balance), 0) as treasury_native
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         WHERE token = 'LDO'
@@ -62,7 +62,7 @@ with
     , net_treasury_cte as (
         SELECT
             date
-            , sum(usd_balance) as net_treasury_value
+            , coalesce(sum(usd_balance), 0) as net_treasury_value
         FROM {{ ref('fact_lido_dao_treasury') }}
         WHERE token <> 'LDO'
         group by 1
@@ -70,80 +70,83 @@ with
     , token_incentives_cte as (
         SELECT
             date
-            , sum(amount_usd) as token_incentives
+            , coalesce(sum(amount_usd), 0) as token_incentives
         FROM
             {{ ref('fact_lido_token_incentives') }}
         GROUP BY 1
     )
-    , price_data as (
+    , market_metrics as (
         {{ get_coingecko_metrics('lido-dao') }}
     )
     , tokenholder_cte as (
         SELECT
             date,
-            token_holder_count
+            coalesce(token_holder_count, 0) as token_holder_count
         FROM
             {{ ref('fact_ldo_tokenholder_count')}}
     )
 select
-    s.date
-    --Old metrics needed for compatibility
-    , COALESCE(f.primary_supply_side_revenue, 0) as primary_supply_side_revenue
-    , COALESCE(f.secondary_supply_side_revenue, 0) as secondary_supply_side_revenue
-    , COALESCE(f.total_supply_side_revenue, 0) as total_supply_side_revenue
-    , COALESCE(t.treasury_value, 0) as treasury_value
-    , COALESCE(tn.treasury_native, 0) as treasury_native
-    , COALESCE(nt.net_treasury_value, 0) as net_treasury_value
-    , COALESCE(s.amount_staked_usd, 0) as net_deposits
-    , COALESCE(s.num_staked_eth, 0) as outstanding_supply
-    , COALESCE(s.amount_staked_usd, 0) as amount_staked_usd
-    , COALESCE(s.num_staked_eth, 0) as num_staked_eth
-    , COALESCE(s.amount_staked_usd_net_change, 0) as amount_staked_usd_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as num_staked_eth_net_change
-    --Standardized Metrics
-    --Market Metrics
-    , COALESCE(p.price, 0) as price
-    , COALESCE(p.fdmc, 0) as fdmc
-    , COALESCE(p.market_cap, 0) as market_cap
-    , COALESCE(p.token_volume, 0) as token_volume
-    --Usage Metrics
-    , COALESCE(s.amount_staked_usd, 0) as lst_tvl
-    , COALESCE(s.amount_staked_usd, 0) as tvl
-    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
-    , COALESCE(s.num_staked_eth, 0) as tvl_native
-    , COALESCE(s.amount_staked_usd_net_change, 0) as lst_tvl_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as lst_tvl_native_net_change
-    , COALESCE(f.yield_generated, 0) as yield_generated
-    --Cash Flow Metrics
-    , COALESCE(f.mev_priority_fees, 0) as mev_priority_fees
-    , COALESCE(f.block_rewards, 0) as block_rewards
-    , COALESCE(f.fees, 0) as fees
-    , COALESCE(f.treasury_fee_allocation, 0) as treasury_fee_allocation
-    , COALESCE(f.validator_fee_allocation, 0) as validator_fee_allocation
-    -- Financial Statement Metrics
-    , COALESCE(f.protocol_revenue, 0) as revenue
-    , COALESCE(ti.token_incentives, 0) as token_incentives
-    , COALESCE(ti.token_incentives, 0) as total_expenses
-    , COALESCE(f.protocol_revenue, 0) - COALESCE(ti.token_incentives, 0) as earnings
-    --Treasury Metrics
-    , COALESCE(t.treasury_value, 0) as treasury
-    , COALESCE(tn.treasury_native, 0) as own_token_treasury_native
-    , COALESCE(nt.net_treasury_value, 0) as net_treasury
-    --Other Metrics
-    , COALESCE(p.token_turnover_fdv, 0) as token_turnover_fdv
-    , COALESCE(p.token_turnover_circulating, 0) as token_turnover_circulating
-    , COALESCE(th.token_holder_count, 0) as token_holder_count
+    staked_eth_metrics.date
+    , 'lido' as artemis_id
+
+    -- Standardized Metrics
+    
+    -- Market Data
+    , market_metrics.price
+    , market_metrics.fdmc
+    , market_metrics.market_cap
+    , market_metrics.token_volume
+
+    -- Usage Data
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.amount_staked_usd as tvl
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , fees_revenue_expenses.yield_generated as yield_generated
+    , staked_eth_metrics.amount_staked_usd_net_change as amount_staked_usd_net_change
+    , staked_eth_metrics.num_staked_eth_net_change as num_staked_eth_net_change
+    
+    -- Fee Data
+    , fees_revenue_expenses.mev_priority_fees as mev_priority_fees
+    , fees_revenue_expenses.block_rewards as block_rewards
+    , fees_revenue_expenses.fees as fees
+    , fees_revenue_expenses.treasury_fee_allocation as treasury_fee_allocation
+    , fees_revenue_expenses.validator_fee_allocation as validator_fee_allocation
+    
+    -- Financial Statement
+    , fees_revenue_expenses.protocol_revenue as revenue
+    , token_incentives_cte.token_incentives as token_incentives
+    , token_incentives_cte.token_incentives as total_expenses
+    , fees_revenue_expenses.protocol_revenue - token_incentives_cte.token_incentives as earnings
+    
+    --Treasury Data
+    , treasury_cte.treasury_value as treasury
+    , net_treasury_cte.net_treasury_value as net_treasury
+    , treasury_native_cte.treasury_native as own_token_treasury_native
+    , treasury_native_cte.treasury_native * market_metrics.price as own_token_treasury
+
+    -- Token Turnover/Other Data
+    , market_metrics.token_turnover_fdv as token_turnover_fdv
+    , market_metrics.token_turnover_circulating as token_turnover_circulating
+    
+    -- Bespoke Metrics
+    , tokenholder_cte.token_holder_count as token_holder_count
+
+
     -- timestamp columns
     , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
     , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
-from staked_eth_metrics s
-left join fees_revenue_expenses f  using(date)
-left join treasury_cte t using(date)
-left join treasury_native_cte tn using(date)
-left join net_treasury_cte nt using(date)
-left join token_incentives_cte ti using(date)
-left join price_data p using(date)
-left join tokenholder_cte th using(date)
+
+from staked_eth_metrics
+left join fees_revenue_expenses using(date)
+left join treasury_cte using(date)
+left join treasury_native_cte using(date)
+left join net_treasury_cte using(date)
+left join token_incentives_cte using(date)
+left join market_metrics using(date)
+left join tokenholder_cte using(date)
 where true
-{{ ez_metrics_incremental('s.date', backfill_date) }}
-and s.date < to_date(sysdate())
+{{ ez_metrics_incremental('staked_eth_metrics.date', backfill_date) }}
+and staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/lido/core/ez_lido_metrics_by_chain.sql
+++ b/models/projects/lido/core/ez_lido_metrics_by_chain.sql
@@ -12,22 +12,22 @@ with
     fees_revenue_expenses as (
         SELECT
             date
-            , block_rewards
-            , mev_priority_fees
-            , total_staking_yield as yield_generated
-            , fees
-            , validator_fee_allocation
-            , treasury_fee_allocation
-            , protocol_revenue
-            , primary_supply_side_revenue
-            , secondary_supply_side_revenue
-            , total_supply_side_revenue
+            , coalesce(block_rewards, 0) as block_rewards
+            , coalesce(mev_priority_fees, 0) as mev_priority_fees
+            , coalesce(total_staking_yield, 0) as yield_generated
+            , coalesce(fees, 0) as fees
+            , coalesce(validator_fee_allocation, 0) as validator_fee_allocation
+            , coalesce(treasury_fee_allocation, 0) as treasury_fee_allocation
+            , coalesce(protocol_revenue, 0) as protocol_revenue
+            , coalesce(primary_supply_side_revenue, 0) as primary_supply_side_revenue
+            , coalesce(secondary_supply_side_revenue, 0) as secondary_supply_side_revenue
+            , coalesce(total_supply_side_revenue, 0) as total_supply_side_revenue
         FROM {{ ref('fact_lido_fees_revs_expenses') }}
     )
     , token_incentives_cte as (
         SELECT
             date
-            , sum(amount_usd) as token_incentives
+            , coalesce(sum(amount_usd), 0) as token_incentives
         FROM
             {{ ref('fact_lido_token_incentives') }}
         GROUP BY 1
@@ -35,16 +35,16 @@ with
     , staked_eth_metrics as (
         select
             date
-            , num_staked_eth
-            , amount_staked_usd
-            , num_staked_eth_net_change
-            , amount_staked_usd_net_change
+            , coalesce(num_staked_eth, 0) as num_staked_eth
+            , coalesce(amount_staked_usd, 0) as amount_staked_usd
+            , coalesce(num_staked_eth_net_change, 0) as num_staked_eth_net_change
+            , coalesce(amount_staked_usd_net_change, 0) as amount_staked_usd_net_change
         from {{ ref('fact_lido_staked_eth_count_with_USD_and_change') }}
     )
     , treasury_cte as (
         SELECT
             date
-            , sum(usd_balance) as treasury_value
+            , coalesce(sum(usd_balance), 0) as treasury_value
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         GROUP BY 1
@@ -52,7 +52,7 @@ with
     , treasury_native_cte as (
         SELECT
             date
-            , sum(native_balance) as treasury_native
+            , coalesce(sum(native_balance), 0) as treasury_native
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         where token = 'LDO'
@@ -61,88 +61,72 @@ with
     , net_treasury_cte as (
         SELECT
             date
-            , sum(usd_balance) as net_treasury_value
+            , coalesce(sum(usd_balance), 0) as net_treasury_value
         FROM {{ ref('fact_lido_dao_treasury') }}
         where token <> 'LDO'
         group by 1
     )
-    , price_data as (
+    , market_metrics as (
         {{ get_coingecko_metrics('lido-dao') }}
     )
     , tokenholder_cte as (
         SELECT
             date,
-            token_holder_count
+            coalesce(token_holder_count, 0) as token_holder_count
         FROM
             {{ ref('fact_ldo_tokenholder_count')}}
     )
 select
-    s.date
-    , 'lido' as app
-    , 'DeFi' as category
+    staked_eth_metrics.date
+    , 'lido' as artemis_id
     , 'ethereum' as chain
 
-    --Old metrics needed for compatibility
-    , COALESCE(f.primary_supply_side_revenue, 0) as primary_supply_side_revenue
-    , COALESCE(f.secondary_supply_side_revenue, 0) as secondary_supply_side_revenue
-    , COALESCE(f.total_supply_side_revenue, 0) as total_supply_side_revenue
-    , COALESCE(t.treasury_value, 0) as treasury_value
-    , COALESCE(tn.treasury_native, 0) as treasury_native
-    , COALESCE(nt.net_treasury_value, 0) as net_treasury_value
-    , COALESCE(s.amount_staked_usd, 0) as net_deposits
-    , COALESCE(s.num_staked_eth, 0) as outstanding_supply
-    , COALESCE(s.amount_staked_usd, 0) as amount_staked_usd
-    , COALESCE(s.num_staked_eth, 0) as num_staked_eth
-    , COALESCE(s.amount_staked_usd_net_change, 0) as amount_staked_usd_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as num_staked_eth_net_change
+    -- Standardized Metrics
 
-    --Standardized Metrics
+    -- Market Data
+    , market_metrics.price as price
+    , market_metrics.fdmc as fdmc
+    , market_metrics.market_cap as market_cap
+    , market_metrics.token_volume as token_volume
 
-    --Market Metrics
-    , COALESCE(p.price, 0) as price
-    , COALESCE(p.fdmc, 0) as fdmc
-    , COALESCE(p.market_cap, 0) as market_cap
-    , COALESCE(p.token_volume, 0) as token_volume
+    -- Usage Data
+    , staked_eth_metrics.amount_staked_usd as lst_tvl
+    , staked_eth_metrics.amount_staked_usd as tvl
+    , staked_eth_metrics.num_staked_eth as lst_tvl_native
+    , staked_eth_metrics.num_staked_eth as tvl_native
+    , staked_eth_metrics.amount_staked_usd_net_change as lst_tvl_net_change
+    , staked_eth_metrics.num_staked_eth_net_change as lst_tvl_native_net_change
+    , fees_revenue_expenses.yield_generated as yield_generated
 
-    --Usage Metrics
-    , COALESCE(s.amount_staked_usd, 0) as lst_tvl
-    , COALESCE(s.amount_staked_usd, 0) as tvl
-    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
-    , COALESCE(s.num_staked_eth, 0) as tvl_native
-    , COALESCE(s.amount_staked_usd_net_change, 0) as lst_tvl_net_change
-    , COALESCE(s.num_staked_eth_net_change, 0) as lst_tvl_native_net_change
-    , COALESCE(f.yield_generated, 0) as yield_generated
+    -- Fee Data
+    , fees_revenue_expenses.mev_priority_fees as mev_priority_fees
+    , fees_revenue_expenses.block_rewards as block_rewards
+    , fees_revenue_expenses.fees as fees
+    , fees_revenue_expenses.treasury_fee_allocation as treasury_fee_allocation
+    , fees_revenue_expenses.validator_fee_allocation as validator_fee_allocation
 
-    --Cash Flow Metrics
-    , COALESCE(f.mev_priority_fees, 0) as mev_priority_fees
-    , COALESCE(f.block_rewards, 0) as block_rewards
-    , COALESCE(f.fees, 0) as fees
+    -- Financial Statements
+    , fees_revenue_expenses.protocol_revenue as revenue
+    , token_incentives_cte.token_incentives as token_incentives
+    , token_incentives_cte.token_incentives as total_expenses
+    , fees_revenue_expenses.protocol_revenue - token_incentives_cte.token_incentives as earnings
 
-    , COALESCE(f.treasury_fee_allocation, 0) as treasury_fee_allocation
-    , COALESCE(f.validator_fee_allocation, 0) as validator_fee_allocation
+    --Treasury Data
+    , treasury_cte.treasury_value as treasury
+    , treasury_native_cte.treasury_native as own_token_treasury_native
+    , net_treasury_cte.net_treasury_value as net_treasury
 
-    -- Financial Statement Metrics
-    , COALESCE(f.protocol_revenue, 0) as revenue
-    , COALESCE(ti.token_incentives, 0) as token_incentives
-    , token_incentives as total_expenses
-    , revenue - total_expenses as earnings
-
-    --Treasury Metrics
-    , COALESCE(t.treasury_value, 0) as treasury
-    , COALESCE(tn.treasury_native, 0) as own_token_treasury_native
-    , COALESCE(nt.net_treasury_value, 0) as net_treasury
-
-    --Other Metrics
-    , COALESCE(p.token_turnover_fdv, 0) as token_turnover_fdv
-    , COALESCE(p.token_turnover_circulating, 0) as token_turnover_circulating
-    , COALESCE(th.token_holder_count, 0) as token_holder_count
+    -- Token Turnover/Other Data
+    , market_metrics.token_turnover_fdv as token_turnover_fdv
+    , market_metrics.token_turnover_circulating as token_turnover_circulating
+    , tokenholder_cte.token_holder_count as token_holder_count
     
-from staked_eth_metrics s
-left join fees_revenue_expenses f using(date)
-left join treasury_cte t using(date)
-left join treasury_native_cte tn using(date)
-left join net_treasury_cte nt using(date)
-left join token_incentives_cte ti using(date)
-left join price_data p using(date)
-left join tokenholder_cte th using(date)
-where s.date < to_date(sysdate())
+from staked_eth_metrics
+left join fees_revenue_expenses using(date)
+left join treasury_cte using(date)
+left join treasury_native_cte using(date)
+left join net_treasury_cte using(date)
+left join token_incentives_cte using(date)
+left join market_metrics using(date)
+left join tokenholder_cte using(date)
+where staked_eth_metrics.date < to_date(sysdate())

--- a/models/projects/lido/core/ez_lido_metrics_by_token.sql
+++ b/models/projects/lido/core/ez_lido_metrics_by_token.sql
@@ -13,28 +13,28 @@ WITH
         SELECT
             date
             , 'ETH' AS token
-            , block_rewards_native
-            , mev_priority_fees_native
-            , fees_native
+            , coalesce(block_rewards_native, 0) as block_rewards_native
+            , coalesce(mev_priority_fees_native, 0) as mev_priority_fees_native
+            , coalesce(fees_native, 0) as fees_native
         FROM {{ ref('fact_lido_fees_revs_expenses') }}
     )
     , revenues_expenses AS (
         SELECT
             date
             , 'stETH' AS token
-            , protocol_revenue_native
-            , primary_supply_side_revenue_native
-            , secondary_supply_side_revenue_native
-            , total_supply_side_revenue_native
-            , treasury_fee_allocation_native
-            , validator_fee_allocation_native
+            , coalesce(protocol_revenue_native, 0) as protocol_revenue_native
+            , coalesce(primary_supply_side_revenue_native, 0) as primary_supply_side_revenue_native
+            , coalesce(secondary_supply_side_revenue_native, 0) as secondary_supply_side_revenue_native
+            , coalesce(total_supply_side_revenue_native, 0) as total_supply_side_revenue_native
+            , coalesce(treasury_fee_allocation_native, 0) as treasury_fee_allocation_native
+            , coalesce(validator_fee_allocation_native, 0) as validator_fee_allocation_native
         FROM {{ ref('fact_lido_fees_revs_expenses') }}
     )
     , token_incentives_cte AS (
         SELECT
             date
             , token
-            , amount_native AS token_incentives_native
+            , coalesce(amount_native, 0) AS token_incentives_native
         FROM
             {{ ref('fact_lido_token_incentives') }}
     )
@@ -42,21 +42,21 @@ WITH
         SELECT
             date
             , 'ETH' AS token
-            , num_staked_eth
+            , coalesce(num_staked_eth, 0) as num_staked_eth
         FROM {{ ref('fact_lido_staked_eth_count_with_USD_and_change') }}
     )
     , steth_outstanding AS (
         SELECT
             date
             , 'stETH' AS token
-            , num_staked_eth AS outstanding_supply_native
+            , coalesce(num_staked_eth, 0) AS outstanding_supply_native
         FROM {{ ref('fact_lido_staked_eth_count_with_USD_and_change') }}
     )
     , treasury_cte AS (
         SELECT
             date
             , token
-            , SUM(native_balance) AS treasury_value_native
+            , coalesce(SUM(native_balance), 0) AS treasury_value_native
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         GROUP BY 1, 2
@@ -65,7 +65,7 @@ WITH
         SELECT
             date
             , token
-            , SUM(native_balance) AS treasury_native
+            , coalesce(SUM(native_balance), 0) AS treasury_native
         FROM
             {{ ref('fact_lido_dao_treasury') }}
         WHERE token = 'LDO'
@@ -75,54 +75,47 @@ WITH
         SELECT
             date
             , token
-            , SUM(native_balance) AS net_treasury_value_native
+            , coalesce(SUM(native_balance), 0) AS net_treasury_value_native
         FROM {{ ref('fact_lido_dao_treasury') }}
         WHERE token <> 'LDO'
         GROUP BY 1, 2
     )
 SELECT
     date
+    , 'lido' as artemis_id
     , token
 
-    --Old metrics needed for compatibility
-    , COALESCE(f.fees_native, 0) AS fees
-    , COALESCE(primary_supply_side_revenue_native, 0) AS primary_supply_side_revenue
-    , COALESCE(secondary_supply_side_revenue_native, 0) AS secondary_supply_side_revenue
-    , COALESCE(total_supply_side_revenue_native, 0) AS total_supply_side_revenue
-    , COALESCE(t.treasury_value_native, 0) AS treasury_value
-    , COALESCE(s.num_staked_eth, 0) AS net_deposits
-    , COALESCE(sto.outstanding_supply_native, 0) AS outstanding_supply
+    -- Standardized Metrics
 
-    --Standardized Metrics
+    -- Usage Data
+    , eth_deposited.num_staked_eth as lst_tvl_native
+    , eth_deposited.num_staked_eth as tvl_native
 
-    --Usage Metrics
-    , COALESCE(s.num_staked_eth, 0) as lst_tvl_native
-    , COALESCE(s.num_staked_eth, 0) as tvl_native
+    -- Fee Data
+    , fees.mev_priority_fees_native as mev_priority_fees_native
+    , fees.block_rewards_native as block_rewards_native
+    , fees.fees_native as yield_generated_native
+    , fees.fees_native as fees_native
+    , revenues_expenses.treasury_fee_allocation_native as treasury_fee_allocation_native
+    , revenues_expenses.validator_fee_allocation_native as validator_fee_allocation_native
 
-    --Cash Flow Metrics
-    , COALESCE(f.mev_priority_fees_native, 0) as mev_priority_fees_native
-    , COALESCE(f.block_rewards_native, 0) as block_rewards_native
-    , COALESCE(f.fees_native, 0) as yield_generated_native
-    , COALESCE(f.fees_native, 0) as fees_native
-    , COALESCE(e.treasury_fee_allocation_native, 0) as treasury_fee_allocation_native
-    , COALESCE(e.validator_fee_allocation_native, 0) as validator_fee_allocation_native
-
-    -- Financial Statement Metrics
-    , COALESCE(e.protocol_revenue_native, 0) as revenue_native
-    , COALESCE(ti.token_incentives_native, 0) as token_incentives_native
-    , COALESCE(ti.token_incentives_native, 0) as total_expenses_native
-    , COALESCE(e.protocol_revenue_native, 0) - COALESCE(ti.token_incentives_native, 0) as earnings_native
+    -- Financial Statements
+    , revenues_expenses.protocol_revenue_native as revenue_native
+    , token_incentives_cte.token_incentives_native as token_incentives_native
+    , token_incentives_cte.token_incentives_native as total_expenses_native
+    , revenues_expenses.protocol_revenue_native - token_incentives_cte.token_incentives_native as earnings_native
 
     --Treasury Metrics
-    , COALESCE(t.treasury_value_native, 0) as treasury_native
-    , COALESCE(tn.treasury_native, 0) as own_token_treasury_native
-    , COALESCE(nt.net_treasury_value_native, 0) as net_treasury_native
-FROM fees f
-FULL JOIN revenues_expenses e USING (date, token)
-FULL JOIN treasury_cte t USING(date, token)
-FULL JOIN treasury_native_cte tn USING(date, token)
-FULL JOIN net_treasury_cte nt USING(date, token)
-FULL JOIN token_incentives_cte ti USING(date, token)
-LEFT JOIN steth_outstanding sto USING(date, token)
-LEFT JOIN eth_deposited s USING(date, token)
+    , treasury_cte.treasury_value_native as treasury_native
+    , net_treasury_cte.net_treasury_value_native as net_treasury_native
+    , treasury_native_cte.treasury_native as own_token_treasury_native
+
+FROM fees
+FULL JOIN revenues_expenses USING (date, token)
+FULL JOIN treasury_cte USING(date, token)
+FULL JOIN treasury_native_cte USING(date, token)
+FULL JOIN net_treasury_cte USING(date, token)
+FULL JOIN token_incentives_cte USING(date, token)
+LEFT JOIN steth_outstanding USING(date, token)
+LEFT JOIN eth_deposited USING(date, token)
 WHERE date < to_date(sysdate())


### PR DESCRIPTION
## Context
[ Write 1-3 sentences describing what you did and why here ]

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="852" height="306" alt="image" src="https://github.com/user-attachments/assets/fa3ca02e-a82c-4d29-af8d-b7dad0669357" />

<img width="1166" height="333" alt="image" src="https://github.com/user-attachments/assets/c8f97510-12f8-4ef4-bde4-248aba7d737c" />

- [x] Successful RETL screenshot
<img width="1155" height="318" alt="image" src="https://github.com/user-attachments/assets/6283897d-0c14-4cbb-b276-22af377cf1f6" />

- [x] Ran make generate schema for changed assets
<img width="1166" height="414" alt="image" src="https://github.com/user-attachments/assets/186428dd-cf46-4522-ac2b-8e956d8b9168" />

- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
This is part of BDR Final Deprecation Plan - Lido

Tests
Backend PR - https://github.com/Artemis-xyz/gokustats-back-end/pull/4096
<img width="1056" height="363" alt="image" src="https://github.com/user-attachments/assets/dd59ce54-8dc8-4337-b69e-6f5a31b25263" />