### PR TITLE
Add asset detail to bridge flows

### DIFF
--- a/models/metrics/bridges/agg_daily_bridge_flows_metrics.sql
+++ b/models/metrics/bridges/agg_daily_bridge_flows_metrics.sql
@@ -1,4 +1,4 @@
 {{ config(materialized="table") }}
 select
-    date, source_chain, destination_chain, app, coalesce(category, 'Not Categorized') as category, amount_usd, fee_usd, unique_id
+    date, source_chain, destination_chain, app, coalesce(category, 'Not Categorized') as category, symbol, amount_usd, fee_usd, unique_id
 from {{ ref("agg_daily_bridge_flows_metrics_silver") }}

--- a/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
+++ b/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
@@ -94,6 +94,7 @@ select
     category,
     lower(symbol) as symbol,
     amount_usd,
+    fee_usd,
     date::string
     || '-'
     || app

--- a/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
+++ b/models/metrics/bridges/agg_daily_bridge_flows_metrics_silver.sql
@@ -36,6 +36,7 @@ with
             'injective' AS source_chain,
             'cosmos_ecosystem' AS destination_chain,
             category,
+            null as symbol, -- don't have symbol upstream
             SUM(amount_usd) AS amount_usd,
             NULL AS fee_usd
         FROM {{ ref("fact_injective_bridge_flows") }}
@@ -54,6 +55,7 @@ with
             'cosmos_ecosystem' AS source_chain,
             'injective' AS destination_chain,
             category,
+            null as symbol, -- don't have symbol upstream
             SUM(amount_usd) AS amount_usd,
             NULL AS fee_usd
         FROM {{ ref("fact_injective_bridge_flows") }}
@@ -72,6 +74,7 @@ with
             source_chain,
             destination_chain,
             category,
+            null as symbol, -- don't have symbol upstream
             amount_usd,
             NULL AS fee_usd
         FROM {{ ref("fact_injective_bridge_flows") }}
@@ -84,7 +87,13 @@ with
         SELECT * FROM cosmos_ecosystem
     )
 select
-    *,
+    date,
+    app,
+    source_chain,
+    destination_chain,
+    category,
+    lower(symbol) as symbol,
+    amount_usd,
     date::string
     || '-'
     || app

--- a/models/staging/across/fact_across_flows.sql
+++ b/models/staging/across/fact_across_flows.sql
@@ -11,9 +11,10 @@ select
     source_chain,
     destination_chain,
     coalesce(destination_category, 'Not Categorized') as category,
+    coalesce(source_token_symbol, destination_token_symbol) as symbol,
     sum(amount_usd) as amount_usd,
     null as fee_usd
 from
     {{ ref("fact_across_transfers_with_price") }}
 WHERE amount_usd < 100000000 and amount_usd is not null
-group by date, source_chain, destination_chain, category
+group by date, source_chain, destination_chain, category, symbol

--- a/models/staging/across/fact_across_transfers.sql
+++ b/models/staging/across/fact_across_transfers.sql
@@ -21,7 +21,8 @@ select
     relayer_fee_pct,
     null as destination_token_symbol,
     null as input_amount,
-    null as input_token
+    null as input_token,
+    null as input_symbol
 from {{ ref("fact_across_v1_transfers") }}
 where origin_chain_id != 1919191  -- a bug
 union all
@@ -42,5 +43,6 @@ SELECT
     , dst_symbol as destination_token_symbol
     , amount_sent_native as input_amount
     , origin_token as input_token
+    , src_symbol as input_symbol
 from {{ref('fact_across_complete_transfers')}}
 where coalesce(src_block_timestamp, dst_block_timestamp) is not null

--- a/models/staging/across/fact_across_transfers_with_price.sql
+++ b/models/staging/across/fact_across_transfers_with_price.sql
@@ -27,6 +27,8 @@ with
             destination_token,
             origin_chain_id,
             destination_token_symbol,
+            input_token,
+            input_symbol,
             t2.chain as destination_chain, 
             t3.chain as source_chain, 
             null as destination_category
@@ -63,6 +65,8 @@ with
         destination_token_symbol,
         destination_chain, 
         source_chain, 
+        input_token as source_token,
+        input_symbol as source_token_symbol,
         case
             when contains(lower(destination_token_symbol), 'usd') then 'Stablecoin'
             when contains(lower(destination_token_symbol), 'eth') then 'Token'

