### PR TITLE
add ts cols to tables that were missing it

### DIFF
--- a/models/projects/ach/core/ez_ach_metrics.sql
+++ b/models/projects/ach/core/ez_ach_metrics.sql
@@ -1,10 +1,16 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         snowflake_warehouse="ACH",
         database="ach",
         schema="core",
         alias="ez_metrics",
+        incremental_strategy="merge",
+        unique_key="date",
+        on_schema_change="append_new_columns",
+        merge_update_columns=var("backfill_columns", []),
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
+        full_refresh=var("full_refresh", false),
     )
 }}
 
@@ -129,5 +135,11 @@ combined_result as (
 select 
     date, 
     transfer_volume 
+
+    -- Timetamp Columns
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
 from combined_result
+WHERE TRUE
+{{ ez_metrics_incremental('date', backfill_date) }}
 order by date

--- a/models/projects/aftermath/core/ez_aftermath_metrics.sql
+++ b/models/projects/aftermath/core/ez_aftermath_metrics.sql
@@ -1,10 +1,16 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         snowflake_warehouse="AFTERMATH",
         database="aftermath",
         schema="core",
         alias="ez_metrics",
+        incremental_strategy="merge",
+        unique_key="date",
+        on_schema_change="append_new_columns",
+        merge_update_columns=var("backfill_columns", []),
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
+        full_refresh=false,
     )
 }}
 
@@ -62,8 +68,13 @@ select
     , COALESCE(tvl.tvl, 0) AS tvl
     , COALESCE(tvl.tvl, 0) - COALESCE(LAG(tvl.tvl) OVER (ORDER BY date), 0) AS tvl_net_change
 
+    -- Timetamp Columns
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
 FROM date_spine
 LEFT JOIN spot_trading_volume USING(date)
 LEFT JOIN spot_dau_txns USING(date)
 LEFT JOIN spot_fees_revenue USING(date)
 LEFT JOIN tvl USING(date)
+WHERE TRUE
+{{ ez_metrics_incremental('date', backfill_date) }}

--- a/models/projects/bitpay/core/ez_bitpay_metrics.sql
+++ b/models/projects/bitpay/core/ez_bitpay_metrics.sql
@@ -1,15 +1,27 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         snowflake_warehouse="BITPAY",
         database="bitpay",
         schema="core",
         alias="ez_metrics",
+        incremental_strategy="merge",
+        unique_key="date",
+        on_schema_change="append_new_columns",
+        merge_update_columns=var("backfill_columns", []),
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
+        full_refresh=var("full_refresh", false),
     )
 }}
 
 select
     date::date as date,
     sum(transfer_volume) as transfer_volume
+
+    -- Timetamp Columns
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
 from {{ ref("fact_bitpay_transfers") }}
+WHERE TRUE
+{{ ez_metrics_incremental('date', backfill_date) }}
 group by 1

--- a/models/projects/braintrust/ez_braintrust_metrics.sql
+++ b/models/projects/braintrust/ez_braintrust_metrics.sql
@@ -1,10 +1,16 @@
 {{
     config(
-        materialized="table",
+        materialized="incremental",
         snowflake_warehouse="BRAINTRUST",
         database="braintrust",
         schema="core",
         alias="ez_metrics",
+        incremental_strategy="merge",
+        unique_key="date",
+        on_schema_change="append_new_columns",
+        merge_update_columns=var("backfill_columns", []),
+        merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
+        full_refresh=var("full_refresh", false),
     )
 }}
 
@@ -24,12 +30,23 @@ with revenue as (
 )
 SELECT
     date_spine.date,
+
+    -- Standardized Metrics
+    -- Market Data
     market_metrics.price,
     market_metrics.market_cap,
     market_metrics.fdmc,
     market_metrics.token_turnover_circulating,
     market_metrics.token_turnover_fdv,
+
+    -- Financial Metrics
     coalesce(revenue.revenue, 0) as revenue
+
+    -- Timetamp Columns
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
 FROM date_spine
 LEFT JOIN revenue USING(date)
 LEFT JOIN market_metrics USING(date)
+WHERE TRUE
+{{ ez_metrics_incremental('date_spine.date', backfill_date) }}


### PR DESCRIPTION
## Context
Added timestamp columns to assets that were missing them.

- [x] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [ ] `dbt build model_name+` screenshot (must include downstream models)
<img width="1062" height="259" alt="CleanShot 2025-07-29 at 18 36 50" src="https://github.com/user-attachments/assets/b99e8d1d-38d9-4775-8f47-bf437e4c6ab3" />

- [ ] Successful RETL screenshot
<img width="961" height="116" alt="CleanShot 2025-07-29 at 18 37 19" src="https://github.com/user-attachments/assets/44e47e49-b589-4b9c-b5d4-084eec01b2dd" />

- [ ] Ran make generate schema for changed assets
N/A
- [ ] Screenshots of changed data **in local frontend**
N/A

Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other

ACH Before:
<img width="1920" height="800" alt="CleanShot 2025-07-29 at 17 09 16@2x" src="https://github.com/user-attachments/assets/30e85fd5-e834-4bed-afef-0996c95ecfec" />

ACH After 2 back-to-back runs:
<img width="1928" height="982" alt="CleanShot 2025-07-29 at 17 12 15@2x" src="https://github.com/user-attachments/assets/03d1ff25-4ee0-4ade-a637-e137cd06ff0b" />

Aftermath Before (seems to be stale to June 10th) (akhil looking into staleness)
<img width="2406" height="954" alt="CleanShot 2025-07-29 at 17 12 59@2x" src="https://github.com/user-attachments/assets/4be5ccf9-5df8-4985-b556-0c85af6c008b" />

Aftermath after 2 back-to-back runs - data is as expected (although stale):
<img width="2230" height="962" alt="CleanShot 2025-07-29 at 17 19 19@2x" src="https://github.com/user-attachments/assets/a020bd18-ff88-4c9f-a97b-c09d5808da64" />

Bitpay Before
<img width="1970" height="978" alt="CleanShot 2025-07-29 at 17 20 12@2x" src="https://github.com/user-attachments/assets/898eb1a2-ac4d-4e28-81e1-4ed6ee9a7909" />

Bitpay After 2 back-to-back runs
<img width="1932" height="812" alt="CleanShot 2025-07-29 at 17 22 50@2x" src="https://github.com/user-attachments/assets/7754a0be-f6f1-4898-af0f-d5a33a71bbb9" />

Braintrust Before
<img width="1908" height="708" alt="CleanShot 2025-07-29 at 17 23 52@2x" src="https://github.com/user-attachments/assets/54c0a008-c04e-44e9-9ef7-3ffeeebd7f32" />

Braintrust After (refreshed upstream tables too)
<img width="1976" height="914" alt="CleanShot 2025-07-29 at 18 35 00@2x" src="https://github.com/user-attachments/assets/8f5758a5-2488-4c5a-b51d-95378cc1192c" />
