### PR TITLE
add macro to create view pointing to latest version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,11 +28,13 @@ clean-targets: # directories to be removed by `dbt clean`
 
 # In this example config, we tell dbt to build all models in the example/ directory
 # as tables. These settings can be overridden in the individual model files
-# using the `{{ config(...) }}` macro.
+# using the `{{ config(...) }}` macro.  
 models:
   +persist_docs:
     relation: true
     columns: true
+  post-hook:
+    - "{{ create_latest_ez_metrics_version_view() }}"
   artemis_dbt:
     metrics:
       contracts:

--- a/macros/admin/create_latest_ez_metrics_version_view.sql
+++ b/macros/admin/create_latest_ez_metrics_version_view.sql
@@ -1,0 +1,32 @@
+{% macro create_latest_ez_metrics_version_view() %}
+
+    -- this hook will run only if the model is versioned, it's the latest version, and it has the ez_metrics tag
+    -- otherwise, it's a no-op
+    {% if model.get('version') and model.get('version') == model.get('latest_version') and 'ez_metrics' in (model.get('tags') or []) %}
+
+        {% set new_relation = this.incorporate(path={"identifier": "ez_metrics"}) %}
+
+        {% set existing_relation = load_relation(new_relation) %}
+
+        {% if existing_relation and not existing_relation.is_view %}
+            {{ drop_relation_if_exists(existing_relation) }}
+        {% endif %}
+        
+        {% set create_view_sql -%}
+            -- this syntax may vary by data platform
+            create or replace view {{ new_relation }}
+              as select * from {{ this }}
+        {%- endset %}
+        
+        {% do log("Creating view " ~ new_relation ~ " pointing to " ~ this, info = true) if execute %}
+        
+        {{ return(create_view_sql) }}
+        
+    {% else %}
+    
+        -- no-op
+        select 1 as id
+    
+    {% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
## Context
For versioning, we need to create a view that will have the `ez_metrics` alias and point to the latest version. Adding this macro to accomplish that. This macro will run in a post-hook on versioned models if they are tagged with the tag `ez_metrics`. 

- [X] Internal only (check this box this PR should not appear in external facing docs/changelog)

## Testing
Created test version models on Acala and ran to verify the view is created correctly:
<img width="984" height="375" alt="Screenshot 2025-08-01 at 5 25 27 PM" src="https://github.com/user-attachments/assets/df07da15-c927-44f1-9758-cb541a707c55" />

Also tested a regular non-versioned model to verify the macro only runs on versioned ez_metrics models:
<img width="815" height="131" alt="Screenshot 2025-08-01 at 5 42 34 PM" src="https://github.com/user-attachments/assets/b6881cba-bfaa-400f-9fc5-90f5dd366515" />


- [ ] `dbt build model_name+` screenshot (must include downstream models)
- [ ] Successful RETL screenshot
- [ ] Ran make generate schema for changed assets
- [ ] Screenshots of changed data **in local frontend**


Tick the following only after PR has been approved and before it is merged: 
- [ ] Added clear and concise metric definitions + methodology to the admin dashboard
- [ ] If methodology was changed, describe the changes in the 'Changelog' in the admin dashboard

## Other
