### PR TITLE
Akhil/Algorand Legacy Replication Deprecation

### DIFF
--- a/models/projects/algorand/core/__algorand__schema.yml
+++ b/models/projects/algorand/core/__algorand__schema.yml
@@ -56,6 +56,18 @@ column_definitions:
     tags:
       - artemis_gaap
 
+  token_turnover_circulating: &token_turnover_circulating
+    name: token_turnover_circulating
+    description: "The turnover of a token in USD, based on the token's circulating supply."
+    tags:
+      - artemis_gaap
+
+  token_turnover_fdv: &token_turnover_fdv
+    name: token_turnover_fdv
+    description: "The turnover of a token in USD, based on the token's fully diluted supply."
+    tags:
+      - artemis_gaap
+
   token_volume: &token_volume
     name: token_volume
     description: "The volume of a token in USD"
@@ -97,5 +109,7 @@ models:
       - *market_cap
       - *price
       - *revenue
+      - *token_turnover_circulating
+      - *token_turnover_fdv
       - *token_volume
       - *validator_fee_allocation

--- a/models/projects/algorand/core/ez_algorand_metrics.sql
+++ b/models/projects/algorand/core/ez_algorand_metrics.sql
@@ -18,16 +18,13 @@
 {% set backfill_date = var("backfill_date", None) %}
 
 WITH
-    -- Alternative fundamental source from BigQuery, preferred when possible over Snowflake data
-    fundamental_data AS (
-        SELECT * EXCLUDE date, TO_TIMESTAMP_NTZ(date) AS date 
-        FROM {{ source('PROD_LANDING', 'ez_algorand_metrics') }}
-    )
-    , date_spine AS (
+    date_spine AS (
         SELECT date
         FROM {{ ref('dim_date_spine') }}
         WHERE date >= '2019-06-01' AND date < TO_DATE(SYSDATE())
     )
+    -- Alternative fundamental source from BigQuery, preferred when possible over Snowflake data
+    , fundamental_data AS (SELECT * FROM {{ ref('fact_algorand_fundamental_data') }})
     , cumulative_burns AS (
         WITH revenue AS (
             SELECT

--- a/models/staging/algorand/__algorand_sources.yml
+++ b/models/staging/algorand/__algorand_sources.yml
@@ -3,7 +3,10 @@ sources:
     schema: PROD_LANDING
     database: LANDING_DATABASE
     tables:
-      - name: ez_algorand_metrics
+      - name: raw_algorand_ez_algorand_metrics_parquet
+        meta:
+          dagster:
+            asset_key: ["PROD_LANDING", "bulk_load_ez_algorand_metrics"]
       - name: raw_algorand_fact_algorand_foundation_address_flow_parquet
         meta:
           dagster:

--- a/models/staging/algorand/fact_algorand_fundamental_data.sql
+++ b/models/staging/algorand/fact_algorand_fundamental_data.sql
@@ -1,0 +1,20 @@
+{{config(
+    materialized = 'table',
+    snowflake_warehouse = 'ALGORAND'
+)}}
+
+SELECT
+    parquet_raw:date::date AS date
+    , parquet_raw:dau::int AS dau
+    , parquet_raw:fees_native::float AS fees_native
+    , parquet_raw:new_eoas::int AS new_eoas
+    , parquet_raw:rewards_algo::float AS rewards_algo
+    , parquet_raw:txns::int AS txns
+    , parquet_raw:unique_eoa_pairs::int AS unique_eoa_pairs
+    , parquet_raw:unique_eoas::int AS unique_eoas
+    , parquet_raw:unique_pairs::int AS unique_pairs
+    , parquet_raw:unique_receivers::int AS unique_receivers
+    , parquet_raw:unique_senders::int AS unique_senders
+    , parquet_raw:unique_tokens::int AS unique_tokens
+FROM {{ source('PROD_LANDING', 'raw_algorand_ez_algorand_metrics_parquet') }}
+QUALIFY ROW_NUMBER() OVER (PARTITION BY date ORDER BY parquet_raw:date::date DESC) = 1


### PR DESCRIPTION
## Context
Added raw_algorand_ez_algorand_metrics_parquet as a source, created a fact table from the parquet file, and updated the EZ table to pull from this new fact table

This PR: 
- Replaces the old `ez_algorand_metrics` source that comes directly from the backend with `raw_algorand_ez_algorand_metrics_parquet` that comes from the Chakra replication
- To make the flow easier, I created a fact table that first takes the parquet file as a source and converts it into a regular table called `fact_algorand_fundamental_data.sql`
- The EZ table calls from this table now

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [X] `dbt build model_name+` screenshot (must include downstream models)
<img width="1512" height="222" alt="Screenshot 2025-07-30 at 2 00 50 PM" src="https://github.com/user-attachments/assets/8e3ab3d1-8667-415c-b902-7eb84f473067" />
<img width="1512" height="222" alt="Screenshot 2025-07-30 at 2 00 57 PM" src="https://github.com/user-attachments/assets/e57341fe-0580-4b48-9a46-5df95311748a" />

- [X] Successful RETL screenshot
<img width="1512" height="222" alt="Screenshot 2025-07-30 at 2 03 13 PM" src="https://github.com/user-attachments/assets/f655ce64-a05d-45af-843e-62abf459ddd7" />

- [X] Ran make generate schema for changed assets
- [] Screenshots of changed data **in local frontend**
There aren't any changes in the data per se, but the data in our local frontend after these changes matches the data in our frontend. There were too many screenshots to add to this PR, but can be done if needed. 


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
