### PR TITLE
add backfill date to get_stablecoin_metrics in chain models

### DIFF
--- a/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
+++ b/models/projects/arbitrum/core/ez_arbitrum_metrics.sql
@@ -22,7 +22,7 @@ with
     fundamental_data as ({{ get_fundamental_data_for_chain("arbitrum", "v2") }}),
     price_data as ({{ get_coingecko_metrics("arbitrum") }}),
     defillama_data as ({{ get_defillama_metrics("arbitrum") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("arbitrum") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("arbitrum", backfill_date="2021-05-29") }}),
     expenses_data as (
         select date, chain, l1_data_cost_native, l1_data_cost
         from {{ ref("fact_arbitrum_l1_data_cost") }}

--- a/models/projects/avalanche/core/ez_avalanche_metrics.sql
+++ b/models/projects/avalanche/core/ez_avalanche_metrics.sql
@@ -24,7 +24,7 @@ with fundamental_data as (
 )
 , price_data as ({{ get_coingecko_metrics("avalanche-2") }})
 , defillama_data as ({{ get_defillama_metrics("avalanche") }})
-, stablecoin_data as ({{ get_stablecoin_metrics("avalanche") }})
+, stablecoin_data as ({{ get_stablecoin_metrics("avalanche", backfill_date="2020-09-10") }})
 , staking_data as ({{ get_staking_metrics("avalanche") }})
 , github_data as ({{ get_github_metrics("avalanche") }})
 , contract_data as ({{ get_contract_metrics("avalanche") }})

--- a/models/projects/base/core/ez_base_metrics.sql
+++ b/models/projects/base/core/ez_base_metrics.sql
@@ -21,7 +21,7 @@
 with
     fundamental_data as ({{ get_fundamental_data_for_chain("base", "v2") }}),
     defillama_data as ({{ get_defillama_metrics("base") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("base") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("base", backfill_date="2023-06-15") }}),
     contract_data as ({{ get_contract_metrics("base") }}),
     expenses_data as (
         select date, chain, l1_data_cost_native, l1_data_cost

--- a/models/projects/bsc/core/ez_bsc_metrics.sql
+++ b/models/projects/bsc/core/ez_bsc_metrics.sql
@@ -22,7 +22,7 @@ with
     fundamental_data as ({{ get_fundamental_data_for_chain("bsc", "v2") }}),
     price_data as ({{ get_coingecko_metrics("binancecoin") }}),
     defillama_data as ({{ get_defillama_metrics("bsc") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("bsc") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("bsc", backfill_date="2020-08-29") }}),
     github_data as ({{ get_github_metrics("Binance Smart Chain") }}),
     contract_data as ({{ get_contract_metrics("bsc") }}),
     nft_metrics as ({{ get_nft_metrics("bsc") }}),

--- a/models/projects/celo/core/ez_celo_metrics.sql
+++ b/models/projects/celo/core/ez_celo_metrics.sql
@@ -26,7 +26,7 @@ with
     price_data as ({{ get_coingecko_metrics("celo") }}),
     defillama_data as ({{ get_defillama_metrics("celo") }}),
     github_data as ({{ get_github_metrics("celo") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("celo") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("celo", backfill_date="2020-05-22") }}),
     rolling_metrics as ({{ get_rolling_active_address_metrics("celo") }}),
     celo_dex_volumes as (
         select date, daily_volume as dex_volumes, daily_volume_adjusted as adjusted_dex_volumes

--- a/models/projects/ethereum/core/ez_ethereum_metrics.sql
+++ b/models/projects/ethereum/core/ez_ethereum_metrics.sql
@@ -26,7 +26,7 @@ with
     fundamental_data as ({{ get_fundamental_data_for_chain("ethereum", "v2") }}),
     price_data as ({{ get_coingecko_metrics("ethereum") }}),
     defillama_data as ({{ get_defillama_metrics("ethereum") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("ethereum") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("ethereum", backfill_date="2015-08-07") }}),
     staking_data as ({{ get_staking_metrics("ethereum") }}),
     censored_block_metrics as ({{ get_censored_block_metrics("ethereum") }}),
     revenue_data as (

--- a/models/projects/frax/core/ez_frax_metrics.sql
+++ b/models/projects/frax/core/ez_frax_metrics.sql
@@ -61,10 +61,10 @@ with dex_data as (
 )
 , stablecoin_supply_data as (
     with frax_data as (
-        {{ get_stablecoin_metrics("FRAX", breakdown='symbol') }}
+        {{ get_stablecoin_metrics("FRAX", breakdown='symbol', backfill_date="2022-08-19") }}
     )
     , frxusd_data as (
-        {{ get_stablecoin_metrics("FRXUSD", breakdown='symbol') }}
+        {{ get_stablecoin_metrics("FRXUSD", breakdown='symbol', backfill_date="2025-01-08") }}
     )
     , agg as (
         select

--- a/models/projects/mantle/core/ez_mantle_metrics.sql
+++ b/models/projects/mantle/core/ez_mantle_metrics.sql
@@ -36,7 +36,7 @@ fundamental_data as ({{ get_fundamental_data_for_chain("mantle", "v2") }})
 , github_data as ({{ get_github_metrics("mantle") }})
 , rolling_metrics as ({{ get_rolling_active_address_metrics("mantle") }})
 , defillama_data as ({{ get_defillama_metrics("mantle") }})
-, stablecoin_data as ({{ get_stablecoin_metrics("mantle") }})
+, stablecoin_data as ({{ get_stablecoin_metrics("mantle", backfill_date="2023-07-02") }})
 , market_data as ({{ get_coingecko_metrics("mantle") }})
 , mantle_dex_volumes as (
     select date, daily_volume as dex_volumes, daily_volume_adjusted as adjusted_dex_volumes

--- a/models/projects/optimism/core/ez_optimism_metrics.sql
+++ b/models/projects/optimism/core/ez_optimism_metrics.sql
@@ -22,7 +22,7 @@ with
     fundamental_data as ({{ get_fundamental_data_for_chain("optimism", "v2") }}),
     price_data as ({{ get_coingecko_metrics("optimism") }}),
     defillama_data as ({{ get_defillama_metrics("optimism") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("optimism") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("optimism", backfill_date="2021-11-11") }}),
     github_data as ({{ get_github_metrics("optimism") }}),
     contract_data as ({{ get_contract_metrics("optimism") }}),
     expenses_data as (

--- a/models/projects/polygon/core/ez_polygon_metrics.sql
+++ b/models/projects/polygon/core/ez_polygon_metrics.sql
@@ -22,7 +22,7 @@ with
     fundamental_data as ({{ get_fundamental_data_for_chain("polygon", "v2") }}),
     price_data as ({{ get_coingecko_metrics("matic-network") }}),
     defillama_data as ({{ get_defillama_metrics("polygon") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("polygon") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("polygon", backfill_date="2020-05-30") }}),
     github_data as ({{ get_github_metrics("polygon") }}),
     contract_data as ({{ get_contract_metrics("polygon") }}),
     revenue_data as (

--- a/models/projects/solana/core/ez_solana_metrics.sql
+++ b/models/projects/solana/core/ez_solana_metrics.sql
@@ -20,7 +20,7 @@
 
 with
     contract_data as ({{ get_contract_metrics("solana") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("solana") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("solana", backfill_date="2020-03-16") }}),
     defillama_data as ({{ get_defillama_metrics("solana") }}),
     github_data as ({{ get_github_metrics("solana") }}),
     price as ({{ get_coingecko_metrics("solana") }}),

--- a/models/projects/sui/core/ez_sui_metrics.sql
+++ b/models/projects/sui/core/ez_sui_metrics.sql
@@ -26,7 +26,7 @@ with
     ),
     price_data as ({{ get_coingecko_metrics("sui") }}),
     defillama_data as ({{ get_defillama_metrics("sui") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("sui") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("sui", backfill_date="2023-04-12") }}),
     github_data as ({{ get_github_metrics("sui") }})
     , supply_data as (
         select 

--- a/models/projects/ton/core/ez_ton_metrics.sql
+++ b/models/projects/ton/core/ez_ton_metrics.sql
@@ -35,7 +35,7 @@ with
     ),
     price_data as ({{ get_coingecko_metrics("the-open-network") }}),
     defillama_data as ({{ get_defillama_metrics("ton") }}),
-    stablecoin_data as ({{ get_stablecoin_metrics("ton") }}),
+    stablecoin_data as ({{ get_stablecoin_metrics("ton", backfill_date="2019-11-15") }}),
     github_data as ({{ get_github_metrics("ton") }}),
     rolling_metrics as ({{ get_rolling_active_address_metrics("ton") }})
     , block_rewards_data as (

--- a/models/projects/tron/core/ez_tron_metrics.sql
+++ b/models/projects/tron/core/ez_tron_metrics.sql
@@ -23,7 +23,7 @@ with fundamental_data as (
 )
 , market_metrics as ({{ get_coingecko_metrics("tron") }})
 , defillama_data as ({{ get_defillama_metrics("tron") }})
-, stablecoin_data as ({{ get_stablecoin_metrics("tron") }})
+, stablecoin_data as ({{ get_stablecoin_metrics("tron", backfill_date="2018-06-25") }})
 , github_data as ({{ get_github_metrics("tron") }})
 , p2p_metrics as ({{ get_p2p_metrics("tron") }})
 , rolling_metrics as ({{ get_rolling_active_address_metrics("tron") }})


### PR DESCRIPTION
## Context
The `get_stablecoin_metrics` macro is being used in chain models but did not add the `backfill_date` param to these chain models during the refactor leading to incomplete backfills for stablecoin metrics. Adding in the min date per chain as the backfill_date here so we don't have this issue going forward.

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing

- [ ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
