### PR TITLE
amend generate_alias_name to handle versions in dev

### DIFF
--- a/macros/admin/generate_alias_name.sql
+++ b/macros/admin/generate_alias_name.sql
@@ -4,7 +4,7 @@
         'If using the dev target, use the name of the model file as its alias.
         Otherwise, use the default behavior of dbt'
     #}
-    {%- if target.name == "dev" -%}
+    {%- if target.name == "dev" and not node.version -%}
         {{ return(node.name) }}
     {%- endif -%}
 


### PR DESCRIPTION
## Context
Was hitting an issue testing versioning in dev, slightly tweaked this macro to handle aliasing in dev. 

The error I was getting during testing was due to this macro not recognizing versioning in dev and trying to materialize multiple version models to the same db object. 

<img width="1027" height="260" alt="Screenshot 2025-08-01 at 12 36 41 PM" src="https://github.com/user-attachments/assets/e699de9e-9710-41a3-847c-e024ce329627" />


- [ ] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
After making this change to the macro, it materialized correctly in dev
<img width="1035" height="341" alt="Screenshot 2025-08-01 at 12 37 48 PM" src="https://github.com/user-attachments/assets/08ebcdbc-636e-454b-8f7b-0ec9ee37ca18" />



- [ ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