--- a/models/staging/arbitrum/fact_arbitrum_one_bridge_flows.sql
+++ b/models/staging/arbitrum/fact_arbitrum_one_bridge_flows.sql
@@ -38,6 +38,7 @@ with
             source_chain,
             destination_chain,
             coalesce(c.category, 'Not Categorized') as category,
+            p.symbol,
             coalesce(amount::bigint / power(10, p.decimals) * price, 0) as amount_usd
         from {{ ref("fact_arbitrum_one_bridge_transfers") }} t
         left join
@@ -54,7 +55,8 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount_usd) as amount_usd,
     null as fee_usd
 from hourly_volume
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6

--- a/models/staging/avalanche/fact_avalanche_bridge_flows.sql
+++ b/models/staging/avalanche/fact_avalanche_bridge_flows.sql
@@ -23,6 +23,7 @@ with
             destination_chain,
             coalesce(c.category, 'Not Categorized') as category,
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd,
+            p.symbol,
             coalesce((fee / power(10, p.decimals)) * price, 0) as fee_usd
         from {{ ref("fact_avalanche_bridge_transfers") }} t
         left join
@@ -38,7 +39,8 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount_usd) as amount_usd,
     sum(fee_usd) as fee_usd
 from hourly_volume
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6

--- a/models/staging/base/fact_base_bridge_flows.sql
+++ b/models/staging/base/fact_base_bridge_flows.sql
@@ -13,6 +13,7 @@ with
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
             , amount_usd
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
         from {{ ref("fact_base_bridge_transfers") }} t
     )
 
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/debridge/fact_debridge_flows.sql
+++ b/models/staging/debridge/fact_debridge_flows.sql
@@ -7,8 +7,9 @@ select
     source_chain,
     destination_chain,
     category,
+    coalesce(source_token_symbol, destination_token_symbol) as symbol,
     sum(coalesce(amount_sent, amount_received, 0)) as amount_usd,
     sum(coalesce(percentage_fee,0) + coalesce(fix_fee,0)) as fee_usd
 from {{ ref("fact_debridge_transfers_with_prices") }}
 where source_chain is not null and destination_chain is not null
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6

--- a/models/staging/ink/fact_ink_bridge_flows.sql
+++ b/models/staging/ink/fact_ink_bridge_flows.sql
@@ -12,6 +12,7 @@ with
             , source_chain
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
             , amount_usd
         from {{ ref("fact_ink_bridge_transfers") }} t
     )
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/optimism/fact_optimism_bridge_flows.sql
+++ b/models/staging/optimism/fact_optimism_bridge_flows.sql
@@ -12,6 +12,7 @@ with
             , source_chain
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
             , amount_usd
         from {{ ref("fact_optimism_bridge_transfers") }} t
     )
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/polygon/fact_polygon_pos_bridge_flows.sql
+++ b/models/staging/polygon/fact_polygon_pos_bridge_flows.sql
@@ -43,8 +43,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount_usd) as amount_usd,
     null as fee_usd
 from filtered_volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/rainbow_bridge/fact_rainbow_bridge_flows.sql
+++ b/models/staging/rainbow_bridge/fact_rainbow_bridge_flows.sql
@@ -14,7 +14,8 @@ with
             source_chain,
             destination_chain,
             coalesce(c.category, 'Not Categorized') as category,
-            coalesce(amount_usd, 0) as usd_amount
+            coalesce(amount_usd, 0) as usd_amount,
+            symbol
         from {{ ref("fact_rainbow_bridge_transfers") }} t
         left join dim_contracts c on lower(t.token_address) = lower(c.address) and c.chain = 'ethereum' --only using l1token
     )
@@ -25,8 +26,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(usd_amount) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 having amount_usd is not null

