### PR TITLE
add date where clauses

### DIFF
--- a/models/projects/braintrust/ez_braintrust_metrics.sql
+++ b/models/projects/braintrust/ez_braintrust_metrics.sql
@@ -50,3 +50,4 @@ LEFT JOIN revenue USING(date)
 LEFT JOIN market_metrics USING(date)
 WHERE TRUE
 {{ ez_metrics_incremental('date_spine.date', backfill_date) }}
+AND date_spine.date < to_date(sysdate())

--- a/models/projects/mento/core/ez_mento_metrics.sql
+++ b/models/projects/mento/core/ez_mento_metrics.sql
@@ -54,6 +54,10 @@ select
     , p2p_stablecoin_daily_txns
     , artemis_stablecoin_transfer_volume
     , artemis_stablecoin_daily_txns
+
+    -- Timetamp Columns
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as created_on
+    , TO_TIMESTAMP_NTZ(CURRENT_TIMESTAMP()) as modified_on
 from stablecoin_metrics
 left join spot_volume_spot_txn_spot_dau using (date)
 where true

--- a/models/projects/pendle/core/ez_pendle_metrics_by_chain.sql
+++ b/models/projects/pendle/core/ez_pendle_metrics_by_chain.sql
@@ -94,3 +94,5 @@ LEFT JOIN yield_fees yf USING (date, chain)
 LEFT JOIN daus_txns d USING (date, chain)
 LEFT JOIN token_incentives_cte ti USING (date, chain)
 LEFT JOIN tvl t USING (date, chain)
+WHERE TRUE
+    AND f.date < to_date(sysdate())

--- a/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
+++ b/models/projects/polygon_zk/core/ez_polygon_zk_metrics.sql
@@ -11,7 +11,7 @@
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
         merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
-        full_refresh=false,
+        full_refresh=var("full_refresh", false),
         tags=["ez_metrics"]
     )
 }}
@@ -34,7 +34,7 @@ with
     ),
     github_data as ({{ get_github_metrics("Polygon Hermez") }}),
     polygon_zk_dex_volumes as (
-        select date, daily_volume as dex_volumes
+        select date, DAILY_VOLUME_ADJUSTED_WITH_NULLS as dex_volumes
         from {{ ref("fact_polygon_zk_daily_dex_volumes") }}
     )
 select

--- a/models/projects/polymarket/core/ez_polymarket_metrics.sql
+++ b/models/projects/polymarket/core/ez_polymarket_metrics.sql
@@ -10,7 +10,7 @@
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
         merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
-        full_refresh=false,
+        full_refresh=var("full_refresh", false),
         tags=["ez_metrics"]
     )
 }}

--- a/models/projects/render/core/ez_render_metrics.sql
+++ b/models/projects/render/core/ez_render_metrics.sql
@@ -10,7 +10,7 @@
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
         merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
-        full_refresh=false,
+        full_refresh=var("full_refresh", false),
         tags=["ez_metrics"]
     )
 }}

--- a/models/projects/vertex/core/ez_vertex_metrics.sql
+++ b/models/projects/vertex/core/ez_vertex_metrics.sql
@@ -10,7 +10,7 @@
         tags=["ez_metrics"],
         backfill_date=var("backfill_date", None),
         backfill_columns=var("backfill_columns", []),
-        full_refresh=false,
+        full_refresh=var("full_refresh", false),
         incremental_strategy="merge",
         unique_key="date",
         on_schema_change="append_new_columns",

--- a/models/projects/zcash/core/ez_zcash_metrics.sql
+++ b/models/projects/zcash/core/ez_zcash_metrics.sql
@@ -11,7 +11,7 @@
         on_schema_change="append_new_columns",
         merge_update_columns=var("backfill_columns", []),
         merge_exclude_columns=["created_on"] if not var("backfill_columns", []) else none,
-        full_refresh=false,
+        full_refresh=var("full_refresh", false),
         tags=["ez_metrics"]
     )
 }}


### PR DESCRIPTION
## Context
Added `where date < to_date(sysdate())` to a few models that were missing it. This causes issues with the new incremental models.

- [x] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [x] `dbt build model_name+` screenshot (must include downstream models)
<img width="2230" height="506" alt="CleanShot 2025-07-30 at 16 08 19@2x" src="https://github.com/user-attachments/assets/d69277d9-686c-45a5-b0bb-4c31bb775c29" />

- [x] Successful RETL screenshot
**ach**
<img width="1300" height="228" alt="CleanShot 2025-07-30 at 17 43 36@2x" src="https://github.com/user-attachments/assets/4bc31af8-7760-43d5-878c-0ccc5e0ed981" />

**braintrust**
<img width="2024" height="328" alt="CleanShot 2025-07-30 at 16 11 16@2x" src="https://github.com/user-attachments/assets/3f659108-0562-4b10-bece-d1638b69d1a1" />

**mento**
<img width="1292" height="242" alt="CleanShot 2025-07-30 at 17 45 54@2x" src="https://github.com/user-attachments/assets/6b3b9b89-1df9-4a5a-8eff-56c55d547357" />

**polygon_zk**
<img width="1260" height="222" alt="CleanShot 2025-07-30 at 18 31 34@2x" src="https://github.com/user-attachments/assets/f595329f-6e04-4e47-8cdf-9de2e0571342" />


**polymarket**
<img width="1240" height="158" alt="CleanShot 2025-07-30 at 18 26 27@2x" src="https://github.com/user-attachments/assets/5b818bcf-afe5-42c5-a56e-28c85b076fa4" />

**render**
<img width="664" height="268" alt="CleanShot 2025-07-30 at 18 15 49@2x" src="https://github.com/user-attachments/assets/3f40d2d8-dd19-40bc-89ee-dc7b595bdaac" />

**vertex**
<img width="716" height="218" alt="CleanShot 2025-07-30 at 18 15 41@2x" src="https://github.com/user-attachments/assets/17103d3a-24fe-4c2c-bc3f-a8bfba659737" />

**zcash**
<img width="950" height="230" alt="CleanShot 2025-07-30 at 16 27 22@2x" src="https://github.com/user-attachments/assets/927336f1-1bb2-4233-bfb1-578cbb7f1c94" />


- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