--- a/models/staging/rainbow_bridge/fact_rainbow_bridge_transfers.sql
+++ b/models/staging/rainbow_bridge/fact_rainbow_bridge_transfers.sql
@@ -17,6 +17,7 @@ with rainbow_bridge_transfers as (
         , amount
         , amount_usd
         , ez_bridge_activity_id
+        , symbol
     from near_flipside.defi.ez_bridge_activity 
     where platform = 'rainbow' and RECEIPT_SUCCEEDED
         and tx_hash not in ('qrJ4Hwh4xiPHnfWQC7PeXEinspBu1SkJvz3qbPRaGT8', 'DA4UvCkTrJ5py6H7M5RMj4RgdG8r9LNReVQKtWtsYvDy')
@@ -34,5 +35,6 @@ select
     token_address,
     amount,
     amount_usd,
-    ez_bridge_activity_id
+    ez_bridge_activity_id,
+    symbol
 from rainbow_bridge_transfers

--- a/models/staging/soneium/fact_soneium_bridge_flows.sql
+++ b/models/staging/soneium/fact_soneium_bridge_flows.sql
@@ -12,6 +12,7 @@ with
             , source_chain
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
             , amount_usd
         from {{ ref("fact_soneium_bridge_transfers") }} t
     )
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/sonic/fact_sonic_bridge_flows.sql
+++ b/models/staging/sonic/fact_sonic_bridge_flows.sql
@@ -12,6 +12,7 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount) as amount_usd,
     null as fee_usd
 from {{ ref("fact_sonic_bridge_transfers") }} t
@@ -21,5 +22,5 @@ where date >= (
     from {{ this }}
 )
 {% endif %}
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/stargate/fact_stargate_flows.sql
+++ b/models/staging/stargate/fact_stargate_flows.sql
@@ -16,6 +16,7 @@ with
             , t2.category as category
             , amount_sent
             , fees
+            , coalesce(t.src_symbol, t.dst_symbol) as symbol
         from {{ref("fact_stargate_v2_transfers")}} t
         left join dim_contracts t2 on lower(t.src_token_address) = lower(t2.address) and src_chain = t2.chain
     )
@@ -25,10 +26,11 @@ select
     , src_chain as source_chain
     , dst_chain as destination_chain
     , category
+    , symbol
     , sum(amount_sent) as amount_usd
     , sum(fees) as fee_usd
 from transfers_data
 where src_block_timestamp::date < to_date(sysdate())
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 
 

--- a/models/staging/starknet/fact_starknet_bridge_flows.sql
+++ b/models/staging/starknet/fact_starknet_bridge_flows.sql
@@ -11,6 +11,7 @@ with
             source_chain,
             destination_chain,
             coalesce(c.category, 'Not Categorized') as category,
+            p.symbol,
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_starknet_bridge_transfers") }} t
         left join
@@ -26,8 +27,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(coalesce(amount_usd, 0)) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/synapse/fact_synapse_flows.sql
+++ b/models/staging/synapse/fact_synapse_flows.sql
@@ -236,7 +236,8 @@ with
                 when destination_value is null
                 then origin_value
                 else (origin_value + destination_value) / 2
-            end as usd_value
+            end as usd_value,
+            coalesce(t1.origin_token_symbol, t1.destination_token_symbol) as symbol
         from synapse_transfers t1
         left join destination_values t2 using (synapse_tx_hash)
         left join origin_values t3 using (synapse_tx_hash)
@@ -293,7 +294,8 @@ with
             t2.chain as source_chain,
             t3.chain as destination_chain,
             coalesce(t4.category, 'Not Categorized') as category,
-            final_usd_value as amount_usd
+            final_usd_value as amount_usd,
+            symbol
         from final_combined t1
         left join {{ ref("dim_chain_ids")}} t2 on t1.origin_chain_id = t2.id
         left join {{ ref("dim_chain_ids")}} t3 on t1.destination_chain_id = t3.id
@@ -308,8 +310,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount_usd) as amount_usd,
     null as fee_usd
 from flows_by_chain_id
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date desc, source_chain asc

--- a/models/staging/unichain/fact_unichain_bridge_flows.sql
+++ b/models/staging/unichain/fact_unichain_bridge_flows.sql
@@ -12,6 +12,7 @@ with
             , source_chain
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
             , amount_usd
         from {{ ref("fact_unichain_bridge_transfers") }} t
     )
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/usdt0/fact_usdt0_flows.sql
+++ b/models/staging/usdt0/fact_usdt0_flows.sql
@@ -7,8 +7,9 @@ select
     , src_chain as source_chain
     , dst_chain as destination_chain
     , 'Stablecoin' as category
+    , 'usdt' as symbol
     , sum(amount_sent) as amount_usd
     , 0 as fee_usd
 from {{ref("fact_usdt0_transfers")}}
 where src_block_timestamp::date < to_date(sysdate())
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6

--- a/models/staging/worldchain/fact_worldchain_bridge_flows.sql
+++ b/models/staging/worldchain/fact_worldchain_bridge_flows.sql
@@ -12,6 +12,7 @@ with
             , source_chain
             , destination_chain
             , case when contains(coalesce(lower(t.source_token_symbol), lower(t.destination_token_symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
+            , coalesce(t.source_token_symbol, t.destination_token_symbol) as symbol
             , amount_usd
         from {{ ref("fact_worldchain_bridge_transfers") }} t
     )
@@ -22,8 +23,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     coalesce(sum(amount_usd), 0) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc

--- a/models/staging/wormhole/fact_wormhole_flows.sql
+++ b/models/staging/wormhole/fact_wormhole_flows.sql
@@ -7,8 +7,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount) as amount_usd,
     null as fee_usd
 from {{ ref("fact_wormhole_operations_with_price") }}
 where source_chain is not null and destination_chain is not null and amount is not null
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6

--- a/models/staging/wormhole/fact_wormhole_operations_with_price.sql
+++ b/models/staging/wormhole/fact_wormhole_operations_with_price.sql
@@ -111,6 +111,7 @@ select
     , extraction_date
     , case when contains(coalesce(lower(prices.symbol), lower(ops.symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
     , concat(coalesce(ops.id, 'null'), '|' , 'wormhole') as unique_id
+    , coalesce(prices.symbol, ops.symbol) as symbol
 from {{ref('fact_wormhole_operations')}} as ops
 left join chain_ids as f_chain on f_chain.wormhole_chain_id = ops.from_chain
 left join chain_ids as t_chain on t_chain.wormhole_chain_id = ops.to_chain

--- a/models/staging/wormhole/fact_wormhole_operations_with_price.sql
+++ b/models/staging/wormhole/fact_wormhole_operations_with_price.sql
@@ -111,7 +111,6 @@ select
     , extraction_date
     , case when contains(coalesce(lower(prices.symbol), lower(ops.symbol)), 'usd') then 'Stablecoin' else 'Token' end as category
     , concat(coalesce(ops.id, 'null'), '|' , 'wormhole') as unique_id
-    , coalesce(prices.symbol, ops.symbol) as symbol
 from {{ref('fact_wormhole_operations')}} as ops
 left join chain_ids as f_chain on f_chain.wormhole_chain_id = ops.from_chain
 left join chain_ids as t_chain on t_chain.wormhole_chain_id = ops.to_chain

--- a/models/staging/zksync/fact_zksync_era_bridge_flows.sql
+++ b/models/staging/zksync/fact_zksync_era_bridge_flows.sql
@@ -10,6 +10,7 @@ with
             source_chain,
             destination_chain,
             coalesce(c.category, 'Not Categorized') as category,
+            p.symbol,
             coalesce((amount / power(10, p.decimals)) * price, 0) as amount_usd
         from {{ ref("fact_zksync_era_bridge_transfers") }} t
         left join
@@ -25,8 +26,9 @@ select
     source_chain,
     destination_chain,
     category,
+    symbol,
     sum(amount_usd) as amount_usd,
     null as fee_usd
 from volume_and_fees_by_chain_and_symbol
-group by 1, 2, 3, 4, 5
+group by 1, 2, 3, 4, 5, 6
 order by date asc, source_chain asc


### PR DESCRIPTION
## Context
Adding asset details to bridge flows models. Some upstream models only have source or destination token, not both, so I was unable to add both source and destination token for all bridges. Since most source and destination tokens are the same it shouldn't be an issue. In instances where both source and destination are present, I am defaulting to using the source token symbol if present and destination token symbol if the source token symbol is not present. 

- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)
<img width="924" height="794" alt="Screenshot 2025-07-29 at 2 28 06 PM" src="https://github.com/user-attachments/assets/3434cab5-51bf-4159-af56-78b97424a4ee" />

<img width="797" height="231" alt="Screenshot 2025-07-29 at 2 41 44 PM" src="https://github.com/user-attachments/assets/bb71f5cc-68f1-4a1c-8a70-6555895dadba" />

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)

- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
